### PR TITLE
Reattach only if transaction falls below max depth

### DIFF
--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -38,6 +38,7 @@ import {
     filterInvalidPendingTransactions,
     getPendingOutgoingTransfersForAddresses,
     retryFailedTransaction as retry,
+    isAboveMaxDepth,
 } from '../libs/iota/transfers';
 import {
     syncAccountAfterReattachment,
@@ -326,7 +327,9 @@ export const forceTransactionPromotion = (
     let replayCount = 0;
     let promotionAttempt = 0;
 
-    const promote = (hash) => {
+    const promote = (tailTransaction) => {
+        const { hash, attachmentTimestamp } = tailTransaction;
+
         promotionAttempt += 1;
 
         return promoteTransactionAsync(null, powFn)(hash).catch((error) => {
@@ -338,10 +341,12 @@ export const forceTransactionPromotion = (
                 promotionAttempt < maxPromotionAttempts
             ) {
                 // Retry promotion on same reference (hash)
-                return promote(hash);
+                return promote(tailTransaction);
             } else if (
                 isTransactionInconsistent &&
                 promotionAttempt === maxPromotionAttempts &&
+                // Temporarily disable reattachments if transaction is still above max depth
+                !isAboveMaxDepth(attachmentTimestamp) &&
                 // If number of reattachments haven't exceeded max reattachments
                 replayCount < maxReplays
             ) {
@@ -383,12 +388,12 @@ export const forceTransactionPromotion = (
             dispatch(updateAccountAfterReattachment(newState));
             const tailTransaction = find(reattachment, { currentIndex: 0 });
 
-            return promote(tailTransaction.hash);
+            return promote(tailTransaction);
         });
     };
 
     if (has(consistentTail, 'hash')) {
-        return promote(consistentTail.hash);
+        return promote(consistentTail);
     }
 
     return reattachAndPromote();

--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -122,6 +122,7 @@ export const findPromotableTail = (provider) => (tails, idx) => {
 
     return isPromotable(provider)(get(thisTail, 'hash'))
         .then((state) => {
+            // Temporarily allow transaction to promote even if consistency check fails
             if (state || isAboveMaxDepth(get(thisTail, 'attachmentTimestamp'))) {
                 return thisTail;
             }


### PR DESCRIPTION
# Description

Temporarily disable reattachments if a transaction is above max depth

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually promoting transaction (iOS)

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
