### PR TITLE
Fix documentation for globally installing electron

### DIFF
--- a/src/desktop/README.md
+++ b/src/desktop/README.md
@@ -16,7 +16,7 @@ First you need to install Node.JS if you haven’t done that already.
 Then run the following command to install electron globally.
 
 ```
-npm global add electron
+npm install electron -g
 ```
 
 ### 2. Clone or download the Trinity repo from GitHub.


### PR DESCRIPTION
# Description

Fix incorrect instruction for installing electron globally in `src/desktop/README.md`

## Type of change

- Documentation Fix


_Please delete items that are not relevant._

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
