### PR TITLE
Desktop: Empty settings initialisation fix

### DIFF
--- a/src/desktop/main.js
+++ b/src/desktop/main.js
@@ -56,7 +56,7 @@ if (!devMode) {
     app.setAsDefaultProtocolClient('iota');
 }
 
-let settings = null;
+let settings = {};
 
 let windowState = {
     width: 1280,


### PR DESCRIPTION
## Description

Desktop main process settings initialised as null throws error.

Fixes #665 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
