### PR TITLE
Desktop: Terminate application if Remote Debugging Port is detected

### DIFF
--- a/src/desktop/main.js
+++ b/src/desktop/main.js
@@ -12,15 +12,10 @@ const electronSettings = require('electron-settings');
 app.commandLine.appendSwitch('js-flags', '--expose-gc');
 
 /**
- * Disable Remote Debugging Port on production build
- */
-app.commandLine.appendSwitch('remote-debugging-port', '');
-
-/**
  * Terminate application if Node remote debugging detected
  */
 const argv = process.argv.join();
-if (argv.includes('inspect') || typeof v8debug !== 'undefined') {
+if (argv.includes('inspect') || argv.includes('remote') || typeof v8debug !== 'undefined') {
     return app.quit();
 }
 


### PR DESCRIPTION
# Description

Unsetting `remote-debugging-port` (#541) on runtime results in running the debug mode on random port rather disabling it. The application can only be terminated if debug mode is detected.

Fixes #604

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
