### PR TITLE
Revert (temporarily made) promotion adjustments

### DIFF
--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -37,7 +37,6 @@ import {
     filterInvalidPendingTransactions,
     getPendingOutgoingTransfersForAddresses,
     retryFailedTransaction as retry,
-    isAboveMaxDepth,
 } from '../libs/iota/transfers';
 import {
     syncAccountAfterReattachment,
@@ -327,7 +326,7 @@ export const forceTransactionPromotion = (
     let promotionAttempt = 0;
 
     const promote = (tailTransaction) => {
-        const { hash, attachmentTimestamp } = tailTransaction;
+        const { hash } = tailTransaction;
 
         promotionAttempt += 1;
 
@@ -344,8 +343,6 @@ export const forceTransactionPromotion = (
             } else if (
                 isTransactionInconsistent &&
                 promotionAttempt === maxPromotionAttempts &&
-                // Temporarily disable reattachments if transaction is still above max depth
-                !isAboveMaxDepth(attachmentTimestamp) &&
                 // If number of reattachments haven't exceeded max reattachments
                 replayCount < maxReplays
             ) {

--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -133,8 +133,7 @@ export const findPromotableTail = (provider) => (tails, idx) => {
 
     return isPromotable(provider)(get(thisTail, 'hash'))
         .then((state) => {
-            // Temporarily allow transaction to promote even if consistency check fails
-            if (state || isAboveMaxDepth(get(thisTail, 'attachmentTimestamp'))) {
+            if (state === true && isAboveMaxDepth(get(thisTail, 'attachmentTimestamp'))) {
                 return thisTail;
             }
 


### PR DESCRIPTION
# Description

To avoid unnecessary reattachments (because of a bug in IRI checkConsistency endpoint), some temporary adjustments were made in https://github.com/iotaledger/trinity-wallet/pull/368 & https://github.com/iotaledger/trinity-wallet/pull/371.
Since IRI patched the bug in v1.5.5 (https://github.com/iotaledger/iri/releases/tag/v1.5.5) specifically in https://github.com/iotaledger/iri/pull/907, this reverts the temporary adjustments made to promotion setup.

## Type of change

- Enhancement

# How Has This Been Tested?

Analysing transaction promotion (iOS)

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
