### PR TITLE
Reorder start up functions to fix splash screen hang on android

### DIFF
--- a/src/mobile/src/libs/store.js
+++ b/src/mobile/src/libs/store.js
@@ -2,7 +2,6 @@ import get from 'lodash/get';
 import { getVersion, getBuildNumber } from 'react-native-device-info';
 import { AsyncStorage } from 'react-native';
 import store, { persistStore, purgeStoredState, createPersistor } from '../../../shared/store';
-import initializeApp from '../ui/routes/entry';
 import { setAppVersions, resetWallet } from '../../../shared/actions/settings';
 import { updatePersistedState } from '../../../shared/libs/utils';
 
@@ -21,7 +20,7 @@ const shouldMigrate = (restoredState) => {
     return restoredVersion !== currentVersion || restoredBuildNumber !== currentBuildNumber;
 };
 
-const migrate = (state, restoredState) => {
+export const migrate = (state, restoredState) => {
     // TODO: Doing a dirty patch to disable migration setup for alpha v0.2.0
     // since this would be installed as a fresh application.
     const hasAnUpdate = shouldMigrate(restoredState);
@@ -34,27 +33,33 @@ const migrate = (state, restoredState) => {
             }),
         );
 
-        return initializeApp(state);
+        return Promise.resolve(state);
     }
 
-    return purgeStoredState({ storage: persistConfig.storage })
-        .then(() => {
-            state.dispatch(resetWallet());
-            // Set the new app version
-            state.dispatch(
-                setAppVersions({
-                    version: getVersion(),
-                    buildNumber: getBuildNumber(),
-                }),
-            );
+    return purgeStoredState({ storage: persistConfig.storage }).then(() => {
+        state.dispatch(resetWallet());
+        // Set the new app version
+        state.dispatch(
+            setAppVersions({
+                version: getVersion(),
+                buildNumber: getBuildNumber(),
+            }),
+        );
 
-            const persistor = createPersistor(state, persistConfig);
-            const updatedState = updatePersistedState(state.getState(), restoredState);
-            persistor.rehydrate(updatedState);
+        const persistor = createPersistor(state, persistConfig);
+        const updatedState = updatePersistedState(state.getState(), restoredState);
+        persistor.rehydrate(updatedState);
 
-            return initializeApp(state);
-        })
-        .catch((err) => console.error(err)); // eslint-disable-line no-console
+        return state;
+    });
 };
 
-export const persistor = persistStore(store, persistConfig, (err, restoredState) => migrate(store, restoredState));
+export const persistStoreAsync = () =>
+    new Promise((resolve) =>
+        persistStore(store, persistConfig, (err, restoredState) =>
+            resolve({
+                store,
+                restoredState,
+            }),
+        ),
+    );


### PR DESCRIPTION
# Description

Fix splash screen hang on android after upgrade to RNN to v2

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested by successfully building android 

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
