### PR TITLE
Disable sourcemap uploads each time tests are run on CI

### DIFF
--- a/src/desktop/webpack.config/config.production.js
+++ b/src/desktop/webpack.config/config.production.js
@@ -17,8 +17,6 @@ config.output.publicPath = '../dist/';
 
 config.devtool = 'source-map';
 
-console.log(skipSourcemaps);
-
 if (skipSourcemaps) {
   config.plugins = [
       new BugsnagSourceMapUploaderPlugin({


### PR DESCRIPTION
When running tests, the CI will now run `rm -rf ./dist && cross-env NODE_ENV=production SKIP_SOURCEMAPS=true webpack --env=production --config webpack.config` to skip sourcemap uploading, preventing conflicts that caused some builds to fail.