### PR TITLE
Add auto migration from AsyncStorage to Realm storage

### DIFF
--- a/src/mobile/src/libs/progressSteps.js
+++ b/src/mobile/src/libs/progressSteps.js
@@ -17,4 +17,11 @@ export default {
         i18next.t('progressSteps:proofOfWork'),
         i18next.t('progressSteps:broadcasting'),
     ],
+    migration: [
+        i18next.t('progressSteps:preparingData'),
+        i18next.t('progressSteps:migratingSettings'),
+        i18next.t('progressSteps:migratingAccounts'),
+        i18next.t('progressSteps:cleaningUpOldData'),
+        i18next.t('progressSteps:migrationComplete'),
+    ],
 };

--- a/src/mobile/src/libs/store.js
+++ b/src/mobile/src/libs/store.js
@@ -1,24 +1,95 @@
-import get from 'lodash/get';
+import head from 'lodash/head';
+import last from 'lodash/last';
+import filter from 'lodash/filter';
+import includes from 'lodash/includes';
+import split from 'lodash/split';
+import transform from 'lodash/transform';
+import { AsyncStorage } from 'react-native';
 import { getVersion, getBuildNumber } from 'react-native-device-info';
 import { doesSaltExistInKeychain } from 'libs/keychain';
 import { reinitialise as reinitialiseStorage } from 'shared-modules/storage';
 import { setAppVersions, resetWallet } from 'shared-modules/actions/settings';
+import { parse } from 'shared-modules/libs/utils';
 
 /**
- * Checks if app version/build number has changed
- * @method shouldMigrate
- *
- * @param {object} restoredState
- * @returns {boolean}
+ * AsyncStorage adapter for manipulating state persisted by redux-persist (https://github.com/rt2zz/redux-persist)
  */
-const shouldMigrate = (restoredState) => {
-    const restoredVersion = get(restoredState, 'settings.versions.version');
-    const restoredBuildNumber = get(restoredState, 'settings.versions.buildNumber');
-
-    const currentVersion = getVersion();
-    const currentBuildNumber = getBuildNumber();
-
-    return restoredVersion !== currentVersion || restoredBuildNumber !== currentBuildNumber;
+export const reduxPersistStorageAdapter = {
+    /**
+     * Filters keys that do not have "reduxPersist:" prefix.
+     *
+     * @method _filterIrrelevantKeys
+     * @param {array} keys
+     *
+     * @returns {array}
+     */
+    _filterIrrelevantKeys(keys) {
+        return filter(keys, (key) => includes(key, 'reduxPersist:'));
+    },
+    /**
+     * Gets all keys stored in AsyncStorage
+     *
+     * @method getKeys
+     *
+     * @returns {Promise<array>}
+     */
+    getKeys() {
+        return new Promise((resolve, reject) => {
+            AsyncStorage.getAllKeys((error, keys) => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve(keys);
+                }
+            });
+        });
+    },
+    /**
+     * Gets data persisted by redux-persist (https://github.com/rt2zz/redux-persist) in AsyncStorage
+     *
+     * @method get
+     *
+     * @returns {Promise<object>}
+     */
+    get() {
+        return this.getKeys().then((keys) => {
+            return new Promise((resolve, reject) => {
+                AsyncStorage.multiGet(this._filterIrrelevantKeys(keys), (error, data) => {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        // multiGet(['k1', 'k2'], cb) -> cb([['k1', 'val1'], ['k2', 'val2']])
+                        // https://facebook.github.io/react-native/docs/asyncstorage#multiget
+                        resolve(
+                            transform(
+                                data,
+                                (acc, value) => {
+                                    acc[last(split(head(value), ':'))] = parse(last(value));
+                                },
+                                {},
+                            ),
+                        );
+                    }
+                });
+            });
+        });
+    },
+    /**
+     * Clears all data persisted by redux-persist (https://github.com/rt2zz/redux-persist)
+     *
+     * @method clear
+     *
+     * @returns {Promise}
+     */
+    clear() {
+        return this.getKeys().then((keys) => {
+            AsyncStorage.multiRemove(this._filterIrrelevantKeys(keys), (error) => {
+                if (error) {
+                    throw new Error(error);
+                }
+            });
+        });
+    },
 };
 
 /**
@@ -42,33 +113,7 @@ export const resetIfKeychainIsEmpty = (store) => {
                         buildNumber: Number(getBuildNumber()),
                     }),
                 );
-
-                return store;
             });
         }
-
-        return store;
     });
-};
-
-/**
- * Migrates application state
- * @method migrate
- *
- * @param {object} store - redux store object
- * @returns {Promise<any>}
- */
-export const migrate = (store) => {
-    /* eslint-disable no-unused-vars */
-    const hasAnUpdate = shouldMigrate(store.getState());
-    /* eslint-enable no-unused-vars */
-
-    store.dispatch(
-        setAppVersions({
-            version: getVersion(),
-            buildNumber: Number(getBuildNumber()),
-        }),
-    );
-
-    return Promise.resolve(store);
 };

--- a/src/mobile/src/ui/components/Migration.js
+++ b/src/mobile/src/ui/components/Migration.js
@@ -1,0 +1,177 @@
+import size from 'lodash/size';
+import React, { Component } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import PropTypes from 'prop-types';
+import { Navigation } from 'react-native-navigation';
+import { withNamespaces } from 'react-i18next';
+import { startTrackingProgress } from 'shared-modules/actions/progress';
+import { connect } from 'react-redux';
+import { Styling } from 'ui/theme/general';
+import { Icon } from 'ui/theme/icons';
+import { migrate } from 'shared-modules/actions/migrations';
+import { reduxPersistStorageAdapter } from 'libs/store';
+import ProgressSteps from 'libs/progressSteps';
+import { getThemeFromState } from 'shared-modules/selectors/global';
+import WithBackPressCloseApp from 'ui/components/BackPressCloseApp';
+import Header from 'ui/components/Header';
+import InfoBox from 'ui/components/InfoBox';
+import ProgressBar from 'ui/components/ProgressBar';
+import { width, height } from 'libs/dimensions';
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'space-between',
+    },
+    topContainer: {
+        flex: 1,
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+        paddingTop: height / 16,
+    },
+    midContainer: {
+        flex: 3,
+        alignItems: 'center',
+    },
+    infoText: {
+        fontFamily: 'SourceSansPro-Light',
+        fontSize: Styling.fontSize3,
+        textAlign: 'left',
+        backgroundColor: 'transparent',
+    },
+});
+
+/**
+ * Migration component
+ */
+class Migration extends Component {
+    static propTypes = {
+        /** @ignore */
+        t: PropTypes.func.isRequired,
+        /** @ignore */
+        theme: PropTypes.object.isRequired,
+        /** @ignore */
+        activeStepIndex: PropTypes.number.isRequired,
+        /** @ignore */
+        activeSteps: PropTypes.array.isRequired,
+        /** @ignore */
+        migrate: PropTypes.func.isRequired,
+        /** @ignore */
+        startTrackingProgress: PropTypes.func.isRequired,
+        /** @ignore */
+        completedMigration: PropTypes.bool.isRequired,
+    };
+
+    componentDidMount() {
+        this.props.startTrackingProgress(ProgressSteps.migration);
+
+        this.props.migrate(reduxPersistStorageAdapter);
+    }
+
+    componentWillReceiveProps(newProps) {
+        if (!this.props.completedMigration && newProps.completedMigration) {
+            this.navigateToLoadingScreen();
+        }
+    }
+
+    /**
+     * Navigates to loading screen
+     *
+     * @method navigateToLoadingScreen
+     */
+    navigateToLoadingScreen() {
+        const { theme: { body } } = this.props;
+        Navigation.setStackRoot('appStack', {
+            component: {
+                name: 'loading',
+                options: {
+                    animations: {
+                        setStackRoot: {
+                            enable: false,
+                        },
+                    },
+                    layout: {
+                        backgroundColor: body.bg,
+                        orientation: ['portrait'],
+                    },
+                    topBar: {
+                        visible: false,
+                        drawBehind: true,
+                        elevation: 0,
+                    },
+                    statusBar: {
+                        drawBehind: true,
+                        backgroundColor: body.bg,
+                    },
+                },
+            },
+        });
+    }
+
+    /**
+     * Renders progress bar textual information
+     *
+     * @method renderProgressBarChildren
+     */
+    renderProgressBarChildren() {
+        const { activeStepIndex, activeSteps } = this.props;
+
+        return activeSteps[activeStepIndex] ? activeSteps[activeStepIndex] : null;
+    }
+
+    render() {
+        const { t, theme: { body, primary }, activeSteps, activeStepIndex } = this.props;
+        const textColor = { color: body.color };
+        const sizeOfActiveSteps = size(activeSteps) - 1;
+
+        return (
+            <View style={[styles.container, { backgroundColor: body.bg }]}>
+                <View style={styles.topContainer}>
+                    <Icon name="iota" size={width / 8} color={body.color} />
+                    <View style={{ flex: 0.3 }} />
+                    <Header textColor={body.color}>{t('dataMigration')}</Header>
+                </View>
+                <View style={styles.midContainer}>
+                    <View style={{ flex: 0.3 }} />
+                    <InfoBox
+                        body={body}
+                        text={
+                            <View>
+                                <Text style={[styles.infoText, textColor]}>{t('dataMigrationExplanation')}</Text>
+                            </View>
+                        }
+                    />
+                    <View style={{ flex: 0.4 }} />
+                    <ProgressBar
+                        style={{
+                            textWrapper: { flex: 0.3 },
+                        }}
+                        indeterminate={activeStepIndex === -1}
+                        progress={activeStepIndex / sizeOfActiveSteps}
+                        color={primary.color}
+                        textColor={body.color}
+                    >
+                        {this.renderProgressBarChildren()}
+                    </ProgressBar>
+                </View>
+            </View>
+        );
+    }
+}
+
+const mapStateToProps = (state) => ({
+    theme: getThemeFromState(state),
+    activeStepIndex: state.progress.activeStepIndex,
+    activeSteps: state.progress.activeSteps,
+    completedMigration: state.settings.completedMigration,
+});
+
+const mapDispatchToProps = {
+    migrate,
+    startTrackingProgress,
+};
+
+export default WithBackPressCloseApp()(
+    withNamespaces(['migration'])(connect(mapStateToProps, mapDispatchToProps)(Migration)),
+);

--- a/src/mobile/src/ui/routes/navigation.js
+++ b/src/mobile/src/ui/routes/navigation.js
@@ -28,6 +28,7 @@ import TermsAndConditions from 'ui/views/onboarding/TermsAndConditions';
 import PrivacyPolicy from 'ui/views/onboarding/PrivacyPolicy';
 import ForceChangePassword from 'ui/views/wallet/ForceChangePassword';
 import SeedVaultBackupComponent from 'ui/views/onboarding/SeedVaultBackup';
+import MigrationComponent from 'ui/components/Migration';
 import { isIPhoneX } from 'libs/device';
 
 function applyHOCs(screen) {
@@ -39,6 +40,7 @@ function applyHOCs(screen) {
 }
 
 export default function registerScreens(store, Provider) {
+    Navigation.registerComponentWithRedux('migration', () => applyHOCs(MigrationComponent), Provider, store);
     Navigation.registerComponentWithRedux('home', () => applyHOCs(Home), Provider, store);
     Navigation.registerComponentWithRedux('loading', () => applyHOCs(Loading), Provider, store);
     Navigation.registerComponentWithRedux('newSeedSetup', () => applyHOCs(NewSeedSetup), Provider, store);

--- a/src/mobile/src/ui/views/wallet/Login.js
+++ b/src/mobile/src/ui/views/wallet/Login.js
@@ -59,6 +59,8 @@ class Login extends Component {
         setLoginRoute: PropTypes.func.isRequired,
         /** @ignore */
         isFingerprintEnabled: PropTypes.bool.isRequired,
+        /** @ignore */
+        completedMigration: PropTypes.bool.isRequired,
     };
 
     constructor() {
@@ -92,7 +94,7 @@ class Login extends Component {
      * @returns {Promise<void>}
      */
     async onLoginPress() {
-        const { t, is2FAEnabled, hasConnection, password } = this.props;
+        const { t, is2FAEnabled, hasConnection, password, completedMigration } = this.props;
         if (!hasConnection) {
             return;
         }
@@ -107,7 +109,7 @@ class Login extends Component {
                 this.props.setPassword(pwdHash);
                 this.props.setLoginPasswordField('');
                 if (!is2FAEnabled) {
-                    this.navigateToLoading();
+                    this.navigateTo(completedMigration ? 'migration' : 'loading');
                 } else {
                     this.props.setLoginRoute('complete2FA');
                 }
@@ -126,7 +128,7 @@ class Login extends Component {
      * @method onComplete2FA
      */
     async onComplete2FA(token) {
-        const { t, pwdHash, hasConnection } = this.props;
+        const { t, pwdHash, hasConnection, completedMigration } = this.props;
         if (!hasConnection) {
             return;
         }
@@ -141,7 +143,7 @@ class Login extends Component {
             }
             const verified = authenticator.verifyToken(key, token);
             if (verified) {
-                this.navigateToLoading();
+                this.navigateTo(completedMigration ? 'loading' : 'migration');
                 this.props.setLoginRoute('login');
             } else {
                 this.props.generateAlert('error', t('twoFA:wrongCode'), t('twoFA:wrongCodeExplanation'));
@@ -167,14 +169,16 @@ class Login extends Component {
     }
 
     /**
-     * Navigates to loading screen
-     * @method navigateToLoading
+     * Navigates to provided screen
+     * @method navigateTo
+     *
+     * @param {string} name
      */
-    navigateToLoading() {
+    navigateTo(name) {
         const { theme: { body } } = this.props;
         Navigation.setStackRoot('appStack', {
             component: {
-                name: 'loading',
+                name,
                 options: {
                     animations: {
                         setStackRoot: {
@@ -232,12 +236,12 @@ const mapStateToProps = (state) => ({
     nodes: state.settings.nodes,
     theme: getThemeFromState(state),
     is2FAEnabled: state.settings.is2FAEnabled,
-    accountInfo: state.accounts.accountInfo,
     password: state.ui.loginPasswordFieldText,
     pwdHash: state.wallet.password,
     loginRoute: state.ui.loginRoute,
     hasConnection: state.wallet.hasConnection,
     isFingerprintEnabled: state.settings.isFingerprintEnabled,
+    completedMigration: state.settings.completedMigration,
 });
 
 const mapDispatchToProps = {

--- a/src/shared/actions/migrations.js
+++ b/src/shared/actions/migrations.js
@@ -1,0 +1,126 @@
+import assign from 'lodash/assign';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import { setNextStepAsActive, reset as resetProgress } from './progress';
+import { migrateAccounts, migrateSettings } from '../libs/migrations';
+import { mapStorageToState as mapStorageToStateAction } from './wallet';
+import { generateAlert } from './alerts';
+import { mapStorageToState } from '../libs/storageToStateMappers';
+import { Wallet } from '../storage';
+import Errors from '../libs/errors';
+import i18next from '../libs/i18next.js';
+
+/**
+ * Migration action types
+ */
+export const ActionTypes = {
+    SET_MIGRATION_STATUS: 'IOTA/SETTINGS/SET_MIGRATION_STATUS',
+};
+
+/**
+ * Migrates persisted data from old storage to new storage (Realm)
+ *
+ * @method migrate
+ *
+ * @param {object} oldStorageAdapter - { get: {Promise}, clear: {Promise} }
+ * @returns {function}
+ */
+export const migrate = (oldStorageAdapter) => (dispatch) => {
+    const onComplete = () => {
+        // Set latest (migrated) data to redux store
+        dispatch(mapStorageToStateAction(mapStorageToState()));
+
+        // Mark migration as complete
+        dispatch(setMigrationStatus(true));
+
+        // Reset progress bar
+        dispatch(resetProgress());
+    };
+
+    // Progressbar => (Preparing data)
+    dispatch(setNextStepAsActive());
+
+    return oldStorageAdapter
+        .get()
+        .then((storedData) => {
+            if (isEmpty(storedData)) {
+                throw new Error(Errors.NO_STORED_DATA_FOUND);
+            }
+
+            // Progressbar => Migrating settings
+            dispatch(setNextStepAsActive());
+
+            const settings = get(storedData, 'settings');
+            // If user has wallet settings, migrate them.
+            if (settings) {
+                return migrateSettings(
+                    assign({}, settings, {
+                        // onboardingComplete is part of accounts reducer (in old storage) and has now moved to Wallet schema model
+                        // Assign it to the settings object so that it can be migrated with the rest of the settings.
+                        onboardingComplete: get(storedData, 'accounts.onboardingComplete') || false,
+                        // notificationLog is part of alerts reducer (in old storage) and has now moved to Wallet schema model
+                        // Has also been renamed to errorLog. Assign it to the settings object
+                        errorLog: get(storedData, 'alerts.notificationLog') || [],
+                    }),
+                ).then(() => storedData);
+            }
+
+            return Promise.resolve(storedData);
+        })
+        .then((storedData) => {
+            // Progressbar => Migrating accounts
+            dispatch(setNextStepAsActive());
+
+            const accounts = get(storedData, 'accounts');
+            if (accounts) {
+                return migrateAccounts(accounts).then(() => storedData);
+            }
+
+            return Promise.resolve(storedData);
+        })
+        .then(() => {
+            // Progressbar => Cleaning old data
+            dispatch(setNextStepAsActive());
+
+            return oldStorageAdapter.clear();
+        })
+        .then(() => {
+            // Progressbar => Migration Complete
+            dispatch(setNextStepAsActive());
+
+            setTimeout(onComplete, 2000);
+        })
+        .catch((error) => {
+            if (error.message === Errors.NO_STORED_DATA_FOUND) {
+                // If there is not data to migrate, just mark migration as complete
+                onComplete();
+            } else {
+                dispatch(
+                    generateAlert(
+                        'error',
+                        i18next.t('global:somethingWentWrong'),
+                        i18next.t('migration:problemMigratingYourData'),
+                        5500,
+                        error,
+                    ),
+                );
+            }
+        });
+};
+
+/**
+ * Dispatch to set migration (AsyncStorage to Realm) complete
+ *
+ * @method setMigrationStatus
+ * @param {bool} payload
+ *  *
+ * @returns {{type: {string}, payload: {bool} }}
+ */
+export const setMigrationStatus = (payload) => {
+    Wallet.setMigrationStatus(payload);
+
+    return {
+        type: ActionTypes.SET_MIGRATION_STATUS,
+        payload,
+    };
+};

--- a/src/shared/actions/wallet.js
+++ b/src/shared/actions/wallet.js
@@ -313,6 +313,19 @@ export const setDeepLinkInactive = () => {
 };
 
 /**
+ * Dispatch to map storage (persisted) data to redux state
+ *
+ * @method mapStorageToState
+ * @param {object} payload
+
+ * @returns {{type: {string}, payload: {object} }}
+ */
+export const mapStorageToState = (payload) => ({
+    type: ActionTypes.MAP_STORAGE_TO_STATE,
+    payload,
+});
+
+/**
  * Generate new receive address for wallet
  *
  * @method generateNewAddress

--- a/src/shared/libs/errors.js
+++ b/src/shared/libs/errors.js
@@ -41,4 +41,5 @@ export default {
     CANNOT_FIND_INPUTS_WITH_PROVIDED_LIMIT: 'Cannot find inputs with provided limit.',
     INSUFFICIENT_BALANCE: 'Insufficient balance.',
     INVALID_MAX_INPUTS_PROVIDED: 'Invalid max inputs provided.',
+    NO_STORED_DATA_FOUND: 'No stored data found.',
 };

--- a/src/shared/libs/migrations.js
+++ b/src/shared/libs/migrations.js
@@ -1,0 +1,150 @@
+import assign from 'lodash/assign';
+import get from 'lodash/get';
+import filter from 'lodash/filter';
+import find from 'lodash/find';
+import flatMap from 'lodash/flatMap';
+import includes from 'lodash/includes';
+import keys from 'lodash/keys';
+import map from 'lodash/map';
+import pick from 'lodash/pick';
+import reduce from 'lodash/reduce';
+import size from 'lodash/size';
+import { syncAccount } from '../libs/iota/accounts';
+import { fetchRemoteNodes } from '../libs/iota/utils';
+import { Account, Node, Wallet } from '../storage';
+
+/**
+ * Migrates nodes (custom & remote) to Realm storage
+ *
+ * @method migrateNodes
+ * @param {array} nodes
+ *
+ * @returns {Promise}
+ */
+export const migrateNodes = (nodes) => {
+    return fetchRemoteNodes().then((remoteNodes) => {
+        if (size(remoteNodes)) {
+            Node.addNodes(
+                map(nodes, (node) => {
+                    const remoteNode = find(remoteNodes, { node: node.url });
+
+                    if (remoteNode) {
+                        return assign({}, node, { pow: remoteNode.pow });
+                    }
+
+                    return assign({}, node, { pow: false });
+                }),
+            );
+        }
+
+        // If there is an error fetching remote nodes
+        // Then assign each node pow disbaled
+        Node.addNodes(map(nodes, (node) => assign({}, node, { pow: false })));
+    });
+};
+
+/**
+ * Migrates wallet settings to Realm storage
+ *
+ * @method migrateSettings
+ * @param {object} settings
+ *
+ * @returns {Promise}
+ */
+export const migrateSettings = (settings) => {
+    const { onboardingComplete, errorLog, customNodes, nodes } = settings;
+
+    // Migrate nodes including custom nodes added by user.
+    return migrateNodes([
+        ...map(
+            // Filter custom nodes
+            filter(nodes, (node) => !includes(customNodes, node)),
+            (node) => ({ url: node, custom: false }),
+        ),
+        ...map(customNodes, (node) => ({ url: node, custom: true })),
+    ]).then(() => {
+        // Merge old settings and update storage.
+        Wallet.updateLatest({
+            onboardingComplete,
+            errorLog,
+            settings: pick(settings, [
+                'locale',
+                'mode',
+                'language',
+                'currency',
+                'availableCurrencies',
+                'conversionRate',
+                'themeName',
+                'hasRandomizedNode',
+                'remotePoW',
+                'autoPromotion',
+                'lockScreenTimeout',
+                'autoNodeSwitching',
+                'is2FAEnabled',
+                'isFingerprintEnabled',
+                'acceptedTerms',
+                'acceptedPrivacy',
+                'hideEmptyTransactions',
+                'isTrayEnabled',
+                'completedByteTritSweep',
+                'notifications',
+                'completedForcedPasswordUpdate',
+                'node',
+            ]),
+        });
+    });
+};
+
+/**
+ * Migrates account and related info to Realm storage
+ *
+ * @method migrateAccounts
+ * @param {object} accounts
+ *
+ * @returns {Promise}
+ */
+export const migrateAccounts = (accounts) => {
+    const { accountInfo, failedBundleHashes, setupInfo, tasks } = accounts;
+    const accountNames = keys(accountInfo);
+
+    return reduce(
+        accountNames,
+        (promise, accountName) => {
+            return promise.then(() => {
+                const { addresses } = accountInfo[accountName];
+
+                // In old storage, addresses is an object but has been changed to array in the updated Account schema.
+                const addressData = map(addresses, (data, address) => assign({}, data, { address }));
+
+                return syncAccount()({
+                    addressData,
+                    // Transactions structure has been changed in the updated Account schema model. See schema/index.js.
+                    // Previously, transactions were normalised before they were added to storage
+                    // The transaction structure has been updated now and it follows (https://domschiener.gitbooks.io/iota-guide/content/chapter1/transactions-and-bundles.html)
+                    // It's impossible to reverse engineer updated transactions structure from normalised transactions, so we sync transactions from scratch.
+                    // NOTE: A user will lose transactions that were pruned in the most recent snapshot. However, failed transactions will be kept.
+                    transactions: [],
+                }).then((accountData) => {
+                    Account.createIfNotExists(
+                        accountName,
+                        assign({}, accountData, {
+                            usedExistingSeed: get(setupInfo, `${accountName}.usedExistingSeed`) || false,
+                            displayedSnapshotTransitionGuide:
+                                get(tasks, `${accountName}.hasDisplayedTransitionGuide`) || false,
+                            // Migrate failed transactions (Transaction that were never broadcasted from this wallet)
+                            transactions: [
+                                ...accountData.transactions,
+                                ...flatMap(get(failedBundleHashes, `${accountName}`), (transactions) =>
+                                    map(transactions, (transaction) =>
+                                        assign({}, transaction, { persistence: false, broadcasted: false }),
+                                    ),
+                                ),
+                            ],
+                        }),
+                    );
+                });
+            });
+        },
+        Promise.resolve(),
+    );
+};

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -670,7 +670,12 @@
         "preparingTransfers": "Preparing transfers",
         "gettingTransactionsToApprove": "Getting transactions to approve",
         "proofOfWork": "Completing proof of work",
-        "broadcasting": "Broadcasting"
+        "broadcasting": "Broadcasting",
+        "preparingData": "Preparing data",
+        "migratingSettings": "Migrating settings",
+        "migratingAccounts": "Migrating accounts",
+        "cleaningUpOldData": "Cleaning up old data",
+        "migrationComplete": "Migration complete"
     },
     "snapshotTransition": {
         "cannotCompleteTransition": "Cannot complete snapshot transition",
@@ -740,5 +745,10 @@
         "proceed": "Proceed to Recovery",
         "sweepConfirmation": "You are about to sweep {{amount}} to the address {{address}}. Account: {{accountName}}, address index: {{index}}",
         "sweepConfirmationTitle": "Sweep confirmation"
+     },
+     "migration": {
+         "dataMigration": "Data migration",
+         "dataMigrationExplanation": "Due to performance and storage limitations, Trinity now uses a new database for storing your wallet settings and accounts data. Please wait while Trinity automatically migrates your wallet settings and account information.",
+         "problemMigratingYourData": "There was a probelm migrating your data. Please try again"
      }
 }

--- a/src/shared/reducers/settings.js
+++ b/src/shared/reducers/settings.js
@@ -2,6 +2,7 @@ import merge from 'lodash/merge';
 import union from 'lodash/union';
 import sortBy from 'lodash/sortBy';
 import { ActionTypes } from '../actions/settings';
+import { ActionTypes as MigrationsActionTypes } from '../actions/migrations';
 import { defaultNode as node, nodes } from '../config';
 import { availableCurrencies } from '../libs/currency';
 
@@ -108,6 +109,10 @@ const initialState = {
         confirmations: true,
         messages: true,
     },
+    /**
+     * Determines the status of AsyncStorage to realm migration
+     */
+    completedMigration: true,
 };
 
 const settingsReducer = (state = initialState, action) => {
@@ -253,6 +258,11 @@ const settingsReducer = (state = initialState, action) => {
                     ...state.notifications,
                     [action.payload.type]: action.payload.enabled,
                 },
+            };
+        case MigrationsActionTypes.SET_MIGRATION_STATUS:
+            return {
+                ...state,
+                completedMigration: action.payload,
             };
     }
 

--- a/src/shared/schema/index.js
+++ b/src/shared/schema/index.js
@@ -126,19 +126,9 @@ export const WalletSettingsSchema = {
     name: 'WalletSettings',
     properties: {
         /**
-         * Current wallet's version.
+         * Wallet versions (version & build number)
          */
-        version: {
-            type: 'string',
-            default: '',
-        },
-        /**
-         * Current wallet's build number (mobile).
-         */
-        buildNumber: {
-            type: 'int',
-            optional: true,
-        },
+        versions: 'WalletVersions',
         /**
          * Selected locale for wallet.
          */
@@ -281,6 +271,37 @@ export const WalletSettingsSchema = {
         node: {
             type: 'string',
             default: defaultNode,
+        },
+        /**
+         * Determines the status of AsyncStorage to realm migration
+         */
+        completedMigration: {
+            type: 'bool',
+            default: false,
+        },
+    },
+};
+
+/**
+ * Schema for Wallet versions.
+ */
+export const WalletVersionsSchema = {
+    name: 'WalletVersions',
+    primaryKey: 'version',
+    properties: {
+        /**
+         * Current wallet's version.
+         */
+        version: {
+            type: 'string',
+            default: '',
+        },
+        /**
+         * Current wallet's build number (mobile).
+         */
+        buildNumber: {
+            type: 'int',
+            optional: true,
         },
     },
 };


### PR DESCRIPTION
# Description

This PR adds the ability for the wallet to automatically migrate (accounts & settings) data from old (AsyncStorage) to Realm storage. After login, users will automatically be redirected to the migration screen (on mobile) where behind the scenes, auto migration will be performed. On successful migration, users will be redirected to the dashboard.

## Type of change

- Bug fix

# How Has This Been Tested?

- Manually tested on iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
