### PR TITLE
Desktop release v0.4.1

### DIFF
--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trinity-desktop",
   "productName": "Trinity",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "url": "https://trinity.iota.org",
   "homepage": "https://trinity.iota.org",

--- a/src/desktop/src/ui/global/About.js
+++ b/src/desktop/src/ui/global/About.js
@@ -59,6 +59,20 @@ class About extends React.PureComponent {
 
                     <article>
                         <Scrollbar>
+                            <h5>0.4.1</h5>
+                            <ul>
+                                <li>- Update: Highlight receive address checksum</li>
+                                <li>- Update: Ledger device accounts can send 0 value transactions</li>
+                                <li>- Update: Prefix SeedVault export file name with Account name</li>
+                                <li>- Update: Increase request timeout for all network calls to IRI</li>
+                                <li>- Fix: New account addition results in crash on node errors</li>
+                                <li>- Fix: Unresponsive login button if keychain is not available</li>
+                                <li>- Fix: Cannot add Ledger device account with a specific page</li>
+                                <li>- Fix: Cannot use multiple Ledger devices with the same index</li>
+                                <li>- Fix: IOTA App request does not respond when opening the app</li>
+                                <li>- Fix: Incorrect back navigation when setting Account name</li>
+                                <li>- Fix: Provide correct key index for generating addresses</li>
+                            </ul>
                             <h5>0.4.0</h5>
                             <ul>
                                 <li>- New: Ledger hardware wallet support</li>

--- a/src/desktop/src/ui/global/About.js
+++ b/src/desktop/src/ui/global/About.js
@@ -61,6 +61,7 @@ class About extends React.PureComponent {
                         <Scrollbar>
                             <h5>0.4.1</h5>
                             <ul>
+                                <li>- Update: Complete address tooltip on Send page address input</li> 
                                 <li>- Update: Highlight receive address checksum</li>
                                 <li>- Update: Ledger device accounts can send 0 value transactions</li>
                                 <li>- Update: Prefix SeedVault export file name with Account name</li>


### PR DESCRIPTION
# Description

- Update: Highlight receive address checksum #575
- Update: Complete address tooltip on Send page address input #545
- Update: Ledger device accounts can send 0 value transactions #570
- Update: Prefix SeedVault export file name with Account name #535
- Update: Increase request timeout for all network calls to IRI #583
- Fix: New account addition results in crash on node errors #578
- Fix: Unresponsive login button if keychain is not available #578
- Fix: Cannot add Ledger device account with a specific page #570
- Fix: Cannot use multiple Ledger devices with the same index #570
- Fix: IOTA App request does not respond when opening the app #570
- Fix: Incorrect back navigation when setting Account name #552
- Fix: Provide correct key index for generating addresses #571

Fixes #470, #474, #498, #554, #573, #574  

## Type of change

- New release

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code