### PR TITLE
Shared: Change 'Content-Type' to 'application/json' when checking for remote PoW

### DIFF
--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -13,6 +13,7 @@ import {
     DEFAULT_DEPTH,
     DEFAULT_MIN_WEIGHT_MAGNITUDE,
     NODE_REQUEST_TIMEOUT,
+    IRI_API_VERSION,
 } from '../../config';
 import { performPow, sortTransactionTrytesArray } from './transfers';
 import { EMPTY_HASH_TRYTES } from './utils';
@@ -395,7 +396,7 @@ const checkAttachToTangleAsync = (node) => {
         body: JSON.stringify({ command: 'attachToTangle' }),
         headers: new Headers({
             'Content-Type': 'application/json',
-            'X-IOTA-API-Version': '1',
+            'X-IOTA-API-Version': IRI_API_VERSION,
         }),
     })
         .then((res) => res.json())


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description
Changes the `'Content-Type'` header to `'application/json'` when calling `checkAttachToTangleAsync`

Fixes https://trello.com/c/4WjKATeB

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
- Checked to ensure header is now `application/json`


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile` (have checked desktop but not mobile)
