### PR TITLE
Mobile: Refactor Gemfiles so that Dependabot can fully parse them

### DIFF
--- a/src/mobile/android/Gemfile
+++ b/src/mobile/android/Gemfile
@@ -3,5 +3,4 @@ source "https://rubygems.org"
 gem "fastlane"
 gem "nokogiri"
 
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)
+eval_gemfile('./fastlane/Pluginfile') if File.exist?('./fastlane/Pluginfile')

--- a/src/mobile/ios/Gemfile
+++ b/src/mobile/ios/Gemfile
@@ -6,5 +6,4 @@ source "https://rubygems.org"
 
 gem 'fastlane'
 
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)
+eval_gemfile('./fastlane/Pluginfile') if File.exist?('./fastlane/Pluginfile')


### PR DESCRIPTION
# Description
Refactors Gemfiles so that Dependabot can fully parse them and see all dependencies. This should fix issues where Dependabot accidentally removes fastlane plugins from the Gemfile.lock.

See https://github.com/dependabot/dependabot-core/issues/863

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
N/A


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
