### PR TITLE
Fix snapshot transition bug

### DIFF
--- a/src/mobile/__tests__/ui/views/wallet/SnapshotTransition.spec.js
+++ b/src/mobile/__tests__/ui/views/wallet/SnapshotTransition.spec.js
@@ -1,0 +1,58 @@
+import assign from 'lodash/assign';
+import noop from 'lodash/noop';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SnapshotTransition as SnapshotTransitionComponent } from 'ui/views/wallet/SnapshotTransition';
+
+jest.mock('react-native-is-device-rooted', () => ({
+    isDeviceRooted: () => true,
+    isDeviceLocked: () => false,
+}));
+
+jest.mock('bugsnag-react-native', () => ({
+    Configuration: jest.fn(),
+    Client: jest.fn(() => ({ leaveBreadcrumb: jest.fn() })),
+}));
+
+const getProps = (overrides) =>
+    assign(
+        {},
+        {
+            isTransitioning: false,
+            t: () => '',
+            transitionForSnapshot: noop,
+            transitionBalance: 0,
+            balanceCheckFlag: false,
+            theme: { body: {}, primary: { color: '#862888', body: '#FFFFFF' } },
+            generateAddressesAndGetBalance: noop,
+            transitionAddresses: [],
+            completeSnapshotTransition: noop,
+            selectedAccountName: 'foo',
+            selectedAccountMeta: {},
+            generateAlert: noop,
+            setSetting: noop,
+            addresses: [],
+            shouldPreventAction: false,
+            isAttachingToTangle: false,
+            password: {},
+            activeStepIndex: -1,
+            activeSteps: [],
+            setBalanceCheckFlag: noop,
+            cancelSnapshotTransition: noop,
+        },
+        overrides,
+    );
+
+describe('Testing SnapshotTransition component', () => {
+    describe('when mounts', () => {
+        it('should call prop method cancelSnapshotTransition', () => {
+            const props = getProps({
+                cancelSnapshotTransition: jest.fn(),
+            });
+
+            shallow(<SnapshotTransitionComponent {...props} />);
+
+            expect(props.cancelSnapshotTransition).toHaveBeenCalled();
+        });
+    });
+});

--- a/src/mobile/src/ui/components/SettingsContent.js
+++ b/src/mobile/src/ui/components/SettingsContent.js
@@ -24,7 +24,7 @@ import LanguageSelection from 'ui/views/wallet/LanguageSelection';
 import ChangePassword from 'ui/views/wallet/ChangePassword';
 import ManualSyncComponent from 'ui/views/wallet/ManualSync';
 import ThemeCustomisation from 'ui/views/wallet/ThemeCustomisation';
-import SnapshotTransition from 'ui/views/wallet/SnapshotTransition';
+import SnapshotTransitionComponent from 'ui/views/wallet/SnapshotTransition';
 import SecuritySettings from 'ui/views/wallet/SecuritySettings';
 import SeedVaultSettings from 'ui/views/wallet/SeedVaultSettings';
 import About from 'ui/views/wallet/About';
@@ -49,7 +49,7 @@ const SETTINGS_COMPONENTS = {
     changePassword: ChangePassword,
     manualSync: ManualSyncComponent,
     themeCustomisation: ThemeCustomisation,
-    snapshotTransition: SnapshotTransition,
+    snapshotTransition: SnapshotTransitionComponent,
     securitySettings: SecuritySettings,
     modeSelection: ModeSelection,
     pow: ProofOfWork,

--- a/src/mobile/src/ui/views/wallet/SnapshotTransition.js
+++ b/src/mobile/src/ui/views/wallet/SnapshotTransition.js
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
     },
 });
 
-class SnapshotTransition extends Component {
+export class SnapshotTransition extends Component {
     static propTypes = {
         /** @ignore */
         isTransitioning: PropTypes.bool.isRequired,
@@ -166,6 +166,11 @@ class SnapshotTransition extends Component {
 
     componentDidMount() {
         leaveNavigationBreadcrumb('SnapshotTransition');
+
+        // Cancelling snapshot transition (i.e., navigating back to any other screen) while address generation is in progress
+        // will add transition addresses to redux store. Say a user swaps accounts and revist this screen, then it will mix transition addresses in redux store
+        // Hence, just reset transition addresses every time this screen is mounted
+        this.props.cancelSnapshotTransition();
     }
 
     componentWillReceiveProps(newProps) {


### PR DESCRIPTION
# Description

Cancellation of snapshot transition during address generation lead to a possibility of attaching addresses of a different account. This PR fixes the problem.

## Type of change

- Bug fix

# How Has This Been Tested?

- Added unit test coverage
- Manually tested on iOS (dev mode)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
