### PR TITLE
Fix condition on spend status in libs/iota/removeUnusedAddresses

### DIFF
--- a/src/shared/__tests__/libs/iota/addresses.spec.js
+++ b/src/shared/__tests__/libs/iota/addresses.spec.js
@@ -1014,25 +1014,70 @@ describe('libs: iota/addresses', () => {
             sandbox.restore();
         });
 
-        describe('when the last address has associated meta data', () => {
-            it('should return addresses with latest unused address', () => {
-                // Return transaction hashes on this stub so that there is only iteration
-                const findTransactions = sinon.stub(iota.api, 'findTransactions').yields(null, ['9'.repeat(81)]);
-                const wereAddressesSpentFrom = sinon.stub(iota.api, 'wereAddressesSpentFrom').yields(null, [false]);
-                const getBalances = sinon.stub(iota.api, 'getBalances').yields(null, { balances: ['0'] });
+        describe('when last address has associated meta data', () => {
+            describe('when last address has associated balance', () => {
+                it('should return addresses with latest unused address', () => {
+                    const findTransactions = sinon.stub(iota.api, 'findTransactions').yields(null, []);
+                    const wereAddressesSpentFrom = sinon.stub(iota.api, 'wereAddressesSpentFrom').yields(null, [false]);
+                    const getBalances = sinon.stub(iota.api, 'getBalances').yields(null, { balances: ['10'] });
 
-                const latestUnusedAddress = 'H'.repeat(81);
-                const lastAddressIndex = 6;
+                    const latestUnusedAddress = 'H'.repeat(81);
+                    const lastAddressIndex = 6;
 
-                return addressesUtils
-                    .removeUnusedAddresses()(lastAddressIndex, latestUnusedAddress, addresses)
-                    .then((finalAddresses) => {
-                        expect(finalAddresses).to.eql([...addresses, latestUnusedAddress]);
+                    return addressesUtils
+                        .removeUnusedAddresses()(lastAddressIndex, latestUnusedAddress, addresses)
+                        .then((finalAddresses) => {
+                            expect(finalAddresses).to.eql([...addresses, latestUnusedAddress]);
 
-                        findTransactions.restore();
-                        wereAddressesSpentFrom.restore();
-                        getBalances.restore();
-                    });
+                            findTransactions.restore();
+                            wereAddressesSpentFrom.restore();
+                            getBalances.restore();
+                        });
+                });
+            });
+
+            describe('when last address has associated transactions', () => {
+                it('should return addresses with latest unused address', () => {
+                    // Return transaction hashes on this stub so that there is only iteration
+                    const findTransactions = sinon.stub(iota.api, 'findTransactions').yields(null, ['9'.repeat(81)]);
+                    const wereAddressesSpentFrom = sinon.stub(iota.api, 'wereAddressesSpentFrom').yields(null, [false]);
+                    const getBalances = sinon.stub(iota.api, 'getBalances').yields(null, { balances: ['0'] });
+
+                    const latestUnusedAddress = 'H'.repeat(81);
+                    const lastAddressIndex = 6;
+
+                    return addressesUtils
+                        .removeUnusedAddresses()(lastAddressIndex, latestUnusedAddress, addresses)
+                        .then((finalAddresses) => {
+                            expect(finalAddresses).to.eql([...addresses, latestUnusedAddress]);
+
+                            findTransactions.restore();
+                            wereAddressesSpentFrom.restore();
+                            getBalances.restore();
+                        });
+                });
+            });
+
+            describe('when last address is spent', () => {
+                it('should return addresses with latest unused address', () => {
+                    // Return transaction hashes on this stub so that there is only iteration
+                    const findTransactions = sinon.stub(iota.api, 'findTransactions').yields(null, []);
+                    const wereAddressesSpentFrom = sinon.stub(iota.api, 'wereAddressesSpentFrom').yields(null, [true]);
+                    const getBalances = sinon.stub(iota.api, 'getBalances').yields(null, { balances: ['0'] });
+
+                    const latestUnusedAddress = 'H'.repeat(81);
+                    const lastAddressIndex = 6;
+
+                    return addressesUtils
+                        .removeUnusedAddresses()(lastAddressIndex, latestUnusedAddress, addresses)
+                        .then((finalAddresses) => {
+                            expect(finalAddresses).to.eql([...addresses, latestUnusedAddress]);
+
+                            findTransactions.restore();
+                            wereAddressesSpentFrom.restore();
+                            getBalances.restore();
+                        });
+                });
             });
         });
 
@@ -1079,9 +1124,9 @@ describe('libs: iota/addresses', () => {
                 getBalances.onCall(2).yields(null, { balances: ['0'] });
 
                 // Address DDD...DDD - index 3
-                // Return transaction hashes for this address
-                findTransactions.onCall(3).yields(null, ['9'.repeat(81)]);
-                wereAddressesSpentFrom.onCall(3).yields(null, [false]);
+                // Return spend status as true for this address.
+                findTransactions.onCall(3).yields(null, []);
+                wereAddressesSpentFrom.onCall(3).yields(null, [true]);
                 getBalances.onCall(3).yields(null, { balances: ['0'] });
 
                 const latestUnusedAddress = 'H'.repeat(81);

--- a/src/shared/libs/iota/addresses.js
+++ b/src/shared/libs/iota/addresses.js
@@ -278,7 +278,7 @@ export const removeUnusedAddresses = (provider) => (index, latestUnusedAddress, 
         if (
             size(hashes) === 0 &&
             some(balances, (balance) => balance === 0) &&
-            some(wereSpent, (status) => !status.remote || !status.local)
+            some(wereSpent, (status) => status.remote === false && status.local === false)
         ) {
             return removeUnusedAddresses(provider)(index - 1, finalAddresses[index], finalAddresses.slice(0, index));
         }


### PR DESCRIPTION
# Description

`removeUnusedAddresses` is used in initial account sync and manual sync. Consider a case where an address has no transactions, no balance and spent status true. The incorrect condition will remove the address and wouldn't display it to the user until `syncAccount` is called (e.g., login, before transactions). 

Tests for `removeUnusedAddresses` were all passing because there was no test coverage added for such a case (It was only for positive balances and transaction hashes).

This PR fixes the condition and also adds coverage for the above mentioned case.

Note: This can only be reproduced on a fresh install of wallet because manual sync does not remove seen addresses from wallet. 

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested by using a seed with an address with no transaction hashes, no balance and spent status true
- Added unit test coverage for the above mentioned scenario. 

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
