### PR TITLE
Allow latest solid milestone to be 1 behind latest milestone

### DIFF
--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -338,14 +338,25 @@ const isNodeSynced = (provider = null) => {
     };
 
     return getNodeInfoAsync(provider)
-        .then(({ latestMilestone, latestSolidSubtangleMilestone }) => {
-            cached.latestMilestone = latestMilestone;
-            if (cached.latestMilestone === latestSolidSubtangleMilestone && cached.latestMilestone !== '9'.repeat(81)) {
-                return getTrytesAsync([cached.latestMilestone], provider);
-            }
+        .then(
+            ({
+                latestMilestone,
+                latestMilestoneIndex,
+                latestSolidSubtangleMilestone,
+                latestSolidSubtangleMilestoneIndex,
+            }) => {
+                cached.latestMilestone = latestMilestone;
+                if (
+                    (cached.latestMilestone === latestSolidSubtangleMilestone ||
+                        latestMilestoneIndex - 1 === latestSolidSubtangleMilestoneIndex) &&
+                    cached.latestMilestone !== '9'.repeat(81)
+                ) {
+                    return getTrytesAsync([cached.latestMilestone], provider);
+                }
 
-            throw new Error(Errors.NODE_NOT_SYNCED);
-        })
+                throw new Error(Errors.NODE_NOT_SYNCED);
+            },
+        )
         .then((trytes) => {
             const { timestamp } = iota.utils.fastTransactionObject(cached.latestMilestone, head(trytes));
 


### PR DESCRIPTION
Fixes an edge case where `isNodeSynced` could be run just after a milestone was issued and would return `false`. As the latest solid milestone is not the same as the latest milestone at this moment, `isNodeSynced` will return `false`. Instead, a 1 milestone "grace period" is allowed for a node to solidify the next milestone.