### PR TITLE
Fix react-native-dropdownalert dependency

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -63,7 +63,7 @@
     "react-native-detect-navbar-android": "^0.2.0",
     "react-native-device-info": "^0.13.0",
     "react-native-document-picker": "^2.1.0",
-    "react-native-dropdownalert": "git+https://github.com/cvarley100/react-native-dropdownalert#master",
+    "react-native-dropdownalert": "https://github.com/cvarley100/react-native-dropdownalert#latest",
     "react-native-exit-app": "^1.0.0",
     "react-native-extra-dimensions-android": "^0.21.0",
     "react-native-fast-crypto": "https://github.com/rajivshah3/react-native-fast-crypto#13db40e",

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -63,7 +63,7 @@
     "react-native-detect-navbar-android": "^0.2.0",
     "react-native-device-info": "^0.13.0",
     "react-native-document-picker": "^2.1.0",
-    "react-native-dropdownalert": "https://github.com/cvarley100/react-native-dropdownalert#latest",
+    "react-native-dropdownalert": "https://github.com/cvarley100/react-native-dropdownalert#fc6655c4542e3b35da67ccca5f708adb0a7ccff8",
     "react-native-exit-app": "^1.0.0",
     "react-native-extra-dimensions-android": "^0.21.0",
     "react-native-fast-crypto": "https://github.com/rajivshah3/react-native-fast-crypto#13db40e",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -6058,6 +6058,14 @@ process@~0.5.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  integrity sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
@@ -6343,9 +6351,11 @@ react-native-document-picker@^2.1.0:
   resolved "https://registry.yarnpkg.com/react-native-document-picker/-/react-native-document-picker-2.1.0.tgz#61bbe113435a9d7bf67ab77093a4092d76b52fe3"
   integrity sha512-BFCBXwz8xuLvHLVFVeQM+RhaY8yZ38PEWt9WSbq5VIoZ/VssP6uu51XxOfdwaMALOrAHIojK0SiYnd155upZAg==
 
-"react-native-dropdownalert@https://github.com/cvarley100/react-native-dropdownalert#latest":
-  version "2.5.0"
-  resolved "https://github.com/cvarley100/react-native-dropdownalert#3695021d674adce24898174320f27798dd9e1d96"
+"react-native-dropdownalert@https://github.com/cvarley100/react-native-dropdownalert#fc6655c4542e3b35da67ccca5f708adb0a7ccff8":
+  version "3.7.0"
+  resolved "https://github.com/cvarley100/react-native-dropdownalert#fc6655c4542e3b35da67ccca5f708adb0a7ccff8"
+  dependencies:
+    prop-types "15.5.10"
 
 react-native-exit-app@^1.0.0:
   version "1.0.0"

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -6058,14 +6058,6 @@ process@~0.5.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.5.10:
-  version "15.5.10"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
-  integrity sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-
 prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
@@ -6351,11 +6343,9 @@ react-native-document-picker@^2.1.0:
   resolved "https://registry.yarnpkg.com/react-native-document-picker/-/react-native-document-picker-2.1.0.tgz#61bbe113435a9d7bf67ab77093a4092d76b52fe3"
   integrity sha512-BFCBXwz8xuLvHLVFVeQM+RhaY8yZ38PEWt9WSbq5VIoZ/VssP6uu51XxOfdwaMALOrAHIojK0SiYnd155upZAg==
 
-"react-native-dropdownalert@git+https://github.com/cvarley100/react-native-dropdownalert#master":
-  version "3.4.0"
-  resolved "git+https://github.com/cvarley100/react-native-dropdownalert#e4bc9d37a108a8abb10cdc216b70f5bc672c602c"
-  dependencies:
-    prop-types "15.5.10"
+"react-native-dropdownalert@https://github.com/cvarley100/react-native-dropdownalert#latest":
+  version "2.5.0"
+  resolved "https://github.com/cvarley100/react-native-dropdownalert#3695021d674adce24898174320f27798dd9e1d96"
 
 react-native-exit-app@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description
Fix force push to `react-native-dropdownalert`

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
N/A

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code