### PR TITLE
Remove outdated promotion description in docs/overview

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -89,8 +89,6 @@ Please note: **Trinity does not update account or market information if the appl
 
 To ensure transactions are confirmed on the Tangle, it is often necessary to promote or reattach them. An explanation of promotion and reattachment can be found [here](https://iota.stackexchange.com/a/801). If it is possible to promote a pending transaction, Trinity will do so automatically. However it is sometimes necessary to first attach the transaction to the Tangle before then promoting that reattachment. This will also occur automatically.
 
-Should you wish to enable **manual promotion and reattachment** please turn on **Expert** mode in the settings.
-
 Please note: **Trinity does not promote/reattach transfers if the application is minimised. Automatic promotion/reattachment only takes place if the app is currently open.**
 
 #### Address Management


### PR DESCRIPTION
# Description

Update overview documentation. 

We do allow manual promotion/reattachment in `standard` mode now.

## Type of change

_Please delete options that are not relevant._
- Documentation Fix

# Checklist:

_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
