### PR TITLE
Use SelfTransactionRow only if all outputs match

### DIFF
--- a/src/mobile/containers/History.js
+++ b/src/mobile/containers/History.js
@@ -173,7 +173,7 @@ class History extends Component {
         if (
             (transfer.value !== 0 &&
                 !transfer.incoming &&
-                transfer.outputs.some((tx) => addresses.includes(tx.address))) ||
+                transfer.outputs.every((tx) => addresses.includes(tx.address))) ||
             (transfer.value === 0 && transfer.outputs.every((tx) => addresses.includes(tx.address)))
         ) {
             return <SelfTransactionRow {...transfer} />;


### PR DESCRIPTION
https://github.com/iotaledger/trinity-wallet/commit/b9800dedf72132da188e44e68fc6b2dc472a15f3#diff-ea27ed22456962e6c0889414a5920025R176

If `some` is used here, any transfer with a remainder amount will be treated as a transfer being sent to an account's own address. This results in [this bundle](https://thetangle.org/bundle/TEMMKNI9AE9HGVK9ZITJQYRLXJNPUKBVPZPLZSI9ZKFZCA9NYPLKKIMOSEELZPIEFFZYHBBNGREHXHFLB) being shown as this:

![image](https://user-images.githubusercontent.com/19519564/42534875-e2e655bc-845b-11e8-962e-d893d4914d3c.png)
