### PR TITLE
Mobile release v0.5.0 (23)

### DIFF
--- a/src/mobile/android/app/build.gradle
+++ b/src/mobile/android/app/build.gradle
@@ -88,7 +88,7 @@ android {
     buildToolsVersion '27.0.3'
     defaultConfig {
         applicationId "com.iota.trinity"
-        versionCode 22
+        versionCode 23
         versionName "0.5.0"
         minSdkVersion 21
         targetSdkVersion 26

--- a/src/mobile/ios/iotaWallet-tvOS/Info.plist
+++ b/src/mobile/ios/iotaWallet-tvOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/src/mobile/ios/iotaWallet-tvOSTests/Info.plist
+++ b/src/mobile/ios/iotaWallet-tvOSTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 </dict>
 </plist>

--- a/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
+++ b/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
@@ -2806,7 +2806,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
@@ -3179,7 +3179,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/src/mobile/ios/iotaWallet/Info.plist
+++ b/src/mobile/ios/iotaWallet/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/src/mobile/ios/iotaWalletTests/Info.plist
+++ b/src/mobile/ios/iotaWalletTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 </dict>
 </plist>

--- a/src/mobile/ios/iotaWalletUITests/Info.plist
+++ b/src/mobile/ios/iotaWalletUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>22</string>
+	<string>23</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Changelog

### Additions
- Add support for Hungarian (#430)
- Use system timezone for timestamps (#434)

### Fixes and improvements

- Fix SeedVault import issues on iOS (#378)
- Fix permission issues for SeedVault import on Android (#393)
- Compress images (#415)
- Fix SeedVault import/export crash - this will temporarily disable SeedVault on on iPhone XS/XS Max/XR (#417)
- Fix `9999...` extra transaction in bundles created by the snapshot transition process (#385)
- Change to `memset_s` in Entangled for iOS (#364)