### PR TITLE
Desktop: Add two-factor authorisation to Password modal

### DIFF
--- a/src/desktop/src/ui/components/modal/Password.js
+++ b/src/desktop/src/ui/components/modal/Password.js
@@ -38,6 +38,9 @@ class ModalPassword extends PureComponent {
          * @param {object} SeedStore - SeedStore content
          */
         onSuccess: PropTypes.func,
+        /** On password entered event callback
+         */
+        onSubmit: PropTypes.func,
         /** Create a notification message
          * @param {string} type - notification type - success, error
          * @param {string} title - notification title
@@ -76,10 +79,14 @@ class ModalPassword extends PureComponent {
 
     handleSubmit = async (e) => {
         const { password, code, verifyTwoFA } = this.state;
-        const { skip2fa, onSuccess, generateAlert, t } = this.props;
+        const { skip2fa, onSuccess, onSubmit, generateAlert, t } = this.props;
 
         if (e) {
             e.preventDefault();
+        }
+
+        if (onSubmit) {
+            return onSubmit(password);
         }
 
         let authorised = false;

--- a/src/desktop/src/ui/components/modal/Password.js
+++ b/src/desktop/src/ui/components/modal/Password.js
@@ -2,11 +2,13 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { withI18n } from 'react-i18next';
 import { connect } from 'react-redux';
+import authenticator from 'authenticator';
 
 import { hash, authorize } from 'libs/crypto';
 
 import { generateAlert } from 'actions/alerts';
 
+import Text from 'ui/components/input/Text';
 import Password from 'ui/components/input/Password';
 import Button from 'ui/components/Button';
 import Modal from 'ui/components/modal/Modal';
@@ -25,6 +27,8 @@ class ModalPassword extends PureComponent {
         isOpen: PropTypes.bool,
         /** Should the dialog be without a cancel option */
         isForced: PropTypes.bool,
+        /** Should 2fa authorisation be skipped */
+        skip2fa: PropTypes.bool,
         /** Modal inline style state */
         inline: PropTypes.bool,
         /** On dialog close event */
@@ -34,9 +38,6 @@ class ModalPassword extends PureComponent {
          * @param {object} SeedStore - SeedStore content
          */
         onSuccess: PropTypes.func,
-        /** On password entered event callback
-         */
-        onSubmit: PropTypes.func,
         /** Create a notification message
          * @param {string} type - notification type - success, error
          * @param {string} title - notification title
@@ -53,6 +54,8 @@ class ModalPassword extends PureComponent {
 
     state = {
         password: '',
+        code: '',
+        verifyTwoFA: false,
     };
 
     componentWillReceiveProps(nextProps) {
@@ -63,20 +66,41 @@ class ModalPassword extends PureComponent {
         }
     }
 
-    onSubmit = async (e) => {
-        const { password } = this.state;
-        const { onSubmit, onSuccess, generateAlert, t } = this.props;
+    /**
+     * Update 2fa code value and trigger authentication once necessary length is reached
+     * @param {string} value - Code value
+     */
+    setCode = (value) => {
+        this.setState({ code: value }, () => value.length === 6 && this.handleSubmit());
+    };
 
-        e.preventDefault();
+    handleSubmit = async (e) => {
+        const { password, code, verifyTwoFA } = this.state;
+        const { skip2fa, onSuccess, generateAlert, t } = this.props;
 
-        if (onSubmit) {
-            return onSubmit(password);
+        if (e) {
+            e.preventDefault();
         }
+
+        let authorised = false;
 
         const passwordHash = await hash(password);
 
         try {
-            await authorize(passwordHash);
+            authorised = await authorize(passwordHash);
+
+            if (!skip2fa && typeof authorised === 'string' && !authenticator.verifyToken(authorised, code)) {
+                if (verifyTwoFA) {
+                    generateAlert('error', t('twoFA:wrongCode'), t('twoFA:wrongCodeExplanation'));
+                }
+
+                this.setState({
+                    verifyTwoFA: true,
+                    code: '',
+                });
+
+                return;
+            }
         } catch (err) {
             generateAlert(
                 'error',
@@ -89,15 +113,14 @@ class ModalPassword extends PureComponent {
         onSuccess(passwordHash);
     };
 
-    render() {
-        const { content, category, isOpen, isForced, inline, onClose, t } = this.props;
+    passwordContent = () => {
+        const { content, category, isOpen, isForced, onClose, t } = this.props;
         const { password } = this.state;
-
         return (
-            <Modal variant="confirm" inline={inline} isOpen={isOpen} isForced={isForced} onClose={() => onClose()}>
+            <React.Fragment>
                 {content.title ? <h1 className={category ? category : null}>{content.title}</h1> : null}
                 {content.message ? <p>{content.message}</p> : null}
-                <form onSubmit={(e) => this.onSubmit(e)}>
+                <form onSubmit={(e) => this.handleSubmit(e)}>
                     <Password
                         value={password}
                         focus={isOpen}
@@ -105,16 +128,50 @@ class ModalPassword extends PureComponent {
                         onChange={(value) => this.setState({ password: value })}
                     />
                     <footer>
-                        {!isForced ? (
+                        {!isForced && (
                             <Button onClick={() => onClose()} variant="dark">
                                 {t('cancel')}
                             </Button>
-                        ) : null}
+                        )}
                         <Button type="submit" variant={category ? category : 'primary'}>
                             {content.confirm ? content.confirm : t('login:login')}
                         </Button>
                     </footer>
                 </form>
+            </React.Fragment>
+        );
+    };
+
+    twoFaContent = () => {
+        const { isForced, onClose, t } = this.props;
+        const { code } = this.state;
+        return (
+            <React.Fragment>
+                <p>{t('twoFA:enterCode')}</p>
+                <form onSubmit={(e) => this.handleSubmit(e)}>
+                    <Text value={code} focus label={t('twoFA:code')} onChange={this.setCode} />
+                    <footer>
+                        {!isForced && (
+                            <Button onClick={() => onClose()} variant="dark">
+                                {t('cancel')}
+                            </Button>
+                        )}
+                        <Button type="submit" variant="primary">
+                            {t('login:login')}
+                        </Button>
+                    </footer>
+                </form>
+            </React.Fragment>
+        );
+    };
+
+    render() {
+        const { isOpen, isForced, inline, onClose } = this.props;
+        const { verifyTwoFA } = this.state;
+
+        return (
+            <Modal variant="confirm" isOpen={isOpen} inline={inline} isForced={isForced} onClose={() => onClose()}>
+                {verifyTwoFA ? this.twoFaContent() : this.passwordContent()}
             </Modal>
         );
     }
@@ -124,4 +181,7 @@ const mapDispatchToProps = {
     generateAlert,
 };
 
-export default connect(null, mapDispatchToProps)(withI18n()(ModalPassword));
+export default connect(
+    null,
+    mapDispatchToProps,
+)(withI18n()(ModalPassword));

--- a/src/desktop/src/ui/global/Idle.js
+++ b/src/desktop/src/ui/global/Idle.js
@@ -89,7 +89,7 @@ class Idle extends React.Component {
         if (!this.state.locked) {
             return null;
         }
-        return <ModalPassword isOpen isForced content={{}} onSuccess={(password) => this.unlock(password)} />;
+        return <ModalPassword isOpen isForced skip2fa content={{}} onSuccess={(password) => this.unlock(password)} />;
     }
 }
 
@@ -102,4 +102,7 @@ const mapDispatchToProps = {
     setPassword,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Idle);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(Idle);


### PR DESCRIPTION
# Description

Add two-factor authorisation to Password modal, enabling 2fa authorisation at View Seed and Reset wallet views.

Fixes #642 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested manually on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
