### PR TITLE
Preserve order of themes via indexes in ThemeCustomisation component

### DIFF
--- a/src/mobile/src/ui/views/wallet/ThemeCustomisation.js
+++ b/src/mobile/src/ui/views/wallet/ThemeCustomisation.js
@@ -138,7 +138,7 @@ class ThemeCustomisation extends Component {
         this.state = {
             theme: props.theme,
             themeName: props.themeName,
-            themes: Object.keys(THEMES),
+            themes: Object.keys(THEMES).map((theme, index) => ({ theme, index })),
         };
     }
 
@@ -165,14 +165,20 @@ class ThemeCustomisation extends Component {
 
     getLocalizedThemes() {
         const localizedThemes = this.state.themes.map((item) => {
-            return this.getLocalizedThemeName(item);
+            return {
+                ...item,
+                theme: this.getLocalizedThemeName(item.theme),
+            };
         });
+
         return localizedThemes;
     }
 
     getThemeName(localizedThemeName) {
         const localizedThemes = this.getLocalizedThemes();
-        return this.state.themes[localizedThemes.indexOf(localizedThemeName)];
+        const { index } = localizedThemes.find(({ theme }) => theme === localizedThemeName);
+
+        return this.state.themes.find((value) => value.index === index).theme;
     }
 
     render() {
@@ -201,7 +207,7 @@ class ThemeCustomisation extends Component {
                                 background
                                 shadow
                                 defaultOption={this.getLocalizedThemeName(themeName)}
-                                options={this.getLocalizedThemes()}
+                                options={this.getLocalizedThemes().map(({ theme }) => theme)}
                                 saveSelection={(localizedSelection) => {
                                     const selection = this.getThemeName(localizedSelection);
                                     const newTHEMES = cloneDeep(THEMES);


### PR DESCRIPTION
# Description

Upgrade to RN 0.57 has caused [issue](https://github.com/facebook/react-native/issues/22520) where `Object.keys` no longer preserves the order of keys of an object. This has affected several areas including [this](https://github.com/iotaledger/trinity-wallet/pull/715).

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested iOS debug mode

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
