### PR TITLE
[WIP] Mac: Enable App Sandboxing and Hardened Runtime [ci skip]

### DIFF
--- a/src/desktop/entitlements.mac.plist
+++ b/src/desktop/entitlements.mac.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.print</key>
+	<true/>
+</dict>
+</plist>

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -119,7 +119,8 @@
       "target": [
         "dmg",
         "zip"
-      ]
+      ],
+      "entitlements": "./entitlements.mac.plist"
     },
     "publish": {
       "provider": "github",


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description
Enables [App Sandboxing](https://developer.apple.com/app-sandboxing/) and [Hardened Runtime](https://developer.apple.com/videos/play/wwdc2018/702/), which are prerequisites for app notarization by Apple.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Entitlements are verified with `codesign -d --entitlements - <path/to/Trinity.app>` when the app is signed
- [ ] App does not crash with sandbox enabled
- [ ] Hardened runtime is verified with `codesign -d --verbose=2 <path/to/Trinity.app>` when the app is signed with `--options runtime`

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation

# To Do:

- [x] Create entitlements file
- [ ] Ensure Xcode 10 is installed on CI
- [x] Configure code signing for Mac
- [ ] Verify that entitlements and runtime settings are embedded in the code signature when the app is signed