### PR TITLE
Fix Share intent crash on Android 6

### DIFF
--- a/src/mobile/android/app/src/main/java/module/share/ShareSecure.java
+++ b/src/mobile/android/app/src/main/java/module/share/ShareSecure.java
@@ -77,6 +77,7 @@ public class ShareSecure extends ReactContextBaseJavaModule {
             promise.reject(ERROR_INTENT_NOT_AVAILABLE, "Target intent not available.");
         } else {
             Intent chooser = Intent.createChooser(limitedShareIntents.remove(0), content.getString("title"));
+            chooser.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             chooser.putExtra(Intent.EXTRA_INITIAL_INTENTS, limitedShareIntents.toArray(new Parcelable[limitedShareIntents.size()]));
             this.reactContext.startActivity(chooser);
         }


### PR DESCRIPTION
Fixes https://app.bugsnag.com/iota-foundation/trinity-mobile/errors/5b0d95d633f9840018285128 which throws `Calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?` upon tapping `Proceed` to add the seed to Keepass2Android