### PR TITLE
Mobile: Bump bugsnag-react-native to v2.11.0

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -34,7 +34,7 @@
     "axios": "^0.18.0",
     "browserify-zlib": "^0.1.4",
     "buffer": "^3.6.0",
-    "bugsnag-react-native": "^2.9.3",
+    "bugsnag-react-native": "^2.11.0",
     "console-browserify": "^1.1.0",
     "constants-browserify": "0.0.1",
     "dns.js": "^1.0.1",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -1608,10 +1608,10 @@ buffer@^5.0.0, buffer@^5.0.8:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
-bugsnag-react-native@^2.9.3:
-  version "2.9.4"
-  resolved "https://registry.yarnpkg.com/bugsnag-react-native/-/bugsnag-react-native-2.9.4.tgz#a8dfcc44f727909d306e40dd980997a3e69fe2e5"
-  integrity sha1-qN/MRPcnkJ0wbkDdmAmXo+af4uU=
+bugsnag-react-native@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bugsnag-react-native/-/bugsnag-react-native-2.11.0.tgz#a65db95a1b4318e7e0089815ddc4f0779a678616"
+  integrity sha512-1YhPC5ZRCyXvmLuGBklBhNo0/H2Rxs/vU34yij0ElzJsyByYACwMpOEd/NUYdrhEoDSyjStbvAZ9hGSpT587kg==
   dependencies:
     iserror "^0.0.2"
     promise "^7"


### PR DESCRIPTION
# Description

Updates `bugsnag-react-native` to v2.11.0. This version includes bug fixes and improvements to crash reporting.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Manually triggered crash on iOS


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes