### PR TITLE
Desktop: Fix Bugsnag sourcemap uploads

### DIFF
--- a/src/desktop/bugsnag.js
+++ b/src/desktop/bugsnag.js
@@ -26,7 +26,7 @@ upload({
     sourceMap: resolve(__dirname, 'dist/bundle.js.map'),
     minifiedUrl: 'iota://dist/bundle.js',
     minifiedFile: resolve(__dirname, 'dist/bundle.js'),
-    overwrite: false,
+    overwrite: true,
 })
     .then(
         upload({
@@ -36,7 +36,7 @@ upload({
             sourceMap: resolve(__dirname, 'dist/css/main.css.map'),
             minifiedUrl: 'iota://dist/css/main.css',
             minifiedFile: resolve(__dirname, 'dist/css/main.css'),
-            overwrite: false,
+            overwrite: true,
         }),
     )
     .then(() => console.log('Sourcemaps successfully uploaded to Bugsnag'))


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description
Fixes issues where Bugsnag may reject a sourcemap if one for the current version has already been uploaded.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
N/A


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code