### PR TITLE
Shared: Add indicator for over 81 char on seed field

### DIFF
--- a/src/desktop/src/ui/components/input/Seed.js
+++ b/src/desktop/src/ui/components/input/Seed.js
@@ -260,10 +260,6 @@ class SeedInput extends React.PureComponent {
                     seed.splice(Math.min(...cursor), Math.abs(cursor[0] - cursor[1]), byte);
                 }
 
-                if (seed.length > MAX_SEED_LENGTH) {
-                    return;
-                }
-
                 this.setState({
                     cursor: seed.length ? cursorPos : 0,
                 });
@@ -277,7 +273,10 @@ class SeedInput extends React.PureComponent {
         const { seed, label, closeLabel, t } = this.props;
         const { importBuffer, accounts, accountIndex, showScanner, hidden } = this.state;
 
-        const checkSum = seed.length < MAX_SEED_LENGTH ? '< 81' : Electron.getChecksum(seed);
+        const checkSum =
+            seed.length < MAX_SEED_LENGTH
+                ? '< 81'
+                : seed.length > MAX_SEED_LENGTH ? '> 81' : Electron.getChecksum(seed);
 
         return (
             <div className={classNames(css.input, css.seed)}>

--- a/src/desktop/src/ui/views/onboarding/SeedVerify.js
+++ b/src/desktop/src/ui/views/onboarding/SeedVerify.js
@@ -76,10 +76,10 @@ class SeedVerify extends React.PureComponent {
             return;
         }
 
-        if (seed.length < MAX_SEED_LENGTH) {
+        if (seed.length !== MAX_SEED_LENGTH) {
             generateAlert(
                 'error',
-                t('enterSeed:seedTooShort'),
+                seed.length < MAX_SEED_LENGTH ? t('enterSeed:seedTooShort') : t('enterSeed:seedTooLong'),
                 t('enterSeed:seedTooShortExplanation', { maxLength: MAX_SEED_LENGTH, currentLength: seed.length }),
             );
             return;

--- a/src/mobile/src/ui/components/CustomTextInput.js
+++ b/src/mobile/src/ui/components/CustomTextInput.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
-import { VALID_SEED_REGEX, getChecksum } from 'shared-modules/libs/iota/utils';
+import { MAX_SEED_LENGTH, VALID_SEED_REGEX, getChecksum } from 'shared-modules/libs/iota/utils';
 import PropTypes from 'prop-types';
 import { width, height } from 'libs/dimensions';
 import { Styling } from 'ui/theme/general';
@@ -209,8 +209,10 @@ class CustomTextInput extends Component {
 
         if (seed.length !== 0 && !seed.match(VALID_SEED_REGEX)) {
             checksumValue = '!';
-        } else if (seed.length !== 0 && seed.length < 81) {
+        } else if (seed.length !== 0 && seed.length < MAX_SEED_LENGTH) {
             checksumValue = '< 81';
+        } else if (seed.length > MAX_SEED_LENGTH) {
+            checksumValue = '> 81';
         } else if (seed.length === 81 && seed.match(VALID_SEED_REGEX)) {
             checksumValue = getChecksum(seed);
         }

--- a/src/mobile/src/ui/views/onboarding/EnterSeed.js
+++ b/src/mobile/src/ui/views/onboarding/EnterSeed.js
@@ -110,13 +110,13 @@ class EnterSeed extends React.Component {
         const { seed } = this.state;
         if (!seed.match(VALID_SEED_REGEX) && seed.length === MAX_SEED_LENGTH) {
             this.props.generateAlert('error', t('invalidCharacters'), t('invalidCharactersExplanation'));
-        } else if (seed.length < MAX_SEED_LENGTH) {
+        } else if (seed.length !== MAX_SEED_LENGTH) {
             this.props.generateAlert(
                 'error',
-                t('seedTooShort'),
+                seed.length > MAX_SEED_LENGTH ? t('seedTooLong') : t('seedTooShort'),
                 t('seedTooShortExplanation', { maxLength: MAX_SEED_LENGTH, currentLength: seed.length }),
             );
-        } else if (seed.length === MAX_SEED_LENGTH) {
+        } else {
             if (isAndroid) {
                 FlagSecure.deactivate();
             }
@@ -245,7 +245,6 @@ class EnterSeed extends React.Component {
                                     enablesReturnKeyAutomatically
                                     returnKeyType="done"
                                     onSubmitEditing={() => this.onDonePress()}
-                                    maxLength={MAX_SEED_LENGTH}
                                     value={seed}
                                     widget="qr"
                                     onQRPress={() => this.onQRPress()}


### PR DESCRIPTION
# Description

Remove seed input max input length and warn user about too long seed.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
