### PR TITLE
Increase request timeout for all network calls to IRI

### DIFF
--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -36,7 +36,7 @@ export const DEFAULT_BALANCES_THRESHOLD = 100;
 
 export const BUNDLE_OUTPUTS_THRESHOLD = 50;
 
-export const NODE_REQUEST_TIMEOUT = 6000;
+export const NODE_REQUEST_TIMEOUT = 6000 * 2;
 
 export const DEFAULT_RETRIES = 4;
 


### PR DESCRIPTION
# Description

Increases default node request timeout.

Related issue https://github.com/iotaledger/trinity-wallet/issues/488

## Type of change

- Bug fix

# How Has This Been Tested?

- Manually tested by noticing request timeouts when a node is changed

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
