### PR TITLE
Mobile: Upgrade nodejs-mobile-react-native to 0.3.2

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -47,7 +47,7 @@
     "lodash": "^4.17.10",
     "lottie-ios": "^2.5.0",
     "lottie-react-native": "^2.5.10",
-    "nodejs-mobile-react-native": "https://github.com/rajivshah3/nodejs-mobile-react-native",
+    "nodejs-mobile-react-native": "https://github.com/rajivshah3/nodejs-mobile-react-native#ab4a655d30a51115c34dbdb30b98df6f130467ff",
     "os-browserify": "^0.1.2",
     "path-browserify": "0.0.0",
     "process": "^0.11.10",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -5944,9 +5944,9 @@ nodejs-mobile-gyp@^0.2.0:
     tar "^3.1.3"
     which "1"
 
-"nodejs-mobile-react-native@https://github.com/rajivshah3/nodejs-mobile-react-native":
-  version "0.2.1"
-  resolved "https://github.com/rajivshah3/nodejs-mobile-react-native#e8337cfb03f72cfa88acf7b2d16d29fe848af174"
+"nodejs-mobile-react-native@https://github.com/rajivshah3/nodejs-mobile-react-native#ab4a655d30a51115c34dbdb30b98df6f130467ff":
+  version "0.3.2"
+  resolved "https://github.com/rajivshah3/nodejs-mobile-react-native#ab4a655d30a51115c34dbdb30b98df6f130467ff"
   dependencies:
     mkdirp "^0.5.1"
     ncp "^2.0.0"


### PR DESCRIPTION
# Description
Upgrades `nodejs-mobile-react-native` to 0.3.2, fixing issues with Apple A12 CPUs (iPhone XS, XS Max, and XR).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Verified that the framework contains bitcode (`cd node_modules/nodejs-mobile-react-native/ios && unzip -t NodeMobile.framework.zip && unzip -o NodeMobile.framework.zip && otool -l NodeMobile.framework/NodeMobile -arch arm64 | grep __LLVM`)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes