### PR TITLE
Fix byteTrit check

### DIFF
--- a/src/desktop/npm-shrinkwrap.json
+++ b/src/desktop/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
     "name": "trinity-desktop",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/desktop/src/ui/views/wallet/Index.js
+++ b/src/desktop/src/ui/views/wallet/Index.js
@@ -58,7 +58,7 @@ class Wallet extends React.PureComponent {
     byteTritCheck = () => {
         const { accountData, password } = this.props;
         const accounts = Object.keys(accountData).map(async (accountName) => {
-            if (accountData[accountName].type !== 'keychain') {
+            if (accountData[accountName].meta.type !== 'keychain') {
                 return null;
             }
             try {


### PR DESCRIPTION
# Description

Due to a bug in desktop version 0.3.4, byte-trit check is performed for recovering funds to a safe address. However, this check was being bypassed because of an incorrect reference to account "type" property. This PR fixes the issue.

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested on desktop (dev mode)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
