### PR TITLE
Desktop: Fix environment detection

### DIFF
--- a/src/desktop/native/preload/Electron.js
+++ b/src/desktop/native/preload/Electron.js
@@ -47,7 +47,7 @@ let onboardingSeed = null;
 let onboardingGenerated = false;
 
 // Use a different keychain entry for development versions
-const KEYTAR_SERVICE = process.env.NODE_ENV === 'development' ? 'Trinity wallet (dev)' : 'Trinity wallet';
+const KEYTAR_SERVICE = remote.app.isPackaged ? 'Trinity wallet' : 'Trinity wallet (dev)';
 
 /**
  * Global Electron helper for native support


### PR DESCRIPTION
# Description
For some reason, Electron is now detecting a production environment even when `NODE_ENV` is `development`. The development version started asking for access to the keychain entries from the production version.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested manually on macOS


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code