### PR TITLE
Desktop: Fix top corner resize not working

### DIFF
--- a/src/desktop/src/ui/global/titlebar.scss
+++ b/src/desktop/src/ui/global/titlebar.scss
@@ -6,6 +6,23 @@
     left: 0px;
     -webkit-app-region: drag;
     z-index: 99999;
+
+    &:before,
+    &:after {
+        display: block;
+        content: '';
+        width: 6px;
+        height: 6px;
+        position: absolute;
+        top: 0px;
+        left: 0px;
+        -webkit-app-region: no-drag;
+        z-index: 2;
+    }
+    &:after {
+        left: auto;
+        right: 0px;
+    }
 }
 
 .windows {


### PR DESCRIPTION
# Description

Override windows drag event on windows top corners to allow resize.

Fixes #324, #320 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Windows

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code