### PR TITLE
Desktop: Fix sweep confirmation message locale

### DIFF
--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -755,7 +755,7 @@
         "explanation": "Trinity Desktop version 0.3.4 contained a bug that can temporarily lock funds. This affects a small number of users that performed transactions with 0.3.4.",
         "explanationAccounts": "Locked funds have been detected on your accounts: {{accounts}}. Trinity will now automatically recover your funds, by moving them to a new address.",
         "proceed": "Proceed to Recovery",
-        "sweepConfirmation": "You are about to sweep {{amount}} to the address {{address}}. Account: {{accountName}, address index: {{index}",
+        "sweepConfirmation": "You are about to sweep {{amount}} to the address {{address}}. Account: {{accountName}}, address index: {{index}}",
         "sweepConfirmationTitle": "Sweep confirmation"
      }
 }


### PR DESCRIPTION
# Description

Sweep confirmation message locale variable missing curly brackets

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code