### PR TITLE
Add additional spend status check

### DIFF
--- a/src/mobile/src/libs/progressSteps.js
+++ b/src/mobile/src/libs/progressSteps.js
@@ -6,6 +6,7 @@ export default {
         'progressSteps:preparingTransfers',
         'progressSteps:gettingTransactionsToApprove',
         'progressSteps:proofOfWork',
+        'progressSteps:validatingTransactionAddresses',
         'progressSteps:broadcasting',
     ],
     zeroValueTransaction: [

--- a/src/shared/__tests__/actions/transfers.spec.js
+++ b/src/shared/__tests__/actions/transfers.spec.js
@@ -383,7 +383,7 @@ describe('actions: transfers', () => {
             });
 
             describe('when transaction is successful', () => {
-                it('should create eight actions of type IOTA/PROGRESS/SET_NEXT_STEP_AS_ACTIVE', () => {
+                it('should create nine actions of type IOTA/PROGRESS/SET_NEXT_STEP_AS_ACTIVE', () => {
                     const wereAddressesSpentFrom = sinon.stub(iota.api, 'wereAddressesSpentFrom').yields(null, [false]);
                     const store = mockStore({ accounts });
 
@@ -425,7 +425,7 @@ describe('actions: transfers', () => {
                                     .getActions()
                                     .map((action) => action.type)
                                     .filter((type) => type === 'IOTA/PROGRESS/SET_NEXT_STEP_AS_ACTIVE').length,
-                            ).to.equal(8);
+                            ).to.equal(9);
 
                             syncAccountAfterSpending.restore();
                             syncAccount.restore();

--- a/src/shared/containers/wallet/Send.js
+++ b/src/shared/containers/wallet/Send.js
@@ -82,6 +82,7 @@ export default function withSendData(SendComponent) {
                       t('progressSteps:preparingTransfers'),
                       t('progressSteps:gettingTransactionsToApprove'),
                       t('progressSteps:proofOfWork'),
+                      t('progressSteps:validatingTransactionAddresses'),
                       t('progressSteps:broadcasting'),
                   ];
 

--- a/src/shared/libs/iota/addresses.js
+++ b/src/shared/libs/iota/addresses.js
@@ -405,19 +405,17 @@ export const filterSpentAddresses = (provider) => (inputs, addressData, normalis
 };
 
 /**
- *   Communicates with ledger and checks if the addresses are spent from.
+ *   Communicates with ledger and checks if the any address is spent.
  *
- *   @method shouldAllowSendingToAddress
+ *   @method isAnyAddressSpent
  *   @param {string} [provider]
  *
  *   @returns {function(array): Promise<boolean>}
  **/
-export const shouldAllowSendingToAddress = (provider) => (addresses) => {
-    return wereAddressesSpentFromAsync(provider)(addresses).then((wereSpent) => {
-        const spentAddresses = filter(addresses, (address, idx) => wereSpent[idx]);
-
-        return !spentAddresses.length;
-    });
+export const isAnyAddressSpent = (provider) => (addresses) => {
+    return wereAddressesSpentFromAsync(provider)(addresses).then((spendStatuses) =>
+        some(spendStatuses, (spendStatus) => spendStatus === true),
+    );
 };
 
 /**

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -705,6 +705,7 @@
     "progressSteps": {
         "checkingNodeHealth": "Checking node health",
         "validatingReceiveAddress": "Validating receive address",
+        "validatingTransactionAddresses": "Validating transaction addresses",
         "syncingAccount": "Syncing account",
         "preparingInputs": "Preparing inputs",
         "preparingTransfers": "Preparing transfers",


### PR DESCRIPTION
# Description

Add additional spend status check for all inputs and outputs just before broadcast

## Type of change

- Enhancement 

# How Has This Been Tested?

- Manually tested iOS (dev)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
