### PR TITLE
Desktop: Fix filled and empty paper wallet templates

### DIFF
--- a/src/desktop/src/ui/components/SeedPrint.js
+++ b/src/desktop/src/ui/components/SeedPrint.js
@@ -76,7 +76,7 @@ export default class SeedPrint extends PureComponent {
                                 checksum.split('').map((letter, index) => {
                                     return (
                                         <path
-                                            transform={`translate(${276 + index * 14}, 724) scale(0.75)`}
+                                            transform={`translate(${372 + index * 12}, 725) scale(0.75)`}
                                             d={SourceSansPro[letter]}
                                             key={`${index}${letter}`}
                                         />
@@ -84,7 +84,7 @@ export default class SeedPrint extends PureComponent {
                                 })}
                         </svg>
                     )}
-                <img width="auto" height="100vh" src={filled ? wallets.paperWallet : wallets.paperWalletFilled} />
+                <img width="auto" height="100vh" src={filled ? wallets.paperWalletFilled : wallets.paperWallet} />
             </div>
         );
     }


### PR DESCRIPTION
# Description

Fix mixed empty and filled paper wallet templates.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS and Ubuntu by printing the seed to a pdf file.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code