### PR TITLE
Make sure accounts are always iterated in correct order 

### DIFF
--- a/src/desktop/npm-shrinkwrap.json
+++ b/src/desktop/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
     "name": "trinity-desktop",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -2426,7 +2426,7 @@
                 },
                 "camelcase-keys": {
                     "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                    "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
                     "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                     "dev": true,
                     "requires": {
@@ -2455,7 +2455,7 @@
                 },
                 "load-json-file": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                    "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
@@ -2474,7 +2474,7 @@
                 },
                 "meow": {
                     "version": "3.7.0",
-                    "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+                    "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
                     "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                     "dev": true,
                     "requires": {
@@ -2533,7 +2533,7 @@
                 },
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 },
@@ -2569,7 +2569,7 @@
                         },
                         "load-json-file": {
                             "version": "2.0.0",
-                            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
                             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
                             "dev": true,
                             "requires": {
@@ -3435,7 +3435,7 @@
                 },
                 "regjsgen": {
                     "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+                    "resolved": "http://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
                     "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
                     "dev": true
                 },
@@ -7412,7 +7412,7 @@
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                     "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                     "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -8032,7 +8032,6 @@
                             "version": "0.0.9",
                             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
                             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-                            "optional": true,
                             "requires": {
                                 "inherits": "~2.0.0"
                             }
@@ -8041,7 +8040,6 @@
                             "version": "2.10.1",
                             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                            "optional": true,
                             "requires": {
                                 "hoek": "2.x.x"
                             }
@@ -8051,15 +8049,14 @@
                             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                             "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                             "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                             }
                         },
                         "buffer-shims": {
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                            "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-                            "optional": true
+                            "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
                         },
                         "caseless": {
                             "version": "0.11.0",
@@ -8091,14 +8088,12 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                            "optional": true
+                            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
                         },
                         "combined-stream": {
                             "version": "1.0.5",
                             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-                            "optional": true,
                             "requires": {
                                 "delayed-stream": "~1.0.0"
                             }
@@ -8121,14 +8116,12 @@
                             "version": "1.1.0",
                             "resolved":
                                 "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-                            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-                            "optional": true
+                            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
                         },
                         "core-util-is": {
                             "version": "1.0.2",
                             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                            "optional": true
+                            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                         },
                         "cryptiles": {
                             "version": "2.0.5",
@@ -8160,6 +8153,7 @@
                             "version": "2.2.0",
                             "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                             "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+                            "optional": true,
                             "requires": {
                                 "ms": "0.7.1"
                             }
@@ -8167,13 +8161,13 @@
                         "deep-extend": {
                             "version": "0.4.1",
                             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                            "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM="
+                            "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
+                            "optional": true
                         },
                         "delayed-stream": {
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                            "optional": true
+                            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                         },
                         "delegates": {
                             "version": "1.0.0",
@@ -8206,8 +8200,7 @@
                         "extsprintf": {
                             "version": "1.0.2",
                             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                            "optional": true
+                            "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
                         },
                         "forever-agent": {
                             "version": "0.6.1",
@@ -8407,7 +8400,6 @@
                             "resolved":
                                 "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -8439,8 +8431,7 @@
                         "isarray": {
                             "version": "1.0.0",
                             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                            "optional": true
+                            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                         },
                         "isstream": {
                             "version": "0.1.2",
@@ -8496,14 +8487,12 @@
                         "mime-db": {
                             "version": "1.25.0",
                             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
-                            "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
-                            "optional": true
+                            "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I="
                         },
                         "mime-types": {
                             "version": "2.1.13",
                             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
                             "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-                            "optional": true,
                             "requires": {
                                 "mime-db": "~1.25.0"
                             }
@@ -8576,8 +8565,7 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                            "optional": true
+                            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                         },
                         "oauth-sign": {
                             "version": "0.8.2",
@@ -8623,8 +8611,7 @@
                             "version": "1.0.7",
                             "resolved":
                                 "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                            "optional": true
+                            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
                         },
                         "punycode": {
                             "version": "1.4.1",
@@ -8635,7 +8622,8 @@
                         "qs": {
                             "version": "6.3.0",
                             "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-                            "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI="
+                            "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
+                            "optional": true
                         },
                         "rc": {
                             "version": "1.1.6",
@@ -8643,6 +8631,7 @@
                             "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
                             "optional": true,
                             "requires": {
+                                "deep-extend": "~0.4.0",
                                 "ini": "~1.3.0",
                                 "minimist": "^1.2.0",
                                 "strip-json-comments": "~1.0.4"
@@ -8692,7 +8681,10 @@
                                 "json-stringify-safe": "~5.0.1",
                                 "mime-types": "~2.1.7",
                                 "oauth-sign": "~0.8.1",
+                                "qs": "~6.3.0",
                                 "stringstream": "~0.0.4",
+                                "tough-cookie": "~2.3.0",
+                                "tunnel-agent": "~0.4.1",
                                 "uuid": "^3.0.0"
                             }
                         },
@@ -8737,15 +8729,15 @@
                             "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
                             "optional": true,
                             "requires": {
-                                "asn1": "0.2.3",
-                                "assert-plus": "1.0.0",
-                                "bcrypt-pbkdf": "1.0.0",
-                                "dashdash": "1.14.1",
-                                "ecc-jsbn": "0.1.1",
-                                "getpass": "0.1.6",
-                                "jodid25519": "1.0.2",
-                                "jsbn": "0.1.0",
-                                "tweetnacl": "0.14.5"
+                                "asn1": "~0.2.3",
+                                "assert-plus": "^1.0.0",
+                                "bcrypt-pbkdf": "^1.0.0",
+                                "dashdash": "^1.12.0",
+                                "ecc-jsbn": "~0.1.1",
+                                "getpass": "^0.1.1",
+                                "jodid25519": "^1.0.0",
+                                "jsbn": "~0.1.0",
+                                "tweetnacl": "~0.14.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
@@ -8760,7 +8752,6 @@
                             "version": "1.0.2",
                             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -8770,8 +8761,7 @@
                         "string_decoder": {
                             "version": "0.10.31",
                             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                            "optional": true
+                            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         },
                         "stringstream": {
                             "version": "0.0.5",
@@ -8804,7 +8794,6 @@
                             "version": "2.2.1",
                             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
                             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-                            "optional": true,
                             "requires": {
                                 "block-stream": "*",
                                 "fstream": "^1.0.2",
@@ -8817,6 +8806,7 @@
                             "integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
                             "optional": true,
                             "requires": {
+                                "debug": "~2.2.0",
                                 "fstream": "~1.0.10",
                                 "fstream-ignore": "~1.0.5",
                                 "once": "~1.3.3",
@@ -8857,14 +8847,16 @@
                             "version": "2.3.2",
                             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                             "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+                            "optional": true,
                             "requires": {
-                                "punycode": "1.4.1"
+                                "punycode": "^1.4.1"
                             }
                         },
                         "tunnel-agent": {
                             "version": "0.4.3",
                             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-                            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+                            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+                            "optional": true
                         },
                         "tweetnacl": {
                             "version": "0.14.5",
@@ -8881,8 +8873,7 @@
                         "util-deprecate": {
                             "version": "1.0.2",
                             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-                            "optional": true
+                            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                         },
                         "uuid": {
                             "version": "3.0.1",
@@ -9309,6 +9300,7 @@
                         "console-browserify": "1.1.x",
                         "exit": "0.1.x",
                         "htmlparser2": "3.8.x",
+                        "lodash": "3.7.x",
                         "minimatch": "~3.0.2",
                         "shelljs": "0.3.x",
                         "strip-json-comments": "1.0.x"
@@ -9568,6 +9560,7 @@
                     "requires": {
                         "browser-stdout": "1.3.0",
                         "commander": "2.9.0",
+                        "debug": "2.2.0",
                         "diff": "1.4.0",
                         "escape-string-regexp": "1.0.5",
                         "glob": "7.0.5",
@@ -9836,6 +9829,7 @@
                     "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
                     "integrity": "sha1-oJY6ZDfQnvjLktky0trUl7DRc2w=",
                     "requires": {
+                        "lodash": "~2.4.1",
                         "rcfinder": "~0.1.6"
                     },
                     "dependencies": {
@@ -9911,7 +9905,10 @@
                         "mime-types": "~2.1.7",
                         "node-uuid": "~1.4.7",
                         "oauth-sign": "~0.8.1",
-                        "stringstream": "~0.0.4"
+                        "qs": "~6.2.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1"
                     }
                 },
                 "resolve": {
@@ -10006,15 +10003,15 @@
                     "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
                     "integrity": "sha1-1agEziJpVRVjjnmNviMnPeBwpfo=",
                     "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.0",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.6",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.0",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -10121,7 +10118,7 @@
                     "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                     "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tty-browserify": {

--- a/src/desktop/src/ui/components/Balance.js
+++ b/src/desktop/src/ui/components/Balance.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withI18n } from 'react-i18next';
 
+import { getAccountNamesFromState } from 'selectors/accounts';
+
 import { formatValue, formatUnit } from 'libs/iota/utils';
 import { round, roundDown } from 'libs/utils';
 import { getCurrencySymbol } from 'libs/currency';
@@ -28,6 +30,8 @@ class Balance extends React.PureComponent {
         seedIndex: PropTypes.number.isRequired,
         /** @ignore */
         accounts: PropTypes.object.isRequired,
+        /** Wallet account names */
+        accountNames: PropTypes.array.isRequired,
         /** @ignore */
         settings: PropTypes.object.isRequired,
         /** @ignore */
@@ -58,13 +62,20 @@ class Balance extends React.PureComponent {
     }
 
     render() {
-        const { summary, index, accounts, switchAccount, seedIndex, settings, marketData, t } = this.props;
+        const {
+            summary,
+            index,
+            accounts,
+            accountNames,
+            switchAccount,
+            seedIndex,
+            settings,
+            marketData,
+            t,
+        } = this.props;
         const { balanceIsShort } = this.state;
 
-        const accountName =
-            summary && index === -1
-                ? t('totalBalance')
-                : Object.keys(accounts.accountInfo)[summary ? index : seedIndex];
+        const accountName = summary && index === -1 ? t('totalBalance') : accountNames[summary ? index : seedIndex];
 
         const accountBalance =
             summary && index === -1
@@ -108,6 +119,7 @@ class Balance extends React.PureComponent {
 const mapStateToProps = (state) => ({
     seedIndex: state.wallet.seedIndex,
     accounts: state.accounts,
+    accountNames: getAccountNamesFromState(state),
     marketData: state.marketData,
     settings: state.settings,
 });

--- a/src/desktop/src/ui/views/settings/Index.js
+++ b/src/desktop/src/ui/views/settings/Index.js
@@ -5,6 +5,7 @@ import { withI18n } from 'react-i18next';
 import { connect } from 'react-redux';
 
 import { shorten } from 'libs/iota/converter';
+import { getAccountNamesFromState } from 'selectors/accounts';
 
 import Icon from 'ui/components/Icon';
 import Scrollbar from 'ui/components/Scrollbar';
@@ -33,6 +34,8 @@ class Settings extends React.PureComponent {
     static propTypes = {
         /** @ignore */
         accounts: PropTypes.object,
+        /** Wallet account names */
+        accountNames: PropTypes.array.isRequired,
         /** @ignore */
         wallet: PropTypes.object,
         /** @ignore */
@@ -48,13 +51,12 @@ class Settings extends React.PureComponent {
     };
 
     render() {
-        const { accounts, location, wallet, history, t } = this.props;
+        const { accounts, accountNames, location, wallet, history, t } = this.props;
         const { accountIndex } = this.props.match.params;
 
         const backRoute = wallet.ready ? '/wallet/' : '/onboarding/';
 
         const accountSettings = typeof accountIndex === 'string';
-        const accountNames = Object.keys(accounts);
 
         const account = accountSettings
             ? { ...accounts[accountNames[accountIndex]], ...{ accountName: accountNames[accountIndex], accountIndex } }
@@ -198,6 +200,7 @@ class Settings extends React.PureComponent {
 
 const mapStateToProps = (state) => ({
     accounts: state.accounts.accountInfo,
+    accountNames: getAccountNamesFromState(state),
     wallet: state.wallet,
 });
 

--- a/src/desktop/src/ui/views/wallet/Sidebar.js
+++ b/src/desktop/src/ui/views/wallet/Sidebar.js
@@ -9,6 +9,7 @@ import { shorten, capitalize } from 'libs/iota/converter';
 import { formatIota } from 'libs/iota/utils';
 
 import { clearWalletData, setSeedIndex } from 'actions/wallet';
+import { getAccountNamesFromState } from 'selectors/accounts';
 
 import Logo from 'ui/components/Logo';
 import Icon from 'ui/components/Icon';
@@ -22,6 +23,8 @@ import css from './index.scss';
  */
 class Sidebar extends React.PureComponent {
     static propTypes = {
+        /** Account names for wallet */
+        accountNames: PropTypes.array.isRequired,
         /** @ignore */
         location: PropTypes.object,
         /** @ignore */
@@ -80,7 +83,8 @@ class Sidebar extends React.PureComponent {
     };
 
     render() {
-        const { accounts, seedIndex, setSeedIndex, t, location, history, isBusy } = this.props;
+        // Use accountNames prop for displaying account names here because accountNames prop preserves the account index
+        const { accountNames, accounts, seedIndex, setSeedIndex, t, location, history, isBusy } = this.props;
         const { modalLogout } = this.state;
 
         return (
@@ -96,7 +100,7 @@ class Sidebar extends React.PureComponent {
                         </a>
                         <ul>
                             <Scrollbar>
-                                {Object.keys(accounts.accountInfo).map((account, index) => {
+                                {accountNames.map((account, index) => {
                                     return (
                                         <a
                                             aria-current={index === seedIndex}
@@ -147,6 +151,7 @@ class Sidebar extends React.PureComponent {
 }
 
 const mapStateToProps = (state) => ({
+    accountNames: getAccountNamesFromState(state),
     accounts: state.accounts,
     seedIndex: state.wallet.seedIndex,
     isBusy:

--- a/src/shared/containers/components/List.js
+++ b/src/shared/containers/components/List.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 import map from 'lodash/map';
 import { connect } from 'react-redux';
 import { withI18n } from 'react-i18next';
-import { getSelectedAccountName, getFailedBundleHashesForSelectedAccount } from '../../selectors/accounts';
+import {
+    getSelectedAccountName,
+    getFailedBundleHashesForSelectedAccount,
+    getAccountNamesFromState,
+} from '../../selectors/accounts';
 
 import { generateAlert } from '../../actions/alerts';
 import { toggleEmptyTransactions } from '../../actions/settings';
@@ -38,6 +42,8 @@ export default function withListData(ListComponent) {
             remotePoW: PropTypes.bool.isRequired,
             generateAlert: PropTypes.func.isRequired,
             failedHashes: PropTypes.object.isRequired,
+            /** Wallet account names */
+            accountNames: PropTypes.array.isRequired,
         };
 
         promoteTransaction = (hash, powFn) => {
@@ -50,6 +56,7 @@ export default function withListData(ListComponent) {
 
         render() {
             const {
+                accountNames,
                 index,
                 seedIndex,
                 accounts,
@@ -72,7 +79,7 @@ export default function withListData(ListComponent) {
 
             const isBusy = ui.isSyncing || ui.isSendingTransfer || ui.isAttachingToTangle || ui.isTransitioning;
 
-            const accountName = Object.keys(accounts.accountInfo)[typeof index === 'number' ? index : seedIndex];
+            const accountName = accountNames[typeof index === 'number' ? index : seedIndex];
 
             if (!accountName && index !== -1) {
                 return null;
@@ -121,6 +128,7 @@ export default function withListData(ListComponent) {
         accounts: state.accounts,
         accountName: getSelectedAccountName(state),
         failedHashes: getFailedBundleHashesForSelectedAccount(state),
+        accountNames: getAccountNamesFromState(state),
         theme: state.settings.theme,
         mode: state.settings.mode,
         ui: state.ui,


### PR DESCRIPTION
# Description

`Object.keys(<object>)` function does not always preserve the order, especially if the object key starts with a number. This causes an issue when `Object.keys` is used for iterating on account names. https://github.com/iotaledger/trinity-wallet/pull/715 adds account indexes to state to make sure the order of accounts is always intact. However, some components in desktop use `Object.keys` directly on accounts object, which leads to certain issues of incorrect references to accounts. This commit fixes this issue by replacing Object.keys implementation on accounts with `getAccountNamesFromState` selector that guarantees the accounts order.

Fixes https://github.com/iotaledger/trinity-wallet/issues/811

Note that the issues `Object.keys` create are not always noticeable. Steps to reproduce these issues are:

- Add account with name "M"
- Add another account with name "0"
- Notice account names order in sidebar (Instead of "0" being the second account, it becomes the first)
- Generate receive address from account "M" (Instead of generating receive address for account "M", it generates receive address for account "0")

## Type of change
- Bug fix

# How Has This Been Tested?

- WIP needs some more testing to see if there are any other affected areas

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
