### PR TITLE
Shared: Fix periodically failing sortTransactionTrytesArray test

### DIFF
--- a/src/shared/__tests__/libs/iota/transfers.spec.js
+++ b/src/shared/__tests__/libs/iota/transfers.spec.js
@@ -4,6 +4,7 @@ import find from 'lodash/find';
 import keys from 'lodash/keys';
 import map from 'lodash/map';
 import shuffle from 'lodash/shuffle';
+import isEqual from 'lodash/isEqual';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import nock from 'nock';
@@ -846,11 +847,20 @@ describe('libs: iota/transfers', () => {
         });
     });
 
-    // FIXME: The following test fails occasionally
     describe('#sortTransactionTrytesArray', () => {
         it('should sort transaction trytes in ascending order', () => {
             // failedTrytesWithCorrectTransactionHashes is in ascending order by default
-            const trytes = shuffle(failedTrytesWithCorrectTransactionHashes);
+            let shuffled = false;
+            let trytes = null;
+
+            // Ensures `trytes` never deeply equals `failedTrytesWithCorrectTransactionHashes`
+            // so that this test does not randomly fail
+            while (!shuffled) {
+                trytes = shuffle(failedTrytesWithCorrectTransactionHashes);
+                if (!isEqual(trytes, failedTrytesWithCorrectTransactionHashes)) {
+                    shuffled = true;
+                }
+            }
             const result = sortTransactionTrytesArray(trytes, 'currentIndex', 'asc');
 
             expect(result).to.not.eql(trytes);
@@ -859,7 +869,17 @@ describe('libs: iota/transfers', () => {
         });
 
         it('should sort transaction trytes in descending order', () => {
-            const trytes = shuffle(failedTrytesWithCorrectTransactionHashes);
+            let shuffled = false;
+            let trytes = null;
+
+            // Ensures `trytes` never deeply equals `failedTrytesWithCorrectTransactionHashes`
+            // so that this test does not randomly fail
+            while (!shuffled) {
+                trytes = shuffle(failedTrytesWithCorrectTransactionHashes);
+                if (!isEqual(trytes, failedTrytesWithCorrectTransactionHashes)) {
+                    shuffled = true;
+                }
+            }
             const result = sortTransactionTrytesArray(trytes);
 
             // failedTrytesWithCorrectTransactionHashes is in ascending order by default to assert with a reversed list

--- a/src/shared/__tests__/libs/iota/transfers.spec.js
+++ b/src/shared/__tests__/libs/iota/transfers.spec.js
@@ -5,7 +5,6 @@ import keys from 'lodash/keys';
 import map from 'lodash/map';
 import shuffle from 'lodash/shuffle';
 import { expect } from 'chai';
-import assert from 'assert';
 import sinon from 'sinon';
 import nock from 'nock';
 import {
@@ -853,7 +852,6 @@ describe('libs: iota/transfers', () => {
             const trytes = failedTrytesWithCorrectTransactionHashes.slice().reverse();
             const result = sortTransactionTrytesArray(trytes, 'currentIndex', 'asc');
 
-            assert(result);
             expect(result).to.eql(failedTrytesWithCorrectTransactionHashes);
             expect(iota.utils.transactionObject(result[0], EMPTY_TRANSACTION_TRYTES).currentIndex).to.equal(0);
         });
@@ -862,7 +860,6 @@ describe('libs: iota/transfers', () => {
             const trytes = failedTrytesWithCorrectTransactionHashes.slice().reverse();
             const result = sortTransactionTrytesArray(trytes);
 
-            assert(result);
             // failedTrytesWithCorrectTransactionHashes is in ascending order by default to assert with a reversed list
             expect(result).to.eql(failedTrytesWithCorrectTransactionHashes.slice().reverse());
             expect(iota.utils.transactionObject(result[0], EMPTY_TRANSACTION_TRYTES).currentIndex).to.equal(2);

--- a/src/shared/__tests__/libs/iota/transfers.spec.js
+++ b/src/shared/__tests__/libs/iota/transfers.spec.js
@@ -4,8 +4,8 @@ import find from 'lodash/find';
 import keys from 'lodash/keys';
 import map from 'lodash/map';
 import shuffle from 'lodash/shuffle';
-import isEqual from 'lodash/isEqual';
 import { expect } from 'chai';
+import assert from 'assert';
 import sinon from 'sinon';
 import nock from 'nock';
 import {
@@ -850,38 +850,19 @@ describe('libs: iota/transfers', () => {
     describe('#sortTransactionTrytesArray', () => {
         it('should sort transaction trytes in ascending order', () => {
             // failedTrytesWithCorrectTransactionHashes is in ascending order by default
-            let shuffled = false;
-            let trytes = null;
-
-            // Ensures `trytes` never deeply equals `failedTrytesWithCorrectTransactionHashes`
-            // so that this test does not randomly fail
-            while (!shuffled) {
-                trytes = shuffle(failedTrytesWithCorrectTransactionHashes);
-                if (!isEqual(trytes, failedTrytesWithCorrectTransactionHashes)) {
-                    shuffled = true;
-                }
-            }
+            const trytes = failedTrytesWithCorrectTransactionHashes.slice().reverse();
             const result = sortTransactionTrytesArray(trytes, 'currentIndex', 'asc');
 
-            expect(result).to.not.eql(trytes);
+            assert(result);
             expect(result).to.eql(failedTrytesWithCorrectTransactionHashes);
             expect(iota.utils.transactionObject(result[0], EMPTY_TRANSACTION_TRYTES).currentIndex).to.equal(0);
         });
 
         it('should sort transaction trytes in descending order', () => {
-            let shuffled = false;
-            let trytes = null;
-
-            // Ensures `trytes` never deeply equals `failedTrytesWithCorrectTransactionHashes`
-            // so that this test does not randomly fail
-            while (!shuffled) {
-                trytes = shuffle(failedTrytesWithCorrectTransactionHashes);
-                if (!isEqual(trytes, failedTrytesWithCorrectTransactionHashes)) {
-                    shuffled = true;
-                }
-            }
+            const trytes = failedTrytesWithCorrectTransactionHashes.slice().reverse();
             const result = sortTransactionTrytesArray(trytes);
 
+            assert(result);
             // failedTrytesWithCorrectTransactionHashes is in ascending order by default to assert with a reversed list
             expect(result).to.eql(failedTrytesWithCorrectTransactionHashes.slice().reverse());
             expect(iota.utils.transactionObject(result[0], EMPTY_TRANSACTION_TRYTES).currentIndex).to.equal(2);


### PR DESCRIPTION
<!---
Hints for a successful PR:
1. It is recommended that before you submit a PR to IOTA, to open an issue first and assign yourself.
This way you may get inputs and discover parallel PRs to the one you want to submit.
2. In case of a big PR, consider breaking it up into smaller PRs. This will help to get it merged in an incremental process.
3. Note that a PR should have a *single* area of responsibility. If your PR does more than one thing than it should be split into several PRs!!!!!
4. It will be helpful if you make additional comments on the code via GitHub PR review to explain the choices you made
-->

# Description

Fixes `sortTransactionTrytesArray` test that occasionally failed because it relied on `shuffle` actually changing the order of the trytes. This PR ensures that they are always in a different order and not equal to the original array.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Ran tests many times without failure


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes