### PR TITLE
Desktop: Fix whatIsAChecksum string

### DIFF
--- a/src/desktop/src/ui/views/onboarding/SeedSaveWrite.js
+++ b/src/desktop/src/ui/views/onboarding/SeedSaveWrite.js
@@ -63,7 +63,7 @@ class SeedSave extends PureComponent {
                         </div>
                         <div>
                             <Tooltip
-                                title={t('saveYourSeed:whatIsChecksum')}
+                                title={t('saveYourSeed:whatIsAChecksum')}
                                 tip={t('saveYourSeed:checksumExplanation')}
                             />{' '}
                             {t('checksum')}: <strong>{checksum}</strong>


### PR DESCRIPTION
# Description
Fixes typo that caused `Translation not available for whatIsChecksum` error since the string was titled `whatIsAChecksum`

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


# How Has This Been Tested?

- Tested manually on macOS


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes