### PR TITLE
TestFlight tester removal script

### DIFF
--- a/src/mobile/android/Gemfile.lock
+++ b/src/mobile/android/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.4)
-    fastlane (2.107.0)
+    fastlane (2.108.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)

--- a/src/mobile/ios/Gemfile.lock
+++ b/src/mobile/ios/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
     dotenv (2.5.0)
     emoji_regex (0.1.1)
     excon (0.62.0)
-    faraday (0.15.2)
+    faraday (0.15.3)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
       faraday (>= 0.7.4)
@@ -26,7 +26,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.4)
-    fastlane (2.104.0)
+    fastlane (2.108.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -62,13 +62,14 @@ GEM
       xcodeproj (>= 1.6.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-bugsnag (1.3.4)
+    fastlane-plugin-bugsnag (1.4.0)
       git
       xml-simple
+    fastlane-plugin-clean_testflight_testers (0.2.0)
     fastlane-plugin-load_json (0.0.1)
     fastlane-plugin-localization (0.2.0)
     gh_inspector (1.1.3)
-    git (1.4.0)
+    git (1.5.0)
     google-api-client (0.23.9)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
@@ -77,10 +78,10 @@ GEM
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
       signet (~> 0.9)
-    googleauth (0.6.6)
+    googleauth (0.6.7)
       faraday (~> 0.12)
       jwt (>= 1.4, < 3.0)
-      memoist (~> 0.12)
+      memoist (~> 0.16)
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
@@ -111,7 +112,7 @@ GEM
     rouge (2.0.7)
     rubyzip (1.2.2)
     security (0.1.3)
-    signet (0.9.2)
+    signet (0.11.0)
       addressable (~> 2.3)
       faraday (~> 0.9)
       jwt (>= 1.5, < 3.0)
@@ -133,7 +134,7 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.0)
     word_wrap (1.0.0)
-    xcodeproj (1.6.0)
+    xcodeproj (1.7.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -151,6 +152,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   fastlane-plugin-bugsnag
+  fastlane-plugin-clean_testflight_testers
   fastlane-plugin-load_json
   fastlane-plugin-localization
 

--- a/src/mobile/ios/fastlane/Fastfile
+++ b/src/mobile/ios/fastlane/Fastfile
@@ -75,3 +75,22 @@ end
 lane :localization do
   import_localizations(source_path: './localizations/*.xliff', project: 'iotaWallet.xcodeproj')
 end
+
+lane :clean_testers_dry_run do
+  UI.important "This may take about 20 minutes for 10,000 testers"
+  UI.important "Do not run this too often! You may be rate limited"
+  clean_testflight_testers(
+    app_identifier: "com.iota.trinity",
+    days_of_inactivity: 120,
+    dry_run: true,
+  )
+end
+
+lane :clean_testers do
+  UI.important "This may take about 20 minutes for 10,000 testers"
+  UI.important "Do not run this too often! You may be rate limited"
+  clean_testflight_testers(
+    app_identifier: "com.iota.trinity",
+    days_of_inactivity: 120,
+  )
+end

--- a/src/mobile/ios/fastlane/Pluginfile
+++ b/src/mobile/ios/fastlane/Pluginfile
@@ -5,3 +5,4 @@
 gem 'fastlane-plugin-bugsnag'
 gem 'fastlane-plugin-load_json'
 gem 'fastlane-plugin-localization'
+gem 'fastlane-plugin-clean_testflight_testers'

--- a/src/mobile/ios/fastlane/README.md
+++ b/src/mobile/ios/fastlane/README.md
@@ -45,6 +45,16 @@ fastlane deploy
 fastlane localization
 ```
 
+### clean_testers_dry_run
+```
+fastlane clean_testers_dry_run
+```
+
+### clean_testers
+```
+fastlane clean_testers
+```
+
 
 ----
 


### PR DESCRIPTION
# Description
Uses https://github.com/KrauseFx/fastlane-plugin-clean_testflight_testers to automatically remove inactive testers from TestFlight.

`clean_testers_dry_run` simply prints out the testers that would have been removed, while `clean_testers` actually removes them.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

N/A


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code