### PR TITLE
Fix failing tests for QrScanner component

### DIFF
--- a/src/mobile/__tests__/ui/components/QrScanner.spec.js
+++ b/src/mobile/__tests__/ui/components/QrScanner.spec.js
@@ -55,7 +55,7 @@ describe('Testing QrScanner component', () => {
             const props = getProps();
 
             const wrapper = shallow(<QrScannerComponent {...props} />);
-            expect(wrapper.find('QRscanner').length).toEqual(1);
+            expect(wrapper.childAt(0).childAt(0).length).toEqual(1);
         });
 
         it('should call prop method onQRRead when onRead prop of QRscanner is triggered', () => {
@@ -68,7 +68,8 @@ describe('Testing QrScanner component', () => {
             expect(props.onQRRead).toHaveBeenCalledTimes(0);
 
             wrapper
-                .find('QRscanner')
+                .childAt(0)
+                .childAt(0)
                 .props()
                 .onRead({ data: 'foo' });
 


### PR DESCRIPTION
# Description

Enzyme fails to find the root element of the new QrScanner [lib](https://github.com/shifeng1993/react-native-qr-scanner) leading to failing tests. This PR fixes them. 

## Type of change

- Bug fix 

# How Has This Been Tested?

Manually tested by checking tests for mobile

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
