### PR TITLE
Exclude manifest.json from iCloud backup

### DIFF
--- a/src/mobile/ios/iotaWallet/AppDelegate.m
+++ b/src/mobile/ios/iotaWallet/AppDelegate.m
@@ -40,7 +40,7 @@
   NSURL *jsCodeLocation;
 
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
-  NSLog(@"%@", jsCodeLocation);
+  
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   self.window.backgroundColor = [UIColor whiteColor];
   [[RCCManager sharedInstance] initBridgeWithBundleURL:jsCodeLocation launchOptions:launchOptions];


### PR DESCRIPTION
Fixes https://iotaledger.atlassian.net/projects/TRINITY/queues/custom/1/TRINITY-487: "Unrecognised password" message is shown on login because the wallet state is being stored in device backups while the keychain is not