### PR TITLE
Desktop: Disallow Node.js runtime debugging mode

### DIFF
--- a/src/desktop/main.js
+++ b/src/desktop/main.js
@@ -17,6 +17,14 @@ app.commandLine.appendSwitch('js-flags', '--expose-gc');
 app.commandLine.appendSwitch('remote-debugging-port', '');
 
 /**
+ * Terminate application if Node remote debugging detected
+ */
+const argv = process.argv.join();
+if (argv.includes('inspect') || typeof v8debug !== 'undefined') {
+    return app.quit();
+}
+
+/**
  * Set AppUserModelID for Windows notifications functionallity
  */
 app.setAppUserModelId('org.iota.trinity');


### PR DESCRIPTION
# Description

Terminate wallet if Node.js runtime debugging mode is detected.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
