### PR TITLE
Auto retry on different nodes when account sync is performed during p…

### DIFF
--- a/src/shared/actions/polling.js
+++ b/src/shared/actions/polling.js
@@ -3,17 +3,17 @@ import each from 'lodash/each';
 import map from 'lodash/map';
 import union from 'lodash/union';
 import { setPrice, setChartData, setMarketData } from './marketData';
-import { setNodeList, setRandomlySelectedNode, setAutoPromotion } from './settings';
+import { setNodeList, setRandomlySelectedNode, setAutoPromotion, changeNode } from './settings';
 import { getRandomNode, changeIotaNode } from '../libs/iota';
-import { fetchRemoteNodes } from '../libs/iota/utils';
+import { fetchRemoteNodes, withRetriesOnDifferentNodes, getRandomNodes } from '../libs/iota/utils';
 import { formatChartData, getUrlTimeFormat, getUrlNumberFormat, rearrangeObjectKeys } from '../libs/utils';
 import { generateAccountInfoErrorAlert, generateAlert } from './alerts';
 import { setNewUnconfirmedBundleTails, removeBundleFromUnconfirmedBundleTails } from './accounts';
 import { findPromotableTail, isStillAValidTransaction } from '../libs/iota/transfers';
-import { selectedAccountStateFactory } from '../selectors/accounts';
+import { selectedAccountStateFactory, getSelectedNodeFromState, getNodesFromState } from '../selectors/accounts';
 import { syncAccount } from '../libs/iota/accounts';
 import { forceTransactionPromotion } from './transfers';
-import { nodes, nodesWithPoWEnabled } from '../config';
+import { nodes, nodesWithPoWEnabled, DEFAULT_RETRIES } from '../config';
 import Errors from '../libs/errors';
 import i18next from '../libs/i18next';
 
@@ -430,9 +430,16 @@ export const getAccountInfo = (accountName, notificationFn) => {
         dispatch(accountInfoFetchRequest());
 
         const existingAccountState = selectedAccountStateFactory(accountName)(getState());
+        const selectedNode = getSelectedNodeFromState(getState());
 
-        return syncAccount()(existingAccountState, undefined, notificationFn)
-            .then((newAccountData) => dispatch(accountInfoFetchSuccess(newAccountData)))
+        withRetriesOnDifferentNodes([
+            selectedNode,
+            ...getRandomNodes(getNodesFromState(getState()), DEFAULT_RETRIES, [selectedNode]),
+        ])(syncAccount)(existingAccountState, undefined, notificationFn)
+            .then(({ node, result }) => {
+                dispatch(changeNode(node));
+                dispatch(accountInfoFetchSuccess(result));
+            })
             .catch((err) => {
                 dispatch(accountInfoFetchError());
                 dispatch(generateAccountInfoErrorAlert(err));


### PR DESCRIPTION
…olls

# Description

If the selected node goes out of sync, polling account info will continuously throw errors. This PR adds the ability to auto retry on a different node if account sync fails on the selected IRI node.

## Type of change

- Enhancement

# How Has This Been Tested?

- Manually tested account sync polls (iOS)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
