### PR TITLE
Mobile/iOS: Add api_key parameter to dSYM upload script [ci skip]

### DIFF
--- a/src/mobile/ios/fastlane/Fastfile
+++ b/src/mobile/ios/fastlane/Fastfile
@@ -42,12 +42,12 @@ end
 
 lane :upload_dsyms do |options|
   if options[:path]
-    upload_symbols_to_bugsnag(dsym_path: options[:path])
+    upload_symbols_to_bugsnag(dsym_path: options[:path], api_key: options[:api_key])
   else
     clean_build_artifacts
     build_number = get_build_number(xcodeproj: 'iotaWallet.xcodeproj')
     download_dsyms(build_number: build_number)
-    upload_symbols_to_bugsnag
+    upload_symbols_to_bugsnag(api_key: options[:api_key])
     clean_build_artifacts
   end
 end


### PR DESCRIPTION
# Description
The Bugsnag plugin for Fastlane was upgraded to 1.4.0 and requires an `api_key` parameter. This PR adds that parameter to the script.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


# How Has This Been Tested?

- Ran script


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code