### PR TITLE
Desktop: Settings view UI layout fixes

### DIFF
--- a/src/desktop/src/ui/views/settings/Node.js
+++ b/src/desktop/src/ui/views/settings/Node.js
@@ -97,7 +97,7 @@ class SetNode extends PureComponent {
                     </Button>
                     {selection !== node &&
                         customNodes.indexOf(selection) > -1 && (
-                            <Button onClick={this.removeNode} variant="negative">
+                            <Button className="square" onClick={this.removeNode} variant="negative">
                                 {t('addCustomNode:removeCustomNode')}
                             </Button>
                         )}

--- a/src/desktop/src/ui/views/settings/account/Addresses.js
+++ b/src/desktop/src/ui/views/settings/account/Addresses.js
@@ -24,35 +24,35 @@ class Addresses extends PureComponent {
         const { account, t } = this.props;
         const isSpent = ({ spent: { local, remote } }) => local || remote;
 
+        const addresses = Object.keys(account.addresses)
+            .map((address) => Object.assign({ address }, account.addresses[address]))
+            .sort((a, b) => b.index - a.index);
+
         return (
             <div className={settingsCSS.scroll}>
                 <Scrollbar>
                     <ul className={css.addresses}>
-                        {Object.keys(account.addresses)
-                            .reverse()
-                            .map((item) => {
-                                const address = item + account.addresses[item].checksum;
-                                return (
-                                    <li key={address}>
-                                        <p className={isSpent(account.addresses[item]) ? css.spent : null}>
-                                            <Clipboard
-                                                text={address}
-                                                title={t('receive:addressCopied')}
-                                                success={t('receive:addressCopiedExplanation')}
-                                            >
-                                                {item.match(/.{1,3}/g).join(' ')}{' '}
-                                                <mark>
-                                                    {account.addresses[item].checksum.match(/.{1,3}/g).join(' ')}
-                                                </mark>
-                                            </Clipboard>
-                                        </p>
-                                        <strong>
-                                            {formatValue(account.addresses[item].balance)}
-                                            {formatUnit(account.addresses[item].balance)}
-                                        </strong>
-                                    </li>
-                                );
-                            })}
+                        {addresses.map((item) => {
+                            const address = item.address + item.checksum;
+                            return (
+                                <li key={address}>
+                                    <p className={isSpent(item) ? css.spent : null}>
+                                        <Clipboard
+                                            text={address}
+                                            title={t('receive:addressCopied')}
+                                            success={t('receive:addressCopiedExplanation')}
+                                        >
+                                            {item.address.match(/.{1,3}/g).join(' ')}{' '}
+                                            <mark>{item.checksum.match(/.{1,3}/g).join(' ')}</mark>
+                                        </Clipboard>
+                                    </p>
+                                    <strong>
+                                        {formatValue(item.balance)}
+                                        {formatUnit(item.balance)}
+                                    </strong>
+                                </li>
+                            );
+                        })}
                     </ul>
                 </Scrollbar>
             </div>

--- a/src/desktop/src/ui/views/settings/account/Addresses.js
+++ b/src/desktop/src/ui/views/settings/account/Addresses.js
@@ -7,6 +7,7 @@ import Scrollbar from 'ui/components/Scrollbar';
 import Clipboard from 'ui/components/Clipboard';
 
 import css from './addresses.scss';
+import settingsCSS from '../index.scss';
 
 /**
  * Account addresses component
@@ -24,39 +25,37 @@ class Addresses extends PureComponent {
         const isSpent = ({ spent: { local, remote } }) => local || remote;
 
         return (
-            <form>
-                <fieldset>
+            <div className={settingsCSS.scroll}>
+                <Scrollbar>
                     <ul className={css.addresses}>
-                        <Scrollbar>
-                            {Object.keys(account.addresses)
-                                .reverse()
-                                .map((item) => {
-                                    const address = item + account.addresses[item].checksum;
-                                    return (
-                                        <li key={address}>
-                                            <p className={isSpent(account.addresses[item]) ? css.spent : null}>
-                                                <Clipboard
-                                                    text={address}
-                                                    title={t('receive:addressCopied')}
-                                                    success={t('receive:addressCopiedExplanation')}
-                                                >
-                                                    {item.match(/.{1,3}/g).join(' ')}{' '}
-                                                    <mark>
-                                                        {account.addresses[item].checksum.match(/.{1,3}/g).join(' ')}
-                                                    </mark>
-                                                </Clipboard>
-                                            </p>
-                                            <strong>
-                                                {formatValue(account.addresses[item].balance)}
-                                                {formatUnit(account.addresses[item].balance)}
-                                            </strong>
-                                        </li>
-                                    );
-                                })}
-                        </Scrollbar>
+                        {Object.keys(account.addresses)
+                            .reverse()
+                            .map((item) => {
+                                const address = item + account.addresses[item].checksum;
+                                return (
+                                    <li key={address}>
+                                        <p className={isSpent(account.addresses[item]) ? css.spent : null}>
+                                            <Clipboard
+                                                text={address}
+                                                title={t('receive:addressCopied')}
+                                                success={t('receive:addressCopiedExplanation')}
+                                            >
+                                                {item.match(/.{1,3}/g).join(' ')}{' '}
+                                                <mark>
+                                                    {account.addresses[item].checksum.match(/.{1,3}/g).join(' ')}
+                                                </mark>
+                                            </Clipboard>
+                                        </p>
+                                        <strong>
+                                            {formatValue(account.addresses[item].balance)}
+                                            {formatUnit(account.addresses[item].balance)}
+                                        </strong>
+                                    </li>
+                                );
+                            })}
                     </ul>
-                </fieldset>
-            </form>
+                </Scrollbar>
+            </div>
         );
     }
 }

--- a/src/desktop/src/ui/views/settings/account/addresses.scss
+++ b/src/desktop/src/ui/views/settings/account/addresses.scss
@@ -1,9 +1,4 @@
 .addresses {
-    position: relative;
-    height: calc(100vh - 160px);
-    margin: 0px;
-    padding: 0;
-
     p {
         font-family: 'SourceCodePro';
         font-size: 12px;

--- a/src/desktop/src/ui/views/settings/index.scss
+++ b/src/desktop/src/ui/views/settings/index.scss
@@ -23,6 +23,13 @@
             display: none;
         }
 
+        @media (max-width: 840px) {
+            position: fixed;
+            z-index: 2;
+            left: 0px;
+            width: 70px;
+        }
+
         h1 {
             display: block;
             position: relative;
@@ -33,6 +40,10 @@
             margin-bottom: 0px;
             opacity: 0.6;
             border-bottom: 1px solid var(--bar-hover);
+
+            @media (max-width: 840px) {
+                display: none;
+            }
         }
 
         > div > a {
@@ -59,6 +70,10 @@
             &:hover,
             &[aria-current='true'] {
                 background: var(--bar-hover);
+            }
+
+            @media (max-width: 840px) {
+                display: none;
             }
         }
 
@@ -100,11 +115,28 @@
                 &:last-of-type {
                     margin-bottom: 20px;
                 }
+
+                @media (max-width: 840px) {
+                    padding: 24px 20px;
+
+                    &:last-of-type {
+                        margin-bottom: 0px;
+                    }
+                    span {
+                        font-size: 24px !important;
+                    }
+                    strong {
+                        display: none;
+                    }
+                }
             }
 
             hr {
                 margin: 6px 0;
                 border: none;
+                @media (max-width: 840px) {
+                    display: none;
+                }
             }
         }
     }
@@ -137,10 +169,14 @@
             }
         }
 
+        @media (max-width: 840px) {
+            padding: 0 0 0 70px;
+        }
+
         > form {
             height: 100vh;
             position: relative;
-            padding-top: 120px;
+            padding: 120px 20px 0;
             fieldset {
                 max-width: 520px;
                 margin: 0 auto;
@@ -153,6 +189,7 @@
             footer {
                 position: absolute;
                 bottom: 0px;
+                left: 0px;
                 height: 70px;
                 width: 100%;
                 display: flex;
@@ -195,10 +232,11 @@
     height: 100vh;
     margin: 0 auto;
 
-    article {
+    article,
+    ul {
         margin: 0 auto;
         max-width: 560px;
-        padding: 120px 0;
+        padding: 120px 20px;
     }
 }
 


### PR DESCRIPTION
# Description

- Fix Settings narrow layout to show only active submenu Icons
- Fix Account settings -> Addresses list layout
- Fix Node settings "Remove custom node" button style

Fixes #846 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested manually on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code