### PR TITLE
Desktop: Highlight address checksum on all views

### DIFF
--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/iotaledger/trinity-wallet.git"
   },
   "scripts": {
-    "start": "concurrently --kill-others \"npm run devserver\" \"cross-env NODE_ENV=development electron main.js\"",
+    "start": "concurrently --kill-others \"npm run devserver\" \"cross-env NODE_ENV=development electron -r @babel/register main.js\"",
     "postinstall": "patch-package && electron-builder install-app-deps",
     "devserver": "node server.js",
     "style:shots": "node scripts/puppeteer.js",
@@ -162,7 +162,6 @@
     "react-qr-reader": "^2.1.1",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.3.1",
-    "react-tooltip": "^3.9.0",
     "react-transition-group": "^2.5.0",
     "recharts": "^1.3.2",
     "redux": "^4.0.0"

--- a/src/desktop/src/ui/components/Checksum.js
+++ b/src/desktop/src/ui/components/Checksum.js
@@ -1,4 +1,3 @@
-/* global Electron */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ADDRESS_LENGTH, VALID_SEED_REGEX } from 'libs/iota/utils';

--- a/src/desktop/src/ui/components/Checksum.js
+++ b/src/desktop/src/ui/components/Checksum.js
@@ -1,0 +1,26 @@
+/* global Electron */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ADDRESS_LENGTH, VALID_SEED_REGEX } from 'libs/iota/utils';
+
+/**
+ * Returns address with highlighted checksum
+ */
+const Checksum = ({ address }) => {
+    const validAddress =
+        typeof address === 'string' && address.length === ADDRESS_LENGTH && address.match(VALID_SEED_REGEX);
+
+    return (
+        <React.Fragment>
+            {!validAddress ? address : address.substr(0, 81)}
+            {validAddress && <mark>{address.substr(81)}</mark>}
+        </React.Fragment>
+    );
+};
+
+Checksum.propTypes = {
+    /** Target address */
+    address: PropTypes.string.isRequired,
+};
+
+export default Checksum;

--- a/src/desktop/src/ui/components/List.js
+++ b/src/desktop/src/ui/components/List.js
@@ -105,7 +105,11 @@ class List extends React.PureComponent {
                                         text={`${input.address}${input.checksum}`}
                                         title={t('history:addressCopied')}
                                         success={t('history:addressCopiedExplanation')}
-                                    />
+                                        address
+                                    >
+                                        {input.address}
+                                        <mark>{input.checksum}</mark>
+                                    </Clipboard>
                                 </span>
                                 <em>
                                     {round(formatValue(input.value), 1)}
@@ -294,8 +298,12 @@ class List extends React.PureComponent {
                                             </span>
                                             <span>
                                                 {!isConfirmed
-                                                    ? isReceived ? t('receiving') : t('sending')
-                                                    : isReceived ? t('received') : t('sent')}
+                                                    ? isReceived
+                                                        ? t('receiving')
+                                                        : t('sending')
+                                                    : isReceived
+                                                        ? t('received')
+                                                        : t('sent')}
                                             </span>
                                             <span>
                                                 {transfer.transferValue === 0 ? '' : isReceived ? '+' : '-'}
@@ -333,7 +341,9 @@ class List extends React.PureComponent {
                                     <small>
                                         {!activeTransfer.persistence
                                             ? t('pending')
-                                            : activeTransfer.incoming ? t('received') : t('sent')}
+                                            : activeTransfer.incoming
+                                                ? t('received')
+                                                : t('sent')}
                                         <em>
                                             {formatModalTime(
                                                 navigator.language,

--- a/src/desktop/src/ui/components/input/Address.js
+++ b/src/desktop/src/ui/components/input/Address.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import QrReader from 'react-qr-reader';
-import ReactTooltip from 'react-tooltip';
 import PropTypes from 'prop-types';
 import { ADDRESS_LENGTH, parseAddress } from 'libs/iota/utils';
 
 import Modal from 'ui/components/modal/Modal';
 import Button from 'ui/components/Button';
+import Checksum from 'ui/components/Checksum';
 import Icon from 'ui/components/Icon';
 import css from './input.scss';
 
@@ -32,7 +32,6 @@ export default class Address extends React.PureComponent {
 
     state = {
         showScanner: false,
-        inputFocused: false
     };
 
     componentDidMount() {
@@ -55,18 +54,6 @@ export default class Address extends React.PureComponent {
             const input = parseAddress(data);
             this.props.onChange(input.address, input.message, input.amount);
         }
-    };
-
-    handleFocus = () => {
-        this.setState(() => ({
-            inputFocused: true,
-        }));
-    };
-
-    handleBlur = () => {
-        this.setState(() => ({
-            inputFocused: false,
-        }));
     };
 
     closeScanner = () => {
@@ -94,7 +81,7 @@ export default class Address extends React.PureComponent {
 
     render() {
         const { address, label, closeLabel } = this.props;
-        const { showScanner, inputFocused } = this.state;
+        const { showScanner } = this.state;
 
         return (
             <div className={css.input}>
@@ -109,21 +96,23 @@ export default class Address extends React.PureComponent {
                         }}
                         value={address}
                         onChange={(e) => this.props.onChange(e.target.value)}
-                        onFocus={() => this.handleFocus()}
-                        onBlur={() => this.handleBlur()}
                         maxLength={ADDRESS_LENGTH}
                         data-tip={address}
                     />
+                    {this.isInputScrolling() && (
+                        <div className={css.tooltip}>
+                            <Checksum address={address} />
+                        </div>
+                    )}
                     <small>{label}</small>
-                    <p ref={(address) => {this.address = address;}} className={css.addressHidden}>
+                    <p
+                        ref={(address) => {
+                            this.address = address;
+                        }}
+                        className={css.addressHidden}
+                    >
                         {address}
                     </p>
-                    {!inputFocused && this.isInputScrolling() && (
-                        <ReactTooltip
-                            place="bottom"
-                            className={css.tooltip}
-                        />
-                    )}
                 </fieldset>
                 {showScanner && (
                     <Modal isOpen onClose={this.closeScanner}>

--- a/src/desktop/src/ui/components/input/input.scss
+++ b/src/desktop/src/ui/components/input/input.scss
@@ -46,6 +46,13 @@
             }
         }
 
+        &:hover {
+            .tooltip {
+                opacity: 1;
+                transition: 0.2s ease-in;
+            }
+        }
+
         .editable {
             display: block;
             font-family: 'SourceCodePro';
@@ -542,18 +549,43 @@
 }
 
 .tooltip {
-    background: var(--bar-bg) !important;
-    color: var(--bar) !important;
-    width: 324px !important;
+    position: absolute;
+    pointer-events: none;
+    z-index: 2;
+    font-size: 14px;
+    background: var(--bar-bg);
+    color: var(--bar);
+    width: 342px;
+    border-radius: 4px;
     font-family: 'SourceCodePro';
     letter-spacing: 2px;
     word-wrap: break-word;
     line-height: 21px;
-    padding: 12px 14px 12px 16px !important;
+    padding: 12px 14px 12px 16px;
+    top: 48px;
+    left: 50%;
+    transform: translate(-50%, 0);
+    opacity: 0;
+
+    mark {
+        color: var(--primary);
+    }
 
     &:after {
-        border-bottom-color: var(--bar-bg) !important;
+        content: '';
+        position: absolute;
+        top: -6px;
+        left: calc(50% - 6px);
+        width: 0;
+        height: 0;
+        border-style: solid;
+        border-width: 0 6px 6px 6px;
+        border-color: transparent transparent var(--bar-bg) transparent;
     }
+}
+
+input:focus + .tooltip {
+    display: none;
 }
 
 .addressHidden {

--- a/src/desktop/src/ui/components/list.scss
+++ b/src/desktop/src/ui/components/list.scss
@@ -437,6 +437,9 @@
                 font-family: 'SourceSansPro';
                 font-weight: 400;
             }
+            mark {
+                color: var(--primary);
+            }
         }
         > div {
             max-height: calc(100vh - 640px);

--- a/src/desktop/src/ui/components/modal/modal.scss
+++ b/src/desktop/src/ui/components/modal/modal.scss
@@ -130,8 +130,9 @@ $footer: 70px;
             margin-bottom: 20px;
         }
 
-
-
+        mark {
+            color: var(--primary);
+        }
     }
 }
 

--- a/src/desktop/src/ui/style/_reset.scss
+++ b/src/desktop/src/ui/style/_reset.scss
@@ -25,3 +25,7 @@ input,
 textarea {
     cursor: text;
 }
+
+mark {
+    background: none;
+}

--- a/src/desktop/src/ui/views/account/Addresses.js
+++ b/src/desktop/src/ui/views/account/Addresses.js
@@ -32,7 +32,6 @@ class Addresses extends PureComponent {
                         .reverse()
                         .map((item) => {
                             const address = item + account.addresses[item].checksum;
-                            const text = address.match(/.{1,3}/g).join(' ');
                             return (
                                 <li key={address}>
                                     <p className={isSpent(account.addresses[item]) ? css.spent : null}>
@@ -41,7 +40,8 @@ class Addresses extends PureComponent {
                                             title={t('receive:addressCopied')}
                                             success={t('receive:addressCopiedExplanation')}
                                         >
-                                            {text}
+                                            {item.match(/.{1,3}/g).join(' ')}{' '}
+                                            <mark>{account.addresses[item].checksum.match(/.{1,3}/g).join(' ')}</mark>
                                         </Clipboard>
                                     </p>
                                     <strong>

--- a/src/desktop/src/ui/views/account/addresses.scss
+++ b/src/desktop/src/ui/views/account/addresses.scss
@@ -8,12 +8,16 @@
         font-family: 'SourceCodePro';
         font-size: 12px;
         word-break: break-word;
+
+        mark {
+            color: var(--primary);
+        }
     }
 
     li {
         display: flex;
         strong {
-            flex: 1 0 80px;
+            flex: 1 0 65px;
             text-align: right;
         }
     }
@@ -21,5 +25,9 @@
     .spent {
         text-decoration: line-through;
         color: var(--negative);
+
+        mark {
+            color: var(--negative);
+        }
     }
 }

--- a/src/desktop/src/ui/views/wallet/Send.js
+++ b/src/desktop/src/ui/views/wallet/Send.js
@@ -14,6 +14,7 @@ import Icon from 'ui/components/Icon';
 import Button from 'ui/components/Button';
 import Progress from 'ui/components/Progress';
 import Balance from 'ui/components/Balance';
+import Checksum from 'ui/components/Checksum';
 import Confirm from 'ui/components/modal/Confirm';
 import withSendData from 'containers/wallet/Send';
 
@@ -120,7 +121,7 @@ class Send extends React.PureComponent {
                 ? `${formatValue(fields.amount)} ${formatUnit(fields.amount)} (${getCurrencySymbol(
                       settings.currency,
                   )}${(
-                      round(fields.amount * settings.usdPrice / 1000000 * settings.conversionRate * 100) / 100
+                      round(((fields.amount * settings.usdPrice) / 1000000) * settings.conversionRate * 100) / 100
                   ).toFixed(2)})`
                 : t('transferConfirmation:aMessage');
 
@@ -137,7 +138,11 @@ class Send extends React.PureComponent {
                         onConfirm={() => this.confirmTransfer()}
                         content={{
                             title: t('transferConfirmation:youAreAbout', { contents: transferContents }),
-                            message: fields.address,
+                            message: (
+                                <span className={css.address}>
+                                    <Checksum address={fields.address} />
+                                </span>
+                            ),
                             confirm: t('send'),
                             cancel: t('cancel'),
                         }}

--- a/src/desktop/src/ui/views/wallet/send.scss
+++ b/src/desktop/src/ui/views/wallet/send.scss
@@ -85,6 +85,16 @@
     }
 }
 
+.address {
+    display: inline-block;
+    font-family: 'SourceCodePro';
+    letter-spacing: 2px;
+    max-width: 390px;
+    word-break: break-word;
+    font-size: 18px;
+    line-height: 28px;
+}
+
 .units {
     position: absolute;
     top: 0px;


### PR DESCRIPTION
# Description

Add address checksum highlight at:
- Address field tooltip
- Account settings, View addresses view
- History transactions details (on Advanced mode)
- Send confirmation popup

Resolves #632

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
