### PR TITLE
Shared: Fix proxyExplanation string

### DIFF
--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -741,7 +741,7 @@
     },
     "proxy": {
         "proxy": "Use system proxy",
-        "proxyExplanation": "Detect and use system wide network proxy settings. Restart the wallet after changing this setting."
+        "proxyExplanation": "Detect and use system wide network proxy settings. Close and reopen the wallet after changing this setting."
     },
     "notifications": {
       "notifications": "Notifications",


### PR DESCRIPTION
# Description
Clarifies the `proxyExplanation` string. The old string, `restart the wallet` could be considered ambiguous, especially because of its proximity to the reset button. For Spanish and Portuguese users, `restart` is the same as `reset`, so this could be confusing.

## Type of change

- Localization fix

# How Has This Been Tested?

N/A


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code

