### PR TITLE
Desktop: Add text drag&drop feature for seed input

### DIFF
--- a/src/desktop/src/ui/components/Dropzone.js
+++ b/src/desktop/src/ui/components/Dropzone.js
@@ -15,12 +15,12 @@ import css from './dropzone.scss';
  */
 class Dropzone extends React.Component {
     static propTypes = {
-        /** Succesful file drop callback
+        /** Succesful file dropped callback
          * @param {buffer} FileBuffer - Droped file content buffer
          * @returns {undefined}
          */
         onDrop: PropTypes.func.isRequired,
-        /** Succesful text drop
+        /** Succesful text seed dropped callback
          * @param {array} seed - Seed byte array
          * @returns {undefined}
          */

--- a/src/desktop/src/ui/components/Dropzone.js
+++ b/src/desktop/src/ui/components/Dropzone.js
@@ -4,6 +4,8 @@ import { translate, Trans } from 'react-i18next';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 
+import { charToByte } from 'libs/helpers';
+
 import Icon from 'ui/components/Icon';
 
 import css from './dropzone.scss';
@@ -18,6 +20,11 @@ class Dropzone extends React.Component {
          * @returns {undefined}
          */
         onDrop: PropTypes.func.isRequired,
+        /** Succesfull text drop
+         * @param {array} seed - Seed byte array
+         * @returns {undefined}
+         */
+        onTextDrop: PropTypes.func.isRequired,
         /** @ignore */
         t: PropTypes.func.isRequired,
     };
@@ -84,6 +91,22 @@ class Dropzone extends React.Component {
     onDrop(e) {
         e.stopPropagation();
         e.preventDefault();
+
+        try {
+            const seed = e.dataTransfer
+                .getData('Text')
+                .split('')
+                .map((char) => charToByte(char.toUpperCase()))
+                .filter((byte) => byte > -1);
+
+            this.setState({
+                isDragActive: false,
+            });
+
+            if (seed.length) {
+                return this.props.onTextDrop(seed);
+            }
+        } catch (err) {}
 
         const { onDrop } = this.props;
 

--- a/src/desktop/src/ui/components/Dropzone.js
+++ b/src/desktop/src/ui/components/Dropzone.js
@@ -15,12 +15,12 @@ import css from './dropzone.scss';
  */
 class Dropzone extends React.Component {
     static propTypes = {
-        /** Succesfull file drop callback
+        /** Succesful file drop callback
          * @param {buffer} FileBuffer - Droped file content buffer
          * @returns {undefined}
          */
         onDrop: PropTypes.func.isRequired,
-        /** Succesfull text drop
+        /** Succesful text drop
          * @param {array} seed - Seed byte array
          * @returns {undefined}
          */

--- a/src/desktop/src/ui/components/input/Seed.js
+++ b/src/desktop/src/ui/components/input/Seed.js
@@ -123,7 +123,11 @@ class SeedInput extends React.PureComponent {
         });
     };
 
-    onTextDrop = async (seed) => {
+    /**
+     * Set valid length drag&drop seed to state
+     * @param {array} seed - Target seed byte array
+     */
+    onTextDrop = (seed) => {
         if (seed.length === MAX_SEED_LENGTH) {
             this.props.onChange(seed);
         }

--- a/src/desktop/src/ui/components/input/Seed.js
+++ b/src/desktop/src/ui/components/input/Seed.js
@@ -36,7 +36,7 @@ class SeedInput extends React.PureComponent {
         /** Camera modal close label */
         closeLabel: PropTypes.string.isRequired,
         /** Seed change event function
-         * @param {string} value - Current seed value
+         * @param {array} value - Current seed value
          */
         onChange: PropTypes.func.isRequired,
         /** Should the onboarding name be updated to imported SeedVault account name */
@@ -121,6 +121,13 @@ class SeedInput extends React.PureComponent {
         this.setState({
             importBuffer: buffer,
         });
+    };
+
+    onTextDrop = async (seed) => {
+        if (seed.length === MAX_SEED_LENGTH) {
+            this.props.onChange(seed);
+        }
+        Electron.garbageCollect();
     };
 
     getCursor = (element) => {
@@ -303,7 +310,7 @@ class SeedInput extends React.PureComponent {
                     </div>
                     <small>{label}</small>
                 </fieldset>
-                <Dropzone onDrop={this.onDrop} />
+                <Dropzone onDrop={this.onDrop} onTextDrop={this.onTextDrop} />
 
                 {seed.length ? <span className={css.info}>{checkSum}</span> : null}
                 {showScanner && (


### PR DESCRIPTION
# Description

Allow users to drag & drop plain text seed on seed input view

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS and Ubuntu

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code