### PR TITLE
Remove all references to iota-wallet-shared-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "eslint-plugin-react": "^7.7.0",
         "eslint-plugin-react-native": "^3.2.1",
         "husky": "^0.14.3",
-        "iota-wallet-shared-modules": "./src/shared/",
+        "shared-modules": "./src/shared/",
         "lint-staged": "^4.2.3",
         "node-cmd": "^3.0.0",
         "os": "^0.1.1",

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -22,7 +22,6 @@
     "test": "NODE_ENV=test ./node_modules/.bin/jest --forceExit",
     "nodejs-deps": "yarn --cwd nodejs-assets/nodejs-project",
     "postinstall": "./node_modules/.bin/rn-nodeify --hack --install && rm ./node_modules/react-native/Libraries/polyfills/babelHelpers.js && cp babelHelpersCopy ./node_modules/react-native/Libraries/polyfills/babelHelpers.js && yarn nodejs-deps",
-    "lint": "./node_modules/.bin/eslint --ext .js .",
     "prepare-release": "yarn version && cd ios && bundle exec fastlane release && cd ../android && bundle exec fastlane release && cd .. && echo Successfully incremented version and build numbers! Please remember to run git add ., git commit, git push --tags, and git push",
     "audit": "./../../node_modules/.bin/auditjs -l error -w whitelist.json"
   },

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -147,7 +147,7 @@
       "/shared/"
     ],
     "transformIgnorePatterns": [
-      "node_modules/?!(react-native|iota-wallet-shared-modules)/"
+      "node_modules/?!(react-native|shared-modules)/"
     ]
   },
   "react-native": {

--- a/src/mobile/src/ui/views/onboarding/SaveYourSeed.js
+++ b/src/mobile/src/ui/views/onboarding/SaveYourSeed.js
@@ -358,7 +358,7 @@ class SaveYourSeed extends Component {
                fill: #231f20;
                font-family: Monospace;
              }
-             @font-face { font-family: "Monospace"; src: "iota-wallet-shared-modules/custom-fonts/SourceCodePro-Medium.ttf"
+             @font-face { font-family: "Monospace"; src: "shared-modules/custom-fonts/SourceCodePro-Medium.ttf"
           </style>
           <body>
             ${this.getHTMLContent()}

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -3026,27 +3026,6 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-iota-wallet-shared-modules@../shared/:
-  version "0.0.0"
-  dependencies:
-    bignumber.js "^7.2.1"
-    i18next "^10.2.2"
-    iota.lib.js "^0.5.0"
-    lodash "^4.17.10"
-    moment "^2.22.2"
-    proxy-polyfill "git+https://git@github.com/GoogleChrome/proxy-polyfill#9c009d7"
-    react "^16.2.0"
-    react-i18next "^7.3.4"
-    react-redux "^5.0.6"
-    redux "^3.7.2"
-    redux-persist "^4.10.1"
-    redux-thunk "^2.2.0"
-    reselect "^3.0.1"
-    tinycolor2 "^1.4.1"
-    url-parse "^1.2.0"
-    valid-url "^1.0.9"
-    zxcvbn "^4.4.2"
-
 iota.lib.js@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/iota.lib.js/-/iota.lib.js-0.5.0.tgz#66e59baf82a4556b739f81d947313d0a3ab2f659"
@@ -5950,6 +5929,27 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shared-modules@../shared/:
+  version "0.0.0"
+  dependencies:
+    bignumber.js "^7.2.1"
+    i18next "^10.2.2"
+    iota.lib.js "^0.5.0"
+    lodash "^4.17.10"
+    moment "^2.22.2"
+    proxy-polyfill "git+https://git@github.com/GoogleChrome/proxy-polyfill#9c009d7"
+    react "^16.2.0"
+    react-i18next "^7.3.4"
+    react-redux "^5.0.6"
+    redux "^3.7.2"
+    redux-persist "^4.10.1"
+    redux-thunk "^2.2.0"
+    reselect "^3.0.1"
+    tinycolor2 "^1.4.1"
+    url-parse "^1.2.0"
+    valid-url "^1.0.9"
+    zxcvbn "^4.4.2"
 
 shebang-command@^1.2.0:
   version "1.2.0"

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "iota-wallet-shared-modules",
+    "name": "shared-modules",
     "version": "0.0.0",
     "description": "",
     "keywords": [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1618,27 +1618,6 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-iota-wallet-shared-modules@./src/shared/:
-  version "0.0.0"
-  dependencies:
-    bignumber.js "^7.2.1"
-    i18next "^10.2.2"
-    iota.lib.js "^0.5.0"
-    lodash "^4.17.10"
-    moment "^2.22.2"
-    proxy-polyfill "git+https://git@github.com/GoogleChrome/proxy-polyfill#9c009d7"
-    react "^16.2.0"
-    react-i18next "^7.3.4"
-    react-redux "^5.0.6"
-    redux "^3.7.2"
-    redux-persist "^4.10.1"
-    redux-thunk "^2.2.0"
-    reselect "^3.0.1"
-    tinycolor2 "^1.4.1"
-    url-parse "^1.2.0"
-    valid-url "^1.0.9"
-    zxcvbn "^4.4.2"
-
 iota.lib.js@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/iota.lib.js/-/iota.lib.js-0.5.0.tgz#66e59baf82a4556b739f81d947313d0a3ab2f659"
@@ -3303,6 +3282,27 @@ sha@~2.0.1:
   dependencies:
     graceful-fs "^4.1.2"
     readable-stream "^2.0.2"
+
+shared-modules@./src/shared/:
+  version "0.0.0"
+  dependencies:
+    bignumber.js "^7.2.1"
+    i18next "^10.2.2"
+    iota.lib.js "^0.5.0"
+    lodash "^4.17.10"
+    moment "^2.22.2"
+    proxy-polyfill "git+https://git@github.com/GoogleChrome/proxy-polyfill#9c009d7"
+    react "^16.2.0"
+    react-i18next "^7.3.4"
+    react-redux "^5.0.6"
+    redux "^3.7.2"
+    redux-persist "^4.10.1"
+    redux-thunk "^2.2.0"
+    reselect "^3.0.1"
+    tinycolor2 "^1.4.1"
+    url-parse "^1.2.0"
+    valid-url "^1.0.9"
+    zxcvbn "^4.4.2"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
# Description
- "iota-wallet-shared-modules" was renamed to "shared-modules" in https://github.com/iotaledger/trinity-wallet/commit/73222dc108a88a38eefb68f83b115ff8e227e2b8 but some of the references were still pointing to the old name.
- Update src/mobile/yarn.lock with "shared-modules"
- Remove unused linting script in `src/mobile/package.json`

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Building iOS debug mode and checking if changes in `shared/` are reflected in `mobile` on runtime

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
