### PR TITLE
Fix params for getTransactionsToApprove api

### DIFF
--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -172,7 +172,7 @@ const promoteTransactionAsync = (provider, powFn) => (
         .then((trytes) => {
             cached.trytes = trytes;
 
-            return getTransactionsToApproveAsync(provider)(hash, depth);
+            return getTransactionsToApproveAsync(provider)({ reference: hash }, depth);
         })
         .then(({ trunkTransaction, branchTransaction }) =>
             attachToTangleAsync(provider, powFn)(
@@ -215,7 +215,7 @@ const replayBundleAsync = (provider, powFn) => (
             cached.trytes = map(bundle, convertToTrytes);
             cached.transactionObjects = bundle;
 
-            return getTransactionsToApproveAsync(provider)(null, depth);
+            return getTransactionsToApproveAsync(provider)({}, depth);
         })
         .then(({ trunkTransaction, branchTransaction }) =>
             attachToTangleAsync(provider, powFn)(
@@ -297,7 +297,7 @@ const sendTransferAsync = (provider, powFn) => (
         .then((trytes) => {
             cached.trytes = trytes;
 
-            return getTransactionsToApproveAsync(provider)(null, depth);
+            return getTransactionsToApproveAsync(provider)({}, depth);
         })
         .then(({ trunkTransaction, branchTransaction }) =>
             attachToTangleAsync(provider, powFn)(


### PR DESCRIPTION
# Description

Update to `getTransactionsToApprove` [iota.lib.js v0.5.0](https://github.com/iotaledger/iota.js/releases/tag/v0.5.0) doesn't check `null` params which has caused some param mismatch in Trinity. 

A fix is already merged in https://github.com/iotaledger/trinity-wallet/commit/93a5da95cf0ff11be414d4c7f9b669e3007ce9fc but reattachments/promotions utils were still passing `null` references. 

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested by sending value transactions and manually reattaching/promoting them. 

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
