### PR TITLE
Shared: Rebuild realm after installing dependencies

### DIFF
--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -13,7 +13,8 @@
         "test": "NODE_ENV=test ./node_modules/.bin/mocha --timeout 5000 --exit --require @babel/register \"__tests__/**/*.spec.js\"",
         "test:watch": "yarn test --watch",
         "auditjs": "./../../node_modules/.bin/auditjs -nl error -w whitelist.json",
-        "themes:sync": "node themes/sync.js"
+        "themes:sync": "node themes/sync.js",
+        "postinstall": "npm rebuild realm --build-from-source"
     },
     "license": "Apache-2.0 OR EPL-2.0",
     "dependencies": {


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

Adds a postinstall hook to rebuild `realm` from source after installing dependencies for `shared`. This provides a workaround for https://github.com/realm/realm-js/issues/2180 and prevents Buildkite mobile CI from hanging indefinitely.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- CI passes


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes