### PR TITLE
Desktop: Allow wallet window resize on top edge

### DIFF
--- a/src/desktop/src/ui/global/titlebar.scss
+++ b/src/desktop/src/ui/global/titlebar.scss
@@ -7,21 +7,16 @@
     -webkit-app-region: drag;
     z-index: 99998;
 
-    &:before,
     &:after {
         display: block;
         content: '';
-        width: 6px;
+        width: 100vw;
         height: 6px;
         position: absolute;
         top: 0px;
         left: 0px;
         -webkit-app-region: no-drag;
         z-index: 2;
-    }
-    &:after {
-        left: auto;
-        right: 0px;
     }
 }
 


### PR DESCRIPTION
# Description

Allow wallet windows resize on top edge (instead of corners only)

Fixes #673 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on Windows 10

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code