### PR TITLE
Fix Android 8.0+ SeedVault crash

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -105,7 +105,7 @@
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
-    "rn-fetch-blob": "^0.10.13",
+    "rn-fetch-blob": "https://github.com/rajivshah3/rn-fetch-blob#10.13-226",
     "shared-modules": "../shared/",
     "snyk": "^1.96.0",
     "stream": "0.0.2",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -7136,10 +7136,9 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rn-fetch-blob@^0.10.13:
+"rn-fetch-blob@https://github.com/rajivshah3/rn-fetch-blob#10.13-226":
   version "0.10.13"
-  resolved "https://registry.yarnpkg.com/rn-fetch-blob/-/rn-fetch-blob-0.10.13.tgz#e0fd5eac1a3a872563b35061353d96c4e51ae1cc"
-  integrity sha512-CEz7coPlMMUpX5RB+k7Mqzq+eYYfZuFbpuNkFYhvEFnT5DnZyqdNF50Xk6BuZyqZwAjNvsQ1CUMz7XDvuN10DA==
+  resolved "https://github.com/rajivshah3/rn-fetch-blob#4d4119360fdc9889a31d599f263ea455ccdc3d02"
   dependencies:
     base-64 "0.1.0"
     glob "7.0.6"


### PR DESCRIPTION
# Description

- Applies fix by @mgeier63 (thanks again!) to the latest version of `rn-fetch-blob` - see original fix at https://github.com/joltup/rn-fetch-blob/pull/226
- Temporarily changes to a fork of https://github.com/joltup/rn-fetch-blob until https://github.com/joltup/rn-fetch-blob/pull/226 is merged

Fixes #517 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Has not been tested


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes