### PR TITLE
Fix address data length mismatch exception

### DIFF
--- a/src/shared/libs/iota/addresses.js
+++ b/src/shared/libs/iota/addresses.js
@@ -212,7 +212,7 @@ export const getFullAddressHistory = (provider) => (seed, addressGenFn) => {
                         addresses,
                         ...addressData,
                         // Append 0 balance to the latest unused address
-                        balances: [...addressData.balances.slice(0, sizeOfAddressesTillOneUnused), 0],
+                        balances: [...addressData.balances.slice(0, sizeOfAddressesTillOneUnused - 1), 0],
                         // Append false as spent status to the latest unused address
                         wereSpent: [
                             ...addressData.wereSpent.slice(0, sizeOfAddressesTillOneUnused - 1),


### PR DESCRIPTION
# Description
[formatAddressData](https://github.com/iotaledger/trinity-wallet/blob/develop/src/shared/libs/iota/addresses.js#L308) has a strict validation for lengths of `balances, spend statuses and keyIndexes`. When address history is being fetched from the tangle, balances length differs from the rest of the parameters. 

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested by performing _manual sync_, _login_ and _adding new seed_

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
