### PR TITLE
Handle exceptions on app entry

### DIFF
--- a/src/mobile/src/libs/bugsnag.js
+++ b/src/mobile/src/libs/bugsnag.js
@@ -4,7 +4,7 @@ import packageJson from '../../package';
 const configuration = new Configuration();
 configuration.appVersion = packageJson.version;
 
-const bugsnag = new Client(configuration);
+export const bugsnag = new Client(configuration);
 
 /**
  * Leaves navigation breadcrumbs to help determine what screen an error occurred on

--- a/src/mobile/src/ui/routes/entry.js
+++ b/src/mobile/src/ui/routes/entry.js
@@ -1,5 +1,5 @@
+/* global __DEV__ */
 import get from 'lodash/get';
-import noop from 'lodash/noop';
 import { Navigation } from 'react-native-navigation';
 import { withNamespaces } from 'react-i18next';
 import { Text, TextInput, NetInfo, YellowBox } from 'react-native';
@@ -17,6 +17,7 @@ import { getLocaleFromLabel } from 'shared-modules/libs/i18n';
 import { clearKeychain } from 'libs/keychain';
 import { getDigestFn } from 'libs/nativeModules';
 import { persistStoreAsync, migrate, versionCheck, resetIfKeychainIsEmpty } from 'libs/store';
+import { bugsnag } from 'libs/bugsnag';
 import registerScreens from 'ui/routes/navigation';
 
 const launch = (store) => {
@@ -190,4 +191,8 @@ onAppStart()
 
         hasConnection('https://iota.org').then((isConnected) => initialize(isConnected));
     })
-    .catch(noop);
+    .catch((error) => {
+        const fn = __DEV__ ? console.error : bugsnag.notify; // eslint-disable-line no-console
+
+        return fn(error);
+    });


### PR DESCRIPTION
# Description

- Report unhandled exception to bugsnag in production mode
- Display full screen alert in development mode

## Type of change

- Enhancement

# How Has This Been Tested?

- Manually tested on android (dev mode) by forcing an exception on app entry.

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
