### PR TITLE
Desktop: Fix menu button color on light themes

### DIFF
--- a/src/desktop/src/ui/Index.js
+++ b/src/desktop/src/ui/Index.js
@@ -278,7 +278,7 @@ class App extends React.Component {
 
         return (
             <div className={css.trintiy}>
-                <Titlebar />
+                <Titlebar path={currentKey} />
                 <About />
                 <ErrorLog />
                 <Idle />

--- a/src/desktop/src/ui/global/Titlebar.js
+++ b/src/desktop/src/ui/global/Titlebar.js
@@ -5,13 +5,18 @@ import css from './titlebar.scss';
 /**
  * Windows platform wallet titlebar component
  */
-const Titlebar = () => {
+const Titlebar = (props) => {
     const os = Electron.getOS();
+
+    const sidebarViews = ['wallet'];
 
     const windows = () => {
         return (
             <nav className={css.windows}>
-                <a onClick={() => Electron.showMenu()}>
+                <a
+                    className={sidebarViews.indexOf(props.path) > -1 ? css.dark : css.light}
+                    onClick={() => Electron.showMenu()}
+                >
                     <svg width="15" height="15" viewBox="0 0 15 15">
                         <path fill="#000" d="M0 1h15v1h-15z" />
                         <path fill="#000" d="M0 7h15v1h-15z" />

--- a/src/desktop/src/ui/global/Titlebar.js
+++ b/src/desktop/src/ui/global/Titlebar.js
@@ -1,11 +1,13 @@
 /* global Electron */
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import css from './titlebar.scss';
 
 /**
  * Windows platform wallet titlebar component
  */
-const Titlebar = (props) => {
+const Titlebar = ({ path }) => {
     const os = Electron.getOS();
 
     const sidebarViews = ['wallet'];
@@ -14,7 +16,7 @@ const Titlebar = (props) => {
         return (
             <nav className={css.windows}>
                 <a
-                    className={sidebarViews.indexOf(props.path) > -1 ? css.dark : css.light}
+                    className={sidebarViews.indexOf(path) > -1 ? css.dark : css.light}
                     onClick={() => Electron.showMenu()}
                 >
                     <svg width="15" height="15" viewBox="0 0 15 15">
@@ -43,6 +45,11 @@ const Titlebar = (props) => {
     };
 
     return <div className={css.titlebar}>{os === 'win32' ? windows() : null}</div>;
+};
+
+Titlebar.propTypes = {
+    /** Current main path */
+    path: PropTypes.string.isRequired,
 };
 
 export default Titlebar;

--- a/src/desktop/src/ui/global/titlebar.scss
+++ b/src/desktop/src/ui/global/titlebar.scss
@@ -49,7 +49,7 @@
                 fill: var(--bar);
             }
 
-            &.light {
+            &.light svg path {
                 fill: var(--body);
             }
         }

--- a/src/desktop/src/ui/global/titlebar.scss
+++ b/src/desktop/src/ui/global/titlebar.scss
@@ -44,6 +44,14 @@
 
         &:first-child {
             margin: 0 auto 0 0;
+
+            &.dark svg path {
+                fill: var(--bar);
+            }
+
+            &.light {
+                fill: var(--body);
+            }
         }
 
         svg {


### PR DESCRIPTION
# Description

Update Main menu icon color to use sidebar color if used over sidebar.

Fixes #702 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
