### PR TITLE
Fix SeedVault import permissions issue

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -79,7 +79,7 @@
     "react-native-keychain": "2.0.0-rc",
     "react-native-level-fs": "^3.0.0",
     "react-native-markdown-renderer": "^3.2.1",
-    "react-native-modal": "^7.0.0",
+    "react-native-modal": "^6.5.0",
     "react-native-modal-translucent": "^1.1.3",
     "react-native-navigation": "^2.0.2539",
     "react-native-optimized-flatlist": "^1.0.4",

--- a/src/mobile/src/ui/components/SeedVaultImportComponent.js
+++ b/src/mobile/src/ui/components/SeedVaultImportComponent.js
@@ -116,40 +116,41 @@ export class SeedVaultImportComponent extends Component {
      */
     importSeedVault() {
         const { t } = this.props;
-        DocumentPicker.show(
-            {
-                filetype: isAndroid
-                    ? ['application/octet-stream']
-                    : ['public.data', 'public.item', 'dyn.ah62d4rv4ge8003dcta'],
-            },
-            (error, res) => {
-                if (error) {
-                    return this.props.generateAlert(
-                        'error',
-                        t('global:somethingWentWrong'),
-                        t('global:somethingWentWrongTryAgain'),
-                    );
-                }
-                let path = res.uri;
-                if (path.startsWith('file://')) {
-                    path = path.slice(7);
-                }
-
-                (isAndroid ? this.grantPermissions() : Promise.resolve())
-                    .then(() => RNFetchBlob.fs.readFile(path, 'ascii'))
-                    .then((data) => {
-                        this.setState({ seedVault: data });
-                        this.props.openPasswordValidationModal();
-                    })
-                    .catch(() =>
-                        this.props.generateAlert(
+        (isAndroid ? this.grantPermissions() : Promise.resolve()).then(() => {
+            DocumentPicker.show(
+                {
+                    filetype: isAndroid
+                        ? ['application/octet-stream']
+                        : ['public.data', 'public.item', 'dyn.ah62d4rv4ge8003dcta'],
+                },
+                (error, res) => {
+                    if (error) {
+                        return this.props.generateAlert(
                             'error',
-                            t('seedVault:seedFileError'),
-                            t('seedVault:seedFileErrorExplanation'),
-                        ),
-                    );
-            },
-        );
+                            t('global:somethingWentWrong'),
+                            t('global:somethingWentWrongTryAgain'),
+                        );
+                    }
+                    let path = res.uri;
+                    if (path.startsWith('file://')) {
+                        path = path.slice(7);
+                    }
+                    RNFetchBlob.fs
+                        .readFile(path, 'ascii')
+                        .then((data) => {
+                            this.setState({ seedVault: data });
+                            this.props.openPasswordValidationModal();
+                        })
+                        .catch(() =>
+                            this.props.generateAlert(
+                                'error',
+                                t('seedVault:seedFileError'),
+                                t('seedVault:seedFileErrorExplanation'),
+                            ),
+                        );
+                },
+            );
+        });
     }
 
     render() {

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -6476,10 +6476,10 @@ react-native-modal-translucent@^1.1.3:
   resolved "https://registry.yarnpkg.com/react-native-modal-translucent/-/react-native-modal-translucent-1.1.3.tgz#9b84fd36061cea4ee1a055a0d7c97e1777a776d6"
   integrity sha512-e2DpapaJiKHr+7XUHDa16QeIfER+1MKD7ZtbVVrqDOyVGdVu5ut+6N7XMuH5iLm5O02c90o7q1LQ4x6MlDOl+w==
 
-react-native-modal@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-7.0.0.tgz#85bda8b52e0e9181e09bd2ec636ed7cec10d74c3"
-  integrity sha512-i9OFAzuV+pvLcEUB1QvJ/KJlvcApQ+UdNhnjUKac5bP4Mb5kFlj+fkj6Y55hakBISwrQk/0N0Fn1vj8Ob7KR6g==
+react-native-modal@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-6.5.0.tgz#46220b2289a41597d344c1db17454611b426a758"
+  integrity sha512-ewchdETAGd32xLGLK93NETEGkRcePtN7ZwjmLSQnNW1Zd0SRUYE8NqftjamPyfKvK0i2DZjX4YAghGZTqaRUbA==
   dependencies:
     prop-types "^15.6.1"
     react-native-animatable "^1.2.4"


### PR DESCRIPTION
# Description

- Fixes SeedVault import permissions order
- Reverts modal lib upgrade

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Android
- iOS


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
