### PR TITLE
Handle read permissions on runtime when seedvault is imported (Android)

### DIFF
--- a/src/mobile/__tests__/ui/components/SeedVaultImportComponent.spec.js
+++ b/src/mobile/__tests__/ui/components/SeedVaultImportComponent.spec.js
@@ -1,0 +1,81 @@
+import assign from 'lodash/assign';
+import noop from 'lodash/noop';
+import React from 'react';
+import { PermissionsAndroid } from 'react-native';
+import { shallow } from 'enzyme';
+import { SeedVaultImportComponent } from 'ui/components/SeedVaultImportComponent';
+
+jest.mock('rn-fetch-blob', () => ({ DocumentDir: () => {} }));
+jest.mock('nodejs-mobile-react-native', () => ({
+    start: () => {},
+    channel: {
+        addListener: () => {},
+        removeListener: () => {},
+    },
+}));
+
+const getProps = (overrides) =>
+    assign(
+        {},
+        {
+            theme: { input: {}, body: {}, primary: {} },
+            t: () => '',
+            generateAlert: noop,
+            openPasswordValidationModal: noop,
+            onSeedImport: noop,
+            onRef: noop,
+        },
+        overrides,
+    );
+
+describe('Testing SeedVaultImportComponent component', () => {
+    describe('instance methods', () => {
+        describe('when called', () => {
+            describe('#grantPermissions', () => {
+                beforeEach(() => {
+                    jest.mock('PermissionsAndroid', () => ({
+                        request: jest.fn(() => Promise.resolve(true)),
+                        PERMISSIONS: {},
+                        RESULTS: {
+                            GRANTED: 'granted',
+                        },
+                    }));
+                });
+
+                describe('when read permission is already granted', () => {
+                    it('should resolve true', () => {
+                        const props = getProps();
+
+                        const instance = shallow(<SeedVaultImportComponent {...props} />).instance();
+
+                        return instance.grantPermissions().then((result) => expect(result).toEqual(true));
+                    });
+                });
+
+                describe('when read permission is granted by user', () => {
+                    it('should resolve "granted"', () => {
+                        PermissionsAndroid.request.mockReturnValueOnce(Promise.resolve('granted'));
+                        const props = getProps();
+
+                        const instance = shallow(<SeedVaultImportComponent {...props} />).instance();
+
+                        return instance.grantPermissions().then((result) => expect(result).toEqual('granted'));
+                    });
+                });
+
+                describe('when read permission is denied by user', () => {
+                    it('should throw an error with message "Read permissions not granted."', () => {
+                        PermissionsAndroid.request.mockReturnValueOnce(Promise.resolve('denied'));
+                        const props = getProps();
+
+                        const instance = shallow(<SeedVaultImportComponent {...props} />).instance();
+
+                        return instance
+                            .grantPermissions()
+                            .catch((err) => expect(err).toEqual(new Error('Read permissions not granted.')));
+                    });
+                });
+            });
+        });
+    });
+});

--- a/src/mobile/src/ui/components/SeedVaultImportComponent.js
+++ b/src/mobile/src/ui/components/SeedVaultImportComponent.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, PermissionsAndroid } from 'react-native';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { DocumentPicker } from 'react-native-document-picker';
@@ -82,6 +82,22 @@ export class SeedVaultImportComponent extends Component {
     }
 
     /**
+     * Grant storage read permissions for android
+     *
+     * @method grantPermissions
+     * @returns {Promise}
+     */
+    grantPermissions() {
+        return PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE).then((granted) => {
+            if (granted === true || granted === PermissionsAndroid.RESULTS.GRANTED) {
+                return Promise.resolve(granted);
+            }
+
+            throw new Error('Read permissions not granted.');
+        });
+    }
+
+    /**
      * Opens document picker, reads chosen file and opens password validation modal
      * @method importSeedVault
      */
@@ -103,8 +119,9 @@ export class SeedVaultImportComponent extends Component {
                 if (path.startsWith('file://')) {
                     path = path.slice(7);
                 }
-                RNFetchBlob.fs
-                    .readFile(path, 'ascii')
+
+                (isAndroid ? this.grantPermissions() : Promise.resolve())
+                    .then(() => RNFetchBlob.fs.readFile(path, 'ascii'))
                     .then((data) => {
                         this.setState({ seedVault: data });
                         this.props.openPasswordValidationModal();


### PR DESCRIPTION
# Description

Fixes https://github.com/iotaledger/trinity-wallet/issues/376

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested seed vault import on Android 5.0.0
- Tested seed vault import on Android 7.0.0
- Added unit test coverage

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
