### PR TITLE
[Desktop] Add dark menu bar icon support for macOS

### DIFF
--- a/src/desktop/main.js
+++ b/src/desktop/main.js
@@ -272,7 +272,7 @@ const setupTray = (enabled) => {
         return;
     }
 
-    tray = new Tray(`${__dirname}/dist/tray@2x.png`);
+    tray = new Tray(`${__dirname}/dist/trayTemplate@2x.png`);
 
     tray.on('click', () => {
         toggleTray();

--- a/src/desktop/webpack.config/config.base.js
+++ b/src/desktop/webpack.config/config.base.js
@@ -87,7 +87,7 @@ module.exports = {
         }),
         new CopyWebpackPlugin([
             { from: 'assets/icon-128.png', to: 'icon.png' },
-            { from: 'assets/icon-64.png', to: 'tray@2x.png' },
+            { from: 'assets/icon-64.png', to: 'trayTemplate@2x.png' },
             { from: 'assets/icon.icns', to: 'icon.icns' },
             { from: 'assets/icon.ico', to: 'icon.ico' },
         ]),


### PR DESCRIPTION
# Description

Add dark menu bar icon support for macOS (see [Electron documentation](https://github.com/electron/electron/blob/master/docs/api/native-image.md#template-image)).

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on macOS 10.13.6 by toggling dark/light menu bar

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
