### PR TITLE
Desktop release v0.3.3

### DIFF
--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trinity-desktop",
   "productName": "Trinity",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "url": "https://trinity.iota.org",
   "homepage": "https://trinity.iota.org",
@@ -123,7 +123,8 @@
     },
     "publish": {
       "provider": "github",
-      "publishAutoUpdate": true
+      "publishAutoUpdate": true,
+      "vPrefixedTagName": false
     }
   },
   "dependencies": {

--- a/src/desktop/src/ui/global/About.js
+++ b/src/desktop/src/ui/global/About.js
@@ -51,6 +51,12 @@ class About extends React.PureComponent {
 
                     <article>
                         <Scrollbar>
+                            <h5>0.3.3</h5>
+                            <ul>
+                                <li>- Update: Linux tutorial missing a required step</li>
+                                <li>- Fix: Paper wallet prints with scramblded characters</li>
+                                <li>- Fix: Auto update dialog raises missing locale error</li>
+                            </ul>
                             <h5>0.3.2</h5>
                             <ul>
                                 <li>Update: Update currency order</li>

--- a/src/desktop/src/ui/global/About.js
+++ b/src/desktop/src/ui/global/About.js
@@ -53,8 +53,11 @@ class About extends React.PureComponent {
                         <Scrollbar>
                             <h5>0.3.3</h5>
                             <ul>
+                                <li>- New: Support for Persian, Kannada, and Serbian (Latin)</li>
                                 <li>- Update: Linux tutorial missing a required step</li>
-                                <li>- Fix: Paper wallet prints with scramblded characters</li>
+                                <li>- Fix: Printing paper wallet from settings prints a blank page on first try</li>
+                                <li>- Fix: Paper wallet prints with scrambled characters</li>
+                                <li>- Fix: Grammatical errors in German privacy policy</li>
                                 <li>- Fix: Auto update dialog raises missing locale error</li>
                             </ul>
                             <h5>0.3.2</h5>


### PR DESCRIPTION
# Description

Desktop v0.3.3 release:
- Update: Linux tutorial missing a required step (#285)
- Fix: Printing paper wallet from settings prints a blank page on first try (#284)
- Fix: Paper wallet prints with scrambled characters (#284)
- Fix: Auto update dialog raises missing locale error (#282)
- Fix: Grammatical errors in German privacy policy (#271, #294)
- Add: Support for Persian, Kannada, and Serbian (Latin) (#277) 

## Type of change

- New release

# How Has This Been Tested?

Tested on macOS, Ubuntu. Should yet be tested on Windows

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have performed new release tests on all platforms