### PR TITLE
Update denominations when currency is changed

### DIFF
--- a/src/mobile/__tests__/containers/CurrencySelection.spec.js
+++ b/src/mobile/__tests__/containers/CurrencySelection.spec.js
@@ -20,11 +20,15 @@ const getProps = (overrides) =>
         {
             isFetchingCurrencyData: true,
             currency: 'foo',
+            qrDenomination: 'i',
+            sendDenomination: 'i',
             availableCurrencies: [],
             setSetting: noop,
             t: noop,
             theme: { body: {}, primary: {} },
             getCurrencyData: noop,
+            setQrDenomination: noop,
+            setSendDenomination: noop,
         },
         overrides,
     );
@@ -41,6 +45,14 @@ describe('Testing CurrencySelection component', () => {
 
         it('should require a currency string as a prop', () => {
             expect(CurrencySelection.propTypes.currency).toBe(PropTypes.string.isRequired);
+        });
+
+        it('should require a sendDenomination string as a prop', () => {
+            expect(CurrencySelection.propTypes.sendDenomination).toBe(PropTypes.string.isRequired);
+        });
+
+        it('should require a qrDenomination string as a prop', () => {
+            expect(CurrencySelection.propTypes.qrDenomination).toBe(PropTypes.string.isRequired);
         });
 
         it('should require a availableCurrencies array as a prop', () => {
@@ -61,47 +73,121 @@ describe('Testing CurrencySelection component', () => {
     });
 
     describe('#componentWillReceiveProps', () => {
-        describe('when isFetchingCurrencyData is true', () => {
-            it('should not call prop method setSetting when isFetchingCurrencyData is true in the newProps', () => {
-                const props = getProps({
-                    setSetting: jest.fn(),
+        describe('when isFetchingCurrencyData prop is true', () => {
+            describe('when isFetchingCurrencyData is true in newProps', () => {
+                it('should not call prop method "setSetting"', () => {
+                    const props = getProps({
+                        setSetting: jest.fn(),
+                    });
+
+                    const wrapper = shallow(<CurrencySelection {...props} />);
+
+                    wrapper.setProps({
+                        isFetchingCurrencyData: true,
+                    });
+
+                    expect(props.setSetting).toHaveBeenCalledTimes(0);
                 });
-
-                const wrapper = shallow(<CurrencySelection {...props} />);
-
-                wrapper.setProps({
-                    isFetchingCurrencyData: true,
-                });
-
-                expect(props.setSetting).toHaveBeenCalledTimes(0);
             });
 
-            it('should not call prop method setSetting when isFetchingCurrencyData is false in the newProps but hasErrorFetchingCurrencyData is true', () => {
-                const props = getProps({
-                    setSetting: jest.fn(),
-                });
+            describe('when isFetchingCurrencyData is false in newProps and hasErrorFetchingCurrencyData is true in newProps', () => {
+                it('should not call prop method "setSetting"', () => {
+                    const props = getProps({
+                        setSetting: jest.fn(),
+                    });
 
-                const wrapper = shallow(<CurrencySelection {...props} />);
-                wrapper.setProps({
-                    isFetchingCurrencyData: false,
-                    hasErrorFetchingCurrencyData: true,
-                });
+                    const wrapper = shallow(<CurrencySelection {...props} />);
+                    wrapper.setProps({
+                        isFetchingCurrencyData: false,
+                        hasErrorFetchingCurrencyData: true,
+                    });
 
-                expect(props.setSetting).toHaveBeenCalledTimes(0);
+                    expect(props.setSetting).toHaveBeenCalledTimes(0);
+                });
             });
 
-            it('should call prop method setSetting when isFetchingCurrencyData and hasErrorFetchingCurrencyData are false in the newProps', () => {
-                const props = getProps({
-                    setSetting: jest.fn(),
+            describe('when isFetchingCurrencyData is false in newProps and hasErrorFetchingCurrencyData is true in newProps', () => {
+                it('should call prop method "setSetting" with "mainSettings"', () => {
+                    const props = getProps({
+                        setSetting: jest.fn(),
+                    });
+
+                    const wrapper = shallow(<CurrencySelection {...props} />);
+                    wrapper.setProps({
+                        isFetchingCurrencyData: false,
+                        hasErrorFetchingCurrencyData: false,
+                    });
+
+                    expect(props.setSetting).toHaveBeenCalledWith('mainSettings');
                 });
 
-                const wrapper = shallow(<CurrencySelection {...props} />);
-                wrapper.setProps({
-                    isFetchingCurrencyData: false,
-                    hasErrorFetchingCurrencyData: false,
+                describe('when "qrDenomination" prop value is included in allowed IOTA denominations', () => {
+                    it('should not call prop method "setQrDenomination"', () => {
+                        const props = getProps({
+                            setQrDenomination: jest.fn(),
+                        });
+
+                        const wrapper = shallow(<CurrencySelection {...props} />);
+                        wrapper.setProps({
+                            isFetchingCurrencyData: false,
+                            hasErrorFetchingCurrencyData: false,
+                        });
+
+                        expect(props.setQrDenomination).toHaveBeenCalledTimes(0);
+                    });
                 });
 
-                expect(props.setSetting).toHaveBeenCalledTimes(1);
+                describe('when "qrDenomination" prop value is not included in allowed IOTA denominations', () => {
+                    it('should call prop method "setQrDenomination" with newly selected currency ', () => {
+                        const props = getProps({
+                            setQrDenomination: jest.fn(),
+                            qrDenomination: 'foo',
+                        });
+
+                        const wrapper = shallow(<CurrencySelection {...props} />);
+                        wrapper.setProps({
+                            isFetchingCurrencyData: false,
+                            hasErrorFetchingCurrencyData: false,
+                            currency: 'new currency symbol',
+                        });
+
+                        expect(props.setQrDenomination).toHaveBeenCalledWith('new currency symbol');
+                    });
+                });
+
+                describe('when "sendDenomination" prop value is included in allowed IOTA denominations', () => {
+                    it('should not call prop method "setSendDenomination"', () => {
+                        const props = getProps({
+                            setSendDenomination: jest.fn(),
+                        });
+
+                        const wrapper = shallow(<CurrencySelection {...props} />);
+                        wrapper.setProps({
+                            isFetchingCurrencyData: false,
+                            hasErrorFetchingCurrencyData: false,
+                        });
+
+                        expect(props.setSendDenomination).toHaveBeenCalledTimes(0);
+                    });
+                });
+
+                describe('when "sendDenomination" prop value is not included in allowed IOTA denominations', () => {
+                    it('should call prop method "setSendDenomination" with newly selected currency ', () => {
+                        const props = getProps({
+                            setSendDenomination: jest.fn(),
+                            sendDenomination: 'foo',
+                        });
+
+                        const wrapper = shallow(<CurrencySelection {...props} />);
+                        wrapper.setProps({
+                            isFetchingCurrencyData: false,
+                            hasErrorFetchingCurrencyData: false,
+                            currency: 'new currency symbol',
+                        });
+
+                        expect(props.setSendDenomination).toHaveBeenCalledWith('new currency symbol');
+                    });
+                });
             });
         });
     });

--- a/src/mobile/containers/CurrencySelection.js
+++ b/src/mobile/containers/CurrencySelection.js
@@ -1,8 +1,11 @@
+import includes from 'lodash/includes';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { ActivityIndicator, View, Text, StyleSheet, TouchableOpacity, TouchableWithoutFeedback } from 'react-native';
 import { connect } from 'react-redux';
 import { getCurrencyData } from 'iota-wallet-shared-modules/actions/settings';
+import { setQrDenomination, setSendDenomination } from 'iota-wallet-shared-modules/actions/ui';
+import { IOTA_DENOMINATIONS } from 'iota-wallet-shared-modules/libs/iota/utils';
 import { setSetting } from 'iota-wallet-shared-modules/actions/wallet';
 import { translate } from 'react-i18next';
 import { width, height } from '../utils/dimensions';
@@ -72,6 +75,10 @@ export class CurrencySelection extends Component {
         /** @ignore */
         currency: PropTypes.string.isRequired,
         /** @ignore */
+        sendDenomination: PropTypes.string.isRequired,
+        /** @ignore */
+        qrDenomination: PropTypes.string.isRequired,
+        /** @ignore */
         availableCurrencies: PropTypes.array.isRequired,
         /** @ignore */
         setSetting: PropTypes.func.isRequired,
@@ -81,6 +88,10 @@ export class CurrencySelection extends Component {
         theme: PropTypes.object.isRequired,
         /** @ignore */
         getCurrencyData: PropTypes.func.isRequired,
+        /** @ignore */
+        setQrDenomination: PropTypes.func.isRequired,
+        /** @ignore */
+        setSendDenomination: PropTypes.func.isRequired,
     };
 
     componentDidMount() {
@@ -91,10 +102,19 @@ export class CurrencySelection extends Component {
         const props = this.props;
 
         const wasFetchingCurrencyData = props.isFetchingCurrencyData && !newProps.isFetchingCurrencyData;
-        const shouldNavigateBack = wasFetchingCurrencyData && !newProps.hasErrorFetchingCurrencyData;
+        const hasFetchedCurrencyData = wasFetchingCurrencyData && !newProps.hasErrorFetchingCurrencyData;
 
-        if (shouldNavigateBack) {
+        if (hasFetchedCurrencyData) {
+            // Navigate to main settings
             props.setSetting('mainSettings');
+
+            if (!includes(IOTA_DENOMINATIONS, props.qrDenomination)) {
+                props.setQrDenomination(newProps.currency);
+            }
+
+            if (!includes(IOTA_DENOMINATIONS, props.sendDenomination)) {
+                props.setSendDenomination(newProps.currency);
+            }
         }
     }
 
@@ -178,6 +198,8 @@ export class CurrencySelection extends Component {
 
 const mapStateToProps = (state) => ({
     currency: state.settings.currency,
+    sendDenomination: state.ui.sendDenomination,
+    qrDenomination: state.ui.qrDenomination,
     availableCurrencies: state.settings.availableCurrencies,
     isFetchingCurrencyData: state.ui.isFetchingCurrencyData,
     hasErrorFetchingCurrencyData: state.ui.hasErrorFetchingCurrencyData,
@@ -187,6 +209,8 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = {
     getCurrencyData,
     setSetting,
+    setQrDenomination,
+    setSendDenomination,
 };
 
 export default translate(['currencySelection', 'global'])(

--- a/src/shared/libs/iota/utils.js
+++ b/src/shared/libs/iota/utils.js
@@ -30,6 +30,7 @@ export const EMPTY_HASH_TRYTES = '9'.repeat(HASH_SIZE);
 
 export const EMPTY_TRANSACTION_TRYTES = '9'.repeat(TRANSACTION_TRYTES_SIZE);
 
+export const IOTA_DENOMINATIONS = ['i', 'Ki', 'Mi', 'Gi', 'Ti'];
 /**
  * Converts trytes to bytes
  *

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,7 +1623,7 @@ iota-wallet-shared-modules@./src/shared/:
   dependencies:
     bignumber.js "^7.2.1"
     i18next "^10.2.2"
-    iota.lib.js "git+https://git@github.com/iotaledger/iota.lib.js#develop"
+    iota.lib.js "^0.5.0"
     lodash "^4.17.10"
     moment "^2.22.2"
     proxy-polyfill "git+https://git@github.com/GoogleChrome/proxy-polyfill#9c009d7"
@@ -1639,9 +1639,9 @@ iota-wallet-shared-modules@./src/shared/:
     valid-url "^1.0.9"
     zxcvbn "^4.4.2"
 
-"iota.lib.js@git+https://git@github.com/iotaledger/iota.lib.js#develop":
-  version "0.4.8"
-  resolved "git+https://git@github.com/iotaledger/iota.lib.js#49cec7296cb179a1c83b4b1fbb4c3fa129ca9f8f"
+iota.lib.js@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/iota.lib.js/-/iota.lib.js-0.5.0.tgz#66e59baf82a4556b739f81d947313d0a3ab2f659"
   dependencies:
     async "^2.5.0"
     bignumber.js "^4.1.0"


### PR DESCRIPTION
# Description

Fixes https://github.com/iotaledger/trinity-wallet/issues/281

## Type of change
- Bug fix 

# How Has This Been Tested?
Added unit test coverage for following scenarios:

When selected denomination is from allowed IOTA denominations:
 - Should not change currency refs in `qrDenomination`
 - Should not change currency refs in `sendDenomination`

When selected denomination is not from allowed IOTA denominations:
 - Should change currency refs in `qrDenomination`
 - Should change currency refs in `sendDenomination`

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
