### PR TITLE
Desktop: Update Linux missing library tutorial

### DIFF
--- a/src/desktop/src/ui/global/FatalError.js
+++ b/src/desktop/src/ui/global/FatalError.js
@@ -26,6 +26,15 @@ class FatalError extends React.PureComponent {
                         Arch Linux: <pre>sudo pacman -S libsecret</pre>
                     </li>
                 </ul>
+                <p>
+                    For some desktop environments (e.g. Kubuntu or KDE), you may need to install an additional library
+                    for the communication with libsecret:
+                </p>
+                <ul>
+                    <li>
+                        <pre>sudo apt-get install gnome-keyring</pre>
+                    </li>
+                </ul>
             </form>
         );
     };

--- a/src/desktop/src/ui/views/onboarding/index.scss
+++ b/src/desktop/src/ui/views/onboarding/index.scss
@@ -451,7 +451,7 @@ $footer: 70px;
 
 .tutorial {
     p {
-        max-width: 560px;
+        max-width: 580px;
         text-align: center;
     }
     ul {
@@ -473,5 +473,9 @@ $footer: 70px;
                 user-select: all;
             }
         }
+    }
+
+    ul + p {
+        margin-top: 20px;
     }
 }


### PR DESCRIPTION
# Description

Update Linux missing library tutorial with `gnome-keyring` installation instructions.

Fixes #290 

## Type of change

- Documentation Fix

# How Has This Been Tested?

Tested on Ubuntu

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation