### PR TITLE
Shared: Make ESLint and Prettier ignore translation files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,5 @@ node_modules/*
 *.min.js
 src/mobile/shim.js
 dist/
+src/shared/locales/*
+!src/shared/locales/en/translation.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,5 @@ src/mobile/android
 src/mobile/ios
 src/mobile/logo-spin/logo-spin-glow-blnk.hyperesources
 package.json
+src/shared/locales/*
+!src/shared/locales/en/translation.json


### PR DESCRIPTION
Since these files are automatically generated by Crowdin, they don't need to be linted or formatted. Linting and formatting seems to cause merge conflicts more often with these files.