### PR TITLE
Assign account index to accounts in state

### DIFF
--- a/src/desktop/src/index.js
+++ b/src/desktop/src/index.js
@@ -8,6 +8,7 @@ import { Provider as Redux } from 'react-redux';
 import { MemoryRouter as Router } from 'react-router';
 import i18next from 'libs/i18next';
 import store, { persistStore } from 'store';
+import { assignAccountIndexIfNecessary } from 'actions/accounts';
 import persistElectronStorage from 'libs/storage';
 import { changeIotaNode } from 'libs/iota';
 import createPlugin from 'bugsnag-react';
@@ -46,6 +47,9 @@ const persistor = persistStore(store, persistConfig, (err, restoredState) => {
     if (node) {
         changeIotaNode(node);
     }
+
+    // Assign accountIndex to every account in accountInfo if it is not assigned already
+    store.dispatch(assignAccountIndexIfNecessary(get(restoredState, 'accounts.accountInfo')));
 });
 
 if (Electron.mode === 'tray') {

--- a/src/mobile/src/ui/routes/entry.js
+++ b/src/mobile/src/ui/routes/entry.js
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 import { changeIotaNode, SwitchingConfig } from 'shared-modules/libs/iota';
 import sharedStore from 'shared-modules/store';
 import iotaNativeBindings, { overrideAsyncTransactionObject } from 'shared-modules/libs/iota/nativeBindings';
+import { assignAccountIndexIfNecessary } from 'shared-modules/actions/accounts';
 import { fetchNodeList as fetchNodes } from 'shared-modules/actions/polling';
 import { setCompletedForcedPasswordUpdate } from 'shared-modules/actions/settings';
 import { ActionTypes } from 'shared-modules/actions/wallet';
@@ -37,6 +38,9 @@ const launch = (store) => {
         clearKeychain();
         store.dispatch(setCompletedForcedPasswordUpdate());
     }
+
+    // Assign accountIndex to every account in accountInfo if it is not assigned already
+    store.dispatch(assignAccountIndexIfNecessary(get(state, 'accounts.accountInfo')));
 
     // Set default language
     i18next.changeLanguage(getLocaleFromLabel(state.settings.language));

--- a/src/shared/__tests__/actions/accounts.spec.js
+++ b/src/shared/__tests__/actions/accounts.spec.js
@@ -1,0 +1,64 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { expect } from 'chai';
+import * as actions from '../../actions/accounts';
+
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('actions: accounts', () => {
+    describe('#assignAccountIndexIfNecessary', () => {
+        describe('provided param is empty', () => {
+            it('should not create an action of type IOTA/ACCOUNTS/ASSIGN_ACCOUNT_INDEX', () => {
+                const store = mockStore({});
+
+                // Dispatch action
+                store.dispatch(actions.assignAccountIndexIfNecessary({}));
+
+                expect(store.getActions()).to.eql([]);
+            });
+        });
+
+        describe('provided param is not empty', () => {
+            describe('when some accounts in accountInfo object have an index property with a non-numeric value', () => {
+                it('should not create an action of type IOTA/ACCOUNTS/ASSIGN_ACCOUNT_INDEX', () => {
+                    const store = mockStore({});
+
+                    let accountInfo = { foo: {}, baz: { index: 2 } };
+
+                    const expectedActions = [
+                        {
+                            type: 'IOTA/ACCOUNTS/ASSIGN_ACCOUNT_INDEX',
+                        },
+                    ];
+
+                    // Dispatch action
+                    store.dispatch(actions.assignAccountIndexIfNecessary(accountInfo));
+                    expect(store.getActions()).to.eql(expectedActions);
+
+                    // Clear actions
+                    store.clearActions();
+
+                    // Reassign account info and check for undefined values
+                    accountInfo = { foo: { index: undefined }, baz: { index: 1 } };
+
+                    // Dispatch action
+                    store.dispatch(actions.assignAccountIndexIfNecessary(accountInfo));
+                    expect(store.getActions()).to.eql(expectedActions);
+                });
+            });
+
+            describe('when every account in accountInfo object has an index property with a numeric value', () => {
+                it('should not create an action of type IOTA/ACCOUNTS/ASSIGN_ACCOUNT_INDEX', () => {
+                    const store = mockStore({});
+
+                    const accountInfo = { foo: { index: 0 }, baz: { index: 1 } };
+
+                    // Dispatch action
+                    store.dispatch(actions.assignAccountIndexIfNecessary(accountInfo));
+                    expect(store.getActions()).to.eql([]);
+                });
+            });
+        });
+    });
+});

--- a/src/shared/__tests__/reducers/accounts.spec.js
+++ b/src/shared/__tests__/reducers/accounts.spec.js
@@ -457,157 +457,6 @@ describe('Reducer: accounts', () => {
     });
 
     describe('FULL_ACCOUNT_INFO_FETCH_SUCCESS', () => {
-        it('should merge unconfirmedBundleTails in payload to unconfirmedBundleTails in state', () => {
-            const initialState = {
-                unconfirmedBundleTails: { foo: {} },
-            };
-
-            const action = actions.fullAccountInfoFetchSuccess({ unconfirmedBundleTails: { baz: {} } });
-
-            const newState = reducer(initialState, action);
-            const expectedState = {
-                unconfirmedBundleTails: { baz: {}, foo: {} },
-            };
-
-            expect(newState.unconfirmedBundleTails).to.eql(expectedState.unconfirmedBundleTails);
-        });
-
-        it('should merge addresses in payload to accountName in accountInfo', () => {
-            const initialState = {
-                accountInfo: {
-                    foo: {
-                        addresses: { foo: {} },
-                        transfers: {},
-                        balance: 0,
-                    },
-                },
-            };
-
-            const action = actions.fullAccountInfoFetchSuccess({
-                accountName: 'foo',
-                accountMeta: { type: 'bar' },
-                addresses: { foo: {}, baz: {} },
-                transfers: {},
-                balance: 100,
-                hashes: [],
-            });
-
-            const newState = reducer(initialState, action);
-            const expectedState = {
-                accountInfo: {
-                    foo: {
-                        meta: { type: 'bar' },
-                        addresses: { foo: {}, baz: {} },
-                        transfers: {},
-                        balance: 100,
-                        hashes: [],
-                    },
-                },
-            };
-
-            expect(newState.accountInfo).to.eql(expectedState.accountInfo);
-        });
-
-        it('should assign transfers and set balance in payload to accountName in accountInfo', () => {
-            const initialState = {
-                accountInfo: {
-                    foo: {
-                        meta: { type: 'bar' },
-                        addresses: { foo: {} },
-                        transfers: { foo: { value: 20 }, baz: { value: 0 } },
-                        balance: 0,
-                    },
-                },
-            };
-
-            const action = actions.fullAccountInfoFetchSuccess({
-                accountName: 'foo',
-                accountMeta: { type: 'bar' },
-                addresses: { foo: {}, baz: {} },
-                transfers: { foo: { value: 0 } },
-                balance: 100,
-                hashes: [],
-            });
-
-            const newState = reducer(initialState, action);
-            const expectedState = {
-                accountInfo: {
-                    foo: {
-                        meta: { type: 'bar' },
-                        addresses: { foo: {}, baz: {} },
-                        transfers: { foo: { value: 0 }, baz: { value: 0 } },
-                        balance: 100,
-                        hashes: [],
-                    },
-                },
-            };
-
-            expect(newState.accountInfo).to.eql(expectedState.accountInfo);
-        });
-
-        it('should set hashes in payload to accountName in accountInfo', () => {
-            const initialState = {
-                accountInfo: {
-                    foo: {
-                        meta: { type: 'bar' },
-                        balance: 0,
-                        transfers: {},
-                        addresses: {},
-                        hashes: ['baz'],
-                    },
-                },
-            };
-
-            const action = actions.fullAccountInfoFetchSuccess({
-                accountName: 'foo',
-                accountMeta: { type: 'bar' },
-                hashes: ['baz', 'bar'],
-                transfers: {},
-                balance: 0,
-                addresses: {},
-            });
-
-            const newState = reducer(initialState, action);
-            const expectedState = {
-                accountInfo: {
-                    foo: {
-                        meta: { type: 'bar' },
-                        balance: 0,
-                        transfers: {},
-                        addresses: {},
-                        hashes: ['baz', 'bar'],
-                    },
-                },
-            };
-
-            expect(newState.accountInfo).to.eql(expectedState.accountInfo);
-        });
-
-        it('should reset accountInfoDuringSetup to default state', () => {
-            const initialState = {
-                accountInfoDuringSetup: {
-                    name: 'foo',
-                    meta: { bar: {} },
-                    usedExistingSeed: true,
-                },
-            };
-
-            const action = actions.fullAccountInfoFetchSuccess({});
-
-            const newState = reducer(initialState, action);
-            const expectedState = {
-                accountInfoDuringSetup: {
-                    name: '',
-                    meta: {},
-                    usedExistingSeed: false,
-                },
-            };
-
-            expect(newState.accountInfoDuringSetup).to.eql(expectedState.accountInfoDuringSetup);
-        });
-    });
-
-    describe('FULL_ACCOUNT_INFO_FETCH_SUCCESS', () => {
         it('should merge addresses in payload to accountName in accountInfo', () => {
             const initialState = {
                 accountInfo: {
@@ -622,6 +471,7 @@ describe('Reducer: accounts', () => {
 
             const action = actions.fullAccountInfoFetchSuccess({
                 accountName: 'foo',
+                accountIndex: 0,
                 accountMeta: { type: 'bar' },
                 addresses: { foo: {}, baz: {} },
                 transfers: {},
@@ -634,6 +484,7 @@ describe('Reducer: accounts', () => {
                 accountInfo: {
                     foo: {
                         meta: { type: 'bar' },
+                        index: 0,
                         addresses: { foo: {}, baz: {} },
                         transfers: {},
                         balance: 100,
@@ -659,6 +510,7 @@ describe('Reducer: accounts', () => {
 
             const action = actions.fullAccountInfoFetchSuccess({
                 accountName: 'foo',
+                accountIndex: 0,
                 accountMeta: { type: 'bar' },
                 addresses: { foo: {}, baz: {} },
                 transfers: { foo: { value: 0 } },
@@ -671,6 +523,7 @@ describe('Reducer: accounts', () => {
                 accountInfo: {
                     foo: {
                         meta: { type: 'bar' },
+                        index: 0,
                         hashes: [],
                         addresses: { foo: {}, baz: {} },
                         transfers: { foo: { value: 0 }, baz: { value: 0 } },
@@ -696,6 +549,7 @@ describe('Reducer: accounts', () => {
 
             const action = actions.fullAccountInfoFetchSuccess({
                 accountName: 'foo',
+                accountIndex: 0,
                 accountMeta: { type: 'bar' },
                 hashes: ['baz', 'bar'],
                 transfers: {},
@@ -708,6 +562,7 @@ describe('Reducer: accounts', () => {
                 accountInfo: {
                     foo: {
                         meta: { type: 'bar' },
+                        index: 0,
                         balance: 0,
                         transfers: {},
                         addresses: {},
@@ -1083,6 +938,7 @@ describe('Reducer: accounts', () => {
                 const initialState = {
                     accountInfo: {
                         dummy: {
+                            index: 1,
                             meta: { type: 'bar' },
                             balance: 0,
                             addresses: { foo: {} },
@@ -1106,6 +962,7 @@ describe('Reducer: accounts', () => {
                 const expectedState = {
                     accountInfo: {
                         dummy: {
+                            index: 1,
                             meta: { type: 'bar' },
                             balance: 0,
                             addresses: { foo: {}, baz: {} },

--- a/src/shared/__tests__/reducers/accounts.spec.js
+++ b/src/shared/__tests__/reducers/accounts.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import reducer, { mergeAddressData } from '../../reducers/accounts';
+import reducer, { mergeAddressData, removeAccountAndReorderIndexes } from '../../reducers/accounts';
 import * as actions from '../../actions/accounts';
 
 describe('Reducer: accounts', () => {
@@ -1138,6 +1138,38 @@ describe('Reducer: accounts', () => {
                     baz: { spent: { local: undefined, remote: null } },
                     foo: { spent: { local: true, remote: true } },
                 });
+            });
+        });
+    });
+
+    describe('#removeAccountAndReorderIndexes', () => {
+        describe('when accountName does not exist in accountInfo', () => {
+            it('should return existing accountInfo', () => {
+                const accountInfo = { foo: { index: 0 } };
+
+                expect(removeAccountAndReorderIndexes(accountInfo, 'baz')).to.eql(accountInfo);
+            });
+        });
+
+        describe('when accountName exists in accountInfo', () => {
+            it('should remove account from accountInfo', () => {
+                const accountInfo = { foo: { index: 0 }, baz: { index: 1 } };
+
+                expect(removeAccountAndReorderIndexes(accountInfo, 'baz')).to.eql({ foo: { index: 0 } });
+            });
+
+            it('should reorder account indexes (Fill missing indexes)', () => {
+                expect(
+                    removeAccountAndReorderIndexes({ foo: { index: 0 }, baz: { index: 1 }, bar: { index: 2 } }, 'baz'),
+                ).to.eql({ foo: { index: 0 }, bar: { index: 1 } });
+
+                expect(
+                    removeAccountAndReorderIndexes({ foo: { index: 0 }, baz: { index: 1 }, bar: { index: 2 } }, 'bar'),
+                ).to.eql({ foo: { index: 0 }, baz: { index: 1 } });
+
+                expect(
+                    removeAccountAndReorderIndexes({ foo: { index: 0 }, baz: { index: 1 }, bar: { index: 2 } }, 'foo'),
+                ).to.eql({ baz: { index: 0 }, bar: { index: 1 } });
             });
         });
     });

--- a/src/shared/__tests__/reducers/accounts.spec.js
+++ b/src/shared/__tests__/reducers/accounts.spec.js
@@ -925,6 +925,31 @@ describe('Reducer: accounts', () => {
         });
     });
 
+    describe('IOTA/ACCOUNTS/ASSIGN_ACCOUNT_INDEX', () => {
+        it('should assign "index" to each account in accountInfo state prop', () => {
+            const initialState = {
+                accountInfo: {
+                    foo: { addresses: { ['U'.repeat(81)]: {} }, transfers: {} },
+                    baz: { addresses: {}, transfers: {} },
+                },
+            };
+
+            const action = {
+                type: 'IOTA/ACCOUNTS/ASSIGN_ACCOUNT_INDEX',
+            };
+
+            const newState = reducer(initialState, action);
+            const expectedState = {
+                accountInfo: {
+                    foo: { index: 0, addresses: { ['U'.repeat(81)]: {} }, transfers: {} },
+                    baz: { index: 1, addresses: {}, transfers: {} },
+                },
+            };
+
+            expect(newState).to.eql(expectedState);
+        });
+    });
+
     [
         'IOTA/ACCOUNTS/UPDATE_ACCOUNT_INFO_AFTER_SPENDING',
         'IOTA/ACCOUNTS/SYNC_ACCOUNT_BEFORE_MANUAL_PROMOTION',

--- a/src/shared/__tests__/selectors/accounts.spec.js
+++ b/src/shared/__tests__/selectors/accounts.spec.js
@@ -157,8 +157,10 @@ describe('selectors: accounts', () => {
         });
 
         describe('when "accountInfo" prop is defined as a nested prop under "accounts" prop in argument', () => {
-            it('should return value for "accountNames" prop', () => {
-                expect(getAccountNamesFromState({ accounts: { accountInfo: { a: {}, b: [] } } })).to.eql(['a', 'b']);
+            it('should return sorted account names by indes', () => {
+                expect(
+                    getAccountNamesFromState({ accounts: { accountInfo: { a: { index: 1 }, b: { index: 0 } } } }),
+                ).to.eql(['b', 'a']);
             });
         });
     });

--- a/src/shared/actions/accounts.js
+++ b/src/shared/actions/accounts.js
@@ -1,3 +1,6 @@
+import some from 'lodash/some';
+import isEmpty from 'lodash/isEmpty';
+import isNumber from 'lodash/isNumber';
 import {
     selectedAccountStateFactory,
     getAccountNamesFromState,
@@ -48,6 +51,7 @@ export const ActionTypes = {
     MARK_BUNDLE_BROADCAST_STATUS_COMPLETE: 'IOTA/ACCOUNTS/MARK_BUNDLE_BROADCAST_STATUS_COMPLETE',
     SYNC_ACCOUNT_BEFORE_SWEEPING: 'IOTA/ACCOUNTS/SYNC_ACCOUNT_BEFORE_SWEEPING',
     OVERRIDE_ACCOUNT_INFO: 'IOTA/ACCOUNTS/OVERRIDE_ACCOUNT_INFO',
+    ASSIGN_ACCOUNT_INDEX: 'IOTA/ACCOUNTS/ASSIGN_ACCOUNT_INDEX',
 };
 
 /**
@@ -402,6 +406,17 @@ export const overrideAccountInfo = (payload) => ({
 });
 
 /**
+ * Dispatch to (automatically) assign accountIndex to every account in state
+ *
+ * @method assignAccountIndex
+ *
+ * @returns {{type: {string} }}
+ */
+export const assignAccountIndex = () => ({
+    type: ActionTypes.ASSIGN_ACCOUNT_INDEX,
+});
+
+/**
  * Gets full account information for the first seed added to the wallet.
  *
  * @method getFullAccountInfo
@@ -559,4 +574,18 @@ export const cleanUpAccountState = (seedStore, accountName) => (dispatch, getSta
         // Resolve new account state
         return result;
     });
+};
+
+/**
+ * Assign account index to each account if not already assigned
+ *
+ * @method assignAccountIndexIfNecessary
+ * @param {object} accountInfo
+ *
+ * @returns {function(*)}
+ */
+export const assignAccountIndexIfNecessary = (accountInfo) => (dispatch) => {
+    if (!isEmpty(accountInfo) && some(accountInfo, ({ index }) => !isNumber(index))) {
+        dispatch(assignAccountIndex());
+    }
 };

--- a/src/shared/actions/accounts.js
+++ b/src/shared/actions/accounts.js
@@ -425,10 +425,14 @@ export const getFullAccountInfo = (seedStore, accountName) => {
             .then(({ node, result }) => {
                 dispatch(changeNode(node));
 
-                dispatch(setSeedIndex(existingAccountNames.length));
+                const seedIndex = existingAccountNames.length;
+
+                dispatch(setSeedIndex(seedIndex));
                 dispatch(setBasicAccountInfo({ accountName, usedExistingSeed }));
 
+                // Assign account meta
                 result.accountMeta = getAccountInfoDuringSetup(getState()).meta;
+                result.accountIndex = seedIndex;
 
                 dispatch(fullAccountInfoFetchSuccess(result));
             })

--- a/src/shared/reducers/accounts.js
+++ b/src/shared/reducers/accounts.js
@@ -3,6 +3,7 @@ import has from 'lodash/has';
 import isBoolean from 'lodash/isBoolean';
 import isUndefined from 'lodash/isUndefined';
 import isEmpty from 'lodash/isEmpty';
+import keys from 'lodash/keys';
 import some from 'lodash/some';
 import map from 'lodash/map';
 import mapValues from 'lodash/mapValues';
@@ -378,6 +379,17 @@ const account = (
                         action.payload.bundleHash,
                     ),
                 },
+            };
+        case ActionTypes.ASSIGN_ACCOUNT_INDEX:
+            return {
+                ...state,
+                accountInfo: transform(
+                    keys(state.accountInfo),
+                    (acc, name, index) => {
+                        acc[name] = { ...state.accountInfo[name], index };
+                    },
+                    {},
+                ),
             };
         default:
             return state;

--- a/src/shared/reducers/accounts.js
+++ b/src/shared/reducers/accounts.js
@@ -89,6 +89,8 @@ const updateAccountInfo = (state, payload) => ({
         ...state.accountInfo,
         [payload.accountName]: {
             ...get(state.accountInfo, `${payload.accountName}`),
+            // Set seed index
+            index: payload.accountIndex || get(state.accountInfo, `${payload.accountName}.index`),
             meta: payload.accountMeta || get(state.accountInfo, `${payload.accountName}.meta`) || { type: 'keychain' },
             balance: payload.balance,
             addresses: mergeAddressData(get(state.accountInfo, `${payload.accountName}.addresses`), payload.addresses),
@@ -261,6 +263,8 @@ const account = (
                 accountInfo: {
                     ...state.accountInfo,
                     [action.payload.accountName]: {
+                        // Preserve the account index
+                        index: get(state.accountInfo, `${action.payload.accountName}.index`),
                         meta: get(state.accountInfo, `${action.payload.accountName}.meta`) || { type: 'keychain' },
                         balance: action.payload.balance,
                         addresses: mergeAddressData(
@@ -288,6 +292,7 @@ const account = (
                 accountInfo: {
                     ...state.accountInfo,
                     [action.payload.accountName]: {
+                        index: get(state.accountInfo, `${action.payload.accountName}.index`),
                         meta: get(state.accountInfo, `${action.payload.accountName}.meta`) || { type: 'keychain' },
                         balance: action.payload.balance,
                         addresses: setAddressData(

--- a/src/shared/reducers/accounts.js
+++ b/src/shared/reducers/accounts.js
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 import has from 'lodash/has';
 import isBoolean from 'lodash/isBoolean';
+import isUndefined from 'lodash/isUndefined';
 import isEmpty from 'lodash/isEmpty';
 import some from 'lodash/some';
 import map from 'lodash/map';
@@ -90,7 +91,9 @@ const updateAccountInfo = (state, payload) => ({
         [payload.accountName]: {
             ...get(state.accountInfo, `${payload.accountName}`),
             // Set seed index
-            index: payload.accountIndex || get(state.accountInfo, `${payload.accountName}.index`),
+            index: isUndefined(payload.accountIndex)
+                ? get(state.accountInfo, `${payload.accountName}.index`)
+                : payload.accountIndex,
             meta: payload.accountMeta || get(state.accountInfo, `${payload.accountName}.meta`) || { type: 'keychain' },
             balance: payload.balance,
             addresses: mergeAddressData(get(state.accountInfo, `${payload.accountName}.addresses`), payload.addresses),

--- a/src/shared/reducers/accounts.js
+++ b/src/shared/reducers/accounts.js
@@ -17,6 +17,30 @@ import { ActionTypes as TransfersActionTypes } from '../actions/transfers';
 import { renameKeys } from '../libs/utils';
 
 /**
+ * Removes account name from account info and reorders account indexes (Fill in missing gaps)
+ *
+ * @method removeAccountAndReorderIndexes
+ * @param {object} accountInfo
+ * @param {string} accountNameToDelete
+ *
+ * @returns {object}
+ */
+export const removeAccountAndReorderIndexes = (accountInfo, accountNameToDelete) => {
+    if (!has(accountInfo, accountNameToDelete)) {
+        return accountInfo;
+    }
+
+    const { index } = accountInfo[accountNameToDelete];
+
+    return mapValues(
+        // Remove account
+        omit(accountInfo, accountNameToDelete),
+        // Reorder (fill in missing) account indexes
+        (data) => ({ ...data, index: data.index > index ? data.index - 1 : data.index }),
+    );
+};
+
+/**
  * Stop overriding local spend status for a known address
  *
  * @method preserveAddressLocalSpendStatus
@@ -220,7 +244,7 @@ const account = (
         case ActionTypes.REMOVE_ACCOUNT:
             return {
                 ...state,
-                accountInfo: omit(state.accountInfo, action.payload),
+                accountInfo: removeAccountAndReorderIndexes(state.accountInfo, action.payload),
                 failedBundleHashes: omit(state.failedBundleHashes, action.payload),
                 tasks: omit(state.tasks, action.payload),
                 setupInfo: omit(state.setupInfo, action.payload),

--- a/src/shared/selectors/accounts.js
+++ b/src/shared/selectors/accounts.js
@@ -2,6 +2,8 @@ import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import isUndefined from 'lodash/isUndefined';
 import keys from 'lodash/keys';
+import map from 'lodash/map';
+import orderBy from 'lodash/orderBy';
 import findKey from 'lodash/findKey';
 import pickBy from 'lodash/pickBy';
 import reduce from 'lodash/reduce';
@@ -139,10 +141,14 @@ export const selectFirstAddressFromAccountFactory = (accountName) => {
  *   @param {object} state
  *   @returns {array}
  **/
-export const getAccountNamesFromState = createSelector(
-    getAccountsFromState,
-    (state) => (state.accountInfo ? Object.keys(state.accountInfo) : []),
-);
+export const getAccountNamesFromState = createSelector(getAccountsFromState, (state) => {
+    // Get [{ index, name }] for all accounts
+    const accountNames = map(state.accountInfo, ({ index }, name) => ({ index, name }));
+
+    // Order them by (account) index
+    const getAccountName = ({ name }) => name;
+    return map(orderBy(accountNames, ['index']), getAccountName);
+});
 
 /**
  *   Selects seedIndex prop from wallet reducer state object.


### PR DESCRIPTION
# Description

- Assign `index` to each account in account state
- Ensure accounts order is preserved
- Add auto-assignment of account index (For version updates)

## Type of change

- Bug fix 
- Enhancement 

# How Has This Been Tested?

- Unit test coverage
- WIP: Manual testing (mobile & desktop)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
