### PR TITLE
[desktop] Add Wallet reset functionality for non authorised users

### DIFF
--- a/src/desktop/lib/Menu.js
+++ b/src/desktop/lib/Menu.js
@@ -195,7 +195,6 @@ const initMenu = (app, getWindow) => {
                             },
                             {
                                 label: language.advanced,
-                                enabled: state.authorised && state.enabled,
                                 click: () => navigate('settings/advanced'),
                             },
                         ],

--- a/src/desktop/src/ui/components/modal/Confirm.js
+++ b/src/desktop/src/ui/components/modal/Confirm.js
@@ -12,8 +12,10 @@ export default class Confirm extends React.PureComponent {
     static propTypes = {
         /** Confirm window visibility state */
         isOpen: PropTypes.bool.isRequired,
+        /** Should the confirmation option disabled for X seconds */
+        countdown: PropTypes.number,
         /** Confirm window type */
-        category: PropTypes.oneOf(['primary', 'secondary', 'positive', 'negative']),
+        category: PropTypes.oneOf([ 'primary', 'secondary', 'positive', 'negative' ]),
         /** Confirm window content */
         content: PropTypes.object.isRequired,
         /** Confirm window cancel function */
@@ -23,7 +25,7 @@ export default class Confirm extends React.PureComponent {
     };
 
     render() {
-        const { category, content, isOpen } = this.props;
+        const { category, content, isOpen, countdown } = this.props;
 
         return (
             <Modal variant="confirm" onClose={this.props.onCancel} isOpen={isOpen}>
@@ -33,8 +35,11 @@ export default class Confirm extends React.PureComponent {
                     <Button onClick={this.props.onCancel} variant="dark">
                         {content.cancel}
                     </Button>
-                    <Button onClick={this.props.onConfirm} variant={category ? category : 'primary'}>
-                        {content.confirm}
+                    <Button
+                        disabled={countdown && countdown > 0}
+                        onClick={this.props.onConfirm}
+                        variant={category ? category : 'primary'}>
+                        {countdown && countdown > 0 ? countdown : content.confirm}
                     </Button>
                 </footer>
             </Modal>

--- a/src/desktop/src/ui/views/settings/Advanced.js
+++ b/src/desktop/src/ui/views/settings/Advanced.js
@@ -99,7 +99,7 @@ class Advanced extends PureComponent {
     confirmReset = () => {
         const { wallet } = this.props;
 
-        this.setState({ resetConfirm: !this.state.resetConfirm, resetCountdown: 6 });
+        this.setState({ resetConfirm: !this.state.resetConfirm, resetCountdown: 15 });
 
         if (!wallet || !wallet.isOpen) {
             this.interval = setInterval(() => {

--- a/src/desktop/src/ui/views/settings/Advanced.js
+++ b/src/desktop/src/ui/views/settings/Advanced.js
@@ -17,6 +17,7 @@ import {
 import { generateAlert } from 'actions/alerts';
 
 import Button from 'ui/components/Button';
+import Confirm from 'ui/components/modal/Confirm';
 import ModalPassword from 'ui/components/modal/Password';
 import Toggle from 'ui/components/Toggle';
 import Checkbox from 'ui/components/Checkbox';
@@ -32,6 +33,8 @@ class Advanced extends PureComponent {
     static propTypes = {
         /** @ignore */
         settings: PropTypes.object.isRequired,
+        /** @ignore */
+        wallet: PropTypes.object,
         /** @ignore */
         setTray: PropTypes.func.isRequired,
         /** @ignore */
@@ -52,11 +55,17 @@ class Advanced extends PureComponent {
 
     state = {
         resetConfirm: false,
+        resetCountdown: 0,
     };
+
+    componentWillUnmount() {
+        if (this.interval) {
+            clearInterval(this.interval);
+        }
+    }
 
     /**
      * Hard reset wallet
-     * @param {string} Password - Plain text wallet password
      * @returns {undefined}
      */
     resetWallet = () => {
@@ -87,9 +96,28 @@ class Advanced extends PureComponent {
         this.props.setLockScreenTimeout(timeout > 60 ? 60 : timeout);
     };
 
+    confirmReset = () => {
+        const { wallet } = this.props;
+
+        this.setState({ resetConfirm: !this.state.resetConfirm, resetCountdown: 6 });
+
+        if (!wallet || !wallet.isOpen) {
+            this.interval = setInterval(() => {
+                if (this.state.resetCountdown === 1) {
+                    clearInterval(this.interval);
+                }
+
+                this.setState({
+                    resetCountdown: this.state.resetCountdown - 1,
+                });
+            }, 1000);
+        }
+    };
+
     render() {
         const {
             settings,
+            wallet,
             changePowSettings,
             changeAutoPromotionSettings,
             lockScreenTimeout,
@@ -98,78 +126,82 @@ class Advanced extends PureComponent {
             t,
         } = this.props;
 
-        const { resetConfirm } = this.state;
+        const { resetConfirm, resetCountdown } = this.state;
 
         return (
             <div className={css.scroll}>
                 <Scrollbar>
-                    <h3>{t('pow:powUpdated')}</h3>
-                    <Toggle
-                        checked={settings.remotePoW}
-                        onChange={() => changePowSettings()}
-                        on={t('pow:remote')}
-                        off={t('pow:local')}
-                    />
-                    <p>
-                        {t('pow:feeless')} {t('pow:localOrRemote')}
-                    </p>
-                    <hr />
-
-                    <h3>{t('advancedSettings:autoPromotion')}</h3>
-                    <Toggle
-                        checked={settings.autoPromotion}
-                        onChange={() => changeAutoPromotionSettings()}
-                        on={t('enabled')}
-                        off={t('disabled')}
-                    />
-                    <p>{t('advancedSettings:autoPromotionExplanation')}</p>
-                    <hr />
-
-                    {Electron.getOS() === 'darwin' && (
+                    {wallet && wallet.ready ? (
                         <React.Fragment>
-                            <h3>{t('tray:trayApplication')}</h3>
+                            <h3>{t('pow:powUpdated')}</h3>
                             <Toggle
-                                checked={settings.isTrayEnabled}
-                                onChange={() => setTray(!settings.isTrayEnabled)}
+                                checked={settings.remotePoW}
+                                onChange={() => changePowSettings()}
+                                on={t('pow:remote')}
+                                off={t('pow:local')}
+                            />
+                            <p>
+                                {t('pow:feeless')} {t('pow:localOrRemote')}
+                            </p>
+                            <hr />
+
+                            <h3>{t('advancedSettings:autoPromotion')}</h3>
+                            <Toggle
+                                checked={settings.autoPromotion}
+                                onChange={() => changeAutoPromotionSettings()}
                                 on={t('enabled')}
                                 off={t('disabled')}
                             />
-                            <p>{t('tray:trayExplanation')}</p>
+                            <p>{t('advancedSettings:autoPromotionExplanation')}</p>
+                            <hr />
+
+                            {Electron.getOS() === 'darwin' && (
+                                <React.Fragment>
+                                    <h3>{t('tray:trayApplication')}</h3>
+                                    <Toggle
+                                        checked={settings.isTrayEnabled}
+                                        onChange={() => setTray(!settings.isTrayEnabled)}
+                                        on={t('enabled')}
+                                        off={t('disabled')}
+                                    />
+                                    <p>{t('tray:trayExplanation')}</p>
+                                    <hr />
+                                </React.Fragment>
+                            )}
+
+                            <h3>{t('notifications:notifications')}</h3>
+                            <Toggle
+                                checked={settings.notifications.general}
+                                onChange={() =>
+                                    setNotifications({ type: 'general', enabled: !settings.notifications.general })}
+                                on={t('enabled')}
+                                off={t('disabled')}
+                            />
+                            <Checkbox
+                                disabled={!settings.notifications.general}
+                                checked={settings.notifications.confirmations}
+                                label={t('notifications:typeConfirmations')}
+                                className="small"
+                                onChange={(value) => setNotifications({ type: 'confirmations', enabled: value })}
+                            />
+                            <Checkbox
+                                disabled={!settings.notifications.general}
+                                checked={settings.notifications.messages}
+                                label={t('notifications:typeMessages')}
+                                className="small"
+                                onChange={(value) => setNotifications({ type: 'messages', enabled: value })}
+                            />
+                            <p>{t('notifications:notificationExplanation')}</p>
+                            <hr />
+
+                            <TextInput
+                                value={lockScreenTimeout.toString()}
+                                label={t('settings:lockScreenTimeout')}
+                                onChange={this.changeLockScreenTimeout}
+                            />
                             <hr />
                         </React.Fragment>
-                    )}
-
-                    <h3>{t('notifications:notifications')}</h3>
-                    <Toggle
-                        checked={settings.notifications.general}
-                        onChange={() => setNotifications({ type: 'general', enabled: !settings.notifications.general })}
-                        on={t('enabled')}
-                        off={t('disabled')}
-                    />
-                    <Checkbox
-                        disabled={!settings.notifications.general}
-                        checked={settings.notifications.confirmations}
-                        label={t('notifications:typeConfirmations')}
-                        className="small"
-                        onChange={(value) => setNotifications({ type: 'confirmations', enabled: value })}
-                    />
-                    <Checkbox
-                        disabled={!settings.notifications.general}
-                        checked={settings.notifications.messages}
-                        label={t('notifications:typeMessages')}
-                        className="small"
-                        onChange={(value) => setNotifications({ type: 'messages', enabled: value })}
-                    />
-                    <p>{t('notifications:notificationExplanation')}</p>
-                    <hr />
-
-                    <TextInput
-                        value={lockScreenTimeout.toString()}
-                        label={t('settings:lockScreenTimeout')}
-                        onChange={this.changeLockScreenTimeout}
-                    />
-                    <hr />
-
+                    ) : null}
                     <h3>{t('settings:reset')}</h3>
                     <Trans i18nKey="walletResetConfirmation:warning">
                         <p>
@@ -180,34 +212,56 @@ class Advanced extends PureComponent {
                             <React.Fragment> will be lost.</React.Fragment>
                         </p>
                     </Trans>
-                    <Button
-                        className="small"
-                        onClick={() => this.setState({ resetConfirm: !resetConfirm })}
-                        variant="negative"
-                    >
+                    <Button className="small" onClick={this.confirmReset} variant="negative">
                         {t('settings:reset')}
                     </Button>
-                    <ModalPassword
-                        isOpen={resetConfirm}
-                        category="negative"
-                        onSuccess={(password) => this.resetWallet(password)}
-                        onClose={() => this.setState({ resetConfirm: false })}
-                        content={{
-                            title: t('walletResetConfirmation:cannotUndo'),
-                            message: (
-                                <Trans i18nKey="walletResetConfirmation:warning">
-                                    <React.Fragment>
-                                        <React.Fragment>All of your wallet data including your </React.Fragment>
-                                        <strong>seeds, password,</strong>
-                                        <React.Fragment>and </React.Fragment>
-                                        <strong>other account information</strong>
-                                        <React.Fragment> will be lost.</React.Fragment>
-                                    </React.Fragment>
-                                </Trans>
-                            ),
-                            confirm: t('settings:reset'),
-                        }}
-                    />
+                    {wallet && wallet.ready ? (
+                        <ModalPassword
+                            isOpen={resetConfirm}
+                            category="negative"
+                            onSuccess={() => this.resetWallet()}
+                            onClose={() => this.setState({ resetConfirm: false })}
+                            content={{
+                                title: t('walletResetConfirmation:cannotUndo'),
+                                message: (
+                                    <Trans i18nKey="walletResetConfirmation:warning">
+                                        <React.Fragment>
+                                            <React.Fragment>All of your wallet data including your </React.Fragment>
+                                            <strong>seeds, password,</strong>
+                                            <React.Fragment>and </React.Fragment>
+                                            <strong>other account information</strong>
+                                            <React.Fragment> will be lost.</React.Fragment>
+                                        </React.Fragment>
+                                    </Trans>
+                                ),
+                                confirm: t('settings:reset'),
+                            }}
+                        />
+                    ) : (
+                        <Confirm
+                            isOpen={resetConfirm}
+                            category="negative"
+                            content={{
+                                title: t('walletResetConfirmation:cannotUndo'),
+                                message: (
+                                    <Trans i18nKey="walletResetConfirmation:warning">
+                                        <React.Fragment>
+                                            <React.Fragment>All of your wallet data including your </React.Fragment>
+                                            <strong>seeds, password,</strong>
+                                            <React.Fragment>and </React.Fragment>
+                                            <strong>other account information</strong>
+                                            <React.Fragment> will be lost.</React.Fragment>
+                                        </React.Fragment>
+                                    </Trans>
+                                ),
+                                cancel: t('cancel'),
+                                confirm: t('settings:reset'),
+                            }}
+                            onCancel={() => this.setState({ resetConfirm: false })}
+                            countdown={resetCountdown}
+                            onConfirm={() => this.resetWallet()}
+                        />
+                    )}
                 </Scrollbar>
             </div>
         );
@@ -216,6 +270,7 @@ class Advanced extends PureComponent {
 
 const mapStateToProps = (state) => ({
     settings: state.settings,
+    wallet: state.wallet,
     lockScreenTimeout: state.settings.lockScreenTimeout,
 });
 

--- a/src/desktop/src/ui/views/settings/Index.js
+++ b/src/desktop/src/ui/views/settings/Index.js
@@ -70,11 +70,11 @@ class Settings extends React.PureComponent {
                                     <NavLink to="/settings/mode">
                                         <Icon icon="mode" size={20} /> <strong>{t('settings:mode')}</strong>
                                     </NavLink>
-                                    <NavLink to="/settings/advanced">
-                                        <Icon icon="advanced" size={20} /> <strong>{t('settings:advanced')}</strong>
-                                    </NavLink>
                                 </div>
                             ) : null}
+                            <NavLink to="/settings/advanced">
+                                <Icon icon="advanced" size={20} /> <strong>{t('settings:advanced')}</strong>
+                            </NavLink>
                         </nav>
                     </section>
                     <section className={css.content}>


### PR DESCRIPTION
# Description

Add Wallet reset functionality for non authorised users.

Fixes #347, #469 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on macOS, Ubuntu

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
