### PR TITLE
Shared: Fix selector for account names with special characters

### DIFF
--- a/src/shared/__tests__/reducers/accounts.spec.js
+++ b/src/shared/__tests__/reducers/accounts.spec.js
@@ -965,7 +965,7 @@ describe('Reducer: accounts', () => {
             it('should merge addresses in payload to accountName in accountInfo', () => {
                 const initialState = {
                     accountInfo: {
-                        dummy: {
+                        'foo[bar]': {
                             index: 1,
                             meta: { type: 'bar' },
                             balance: 0,
@@ -979,7 +979,7 @@ describe('Reducer: accounts', () => {
                     type: actionType,
                     payload: {
                         balance: 0,
-                        accountName: 'dummy',
+                        accountName: 'foo[bar]',
                         addresses: { foo: {}, baz: {} },
                         transfers: {},
                         hashes: [],
@@ -989,7 +989,7 @@ describe('Reducer: accounts', () => {
                 const newState = reducer(initialState, action);
                 const expectedState = {
                     accountInfo: {
-                        dummy: {
+                        'foo[bar]': {
                             index: 1,
                             meta: { type: 'bar' },
                             balance: 0,

--- a/src/shared/reducers/accounts.js
+++ b/src/shared/reducers/accounts.js
@@ -114,16 +114,16 @@ const updateAccountInfo = (state, payload) => ({
     accountInfo: {
         ...state.accountInfo,
         [payload.accountName]: {
-            ...get(state.accountInfo, `${payload.accountName}`),
+            ...get(state.accountInfo, [payload.accountName]),
             // Set seed index
             index: isUndefined(payload.accountIndex)
-                ? get(state.accountInfo, `${payload.accountName}.index`)
+                ? get(state.accountInfo, [payload.accountName, 'index'])
                 : payload.accountIndex,
-            meta: payload.accountMeta || get(state.accountInfo, `${payload.accountName}.meta`) || { type: 'keychain' },
+            meta: payload.accountMeta || get(state.accountInfo, [payload.accountName, 'meta']) || { type: 'keychain' },
             balance: payload.balance,
-            addresses: mergeAddressData(get(state.accountInfo, `${payload.accountName}.addresses`), payload.addresses),
+            addresses: mergeAddressData(get(state.accountInfo, [payload.accountName, 'addresses']), payload.addresses),
             transfers: {
-                ...get(state.accountInfo, `${payload.accountName}.transfers`),
+                ...get(state.accountInfo, [payload.accountName, 'transfers']),
                 ...payload.transfers,
             },
             hashes: payload.hashes,
@@ -296,11 +296,11 @@ const account = (
                     ...state.accountInfo,
                     [action.payload.accountName]: {
                         // Preserve the account index
-                        index: get(state.accountInfo, `${action.payload.accountName}.index`),
-                        meta: get(state.accountInfo, `${action.payload.accountName}.meta`) || { type: 'keychain' },
+                        index: get(state.accountInfo, [action.payload.accountName, 'index']),
+                        meta: get(state.accountInfo, [action.payload.accountName, 'meta']) || { type: 'keychain' },
                         balance: action.payload.balance,
                         addresses: mergeAddressData(
-                            get(state.accountInfo, `${action.payload.accountName}.addresses`),
+                            get(state.accountInfo, [action.payload.accountName, 'addresses']),
                             action.payload.addresses,
                         ),
                         transfers: action.payload.transfers,
@@ -324,11 +324,11 @@ const account = (
                 accountInfo: {
                     ...state.accountInfo,
                     [action.payload.accountName]: {
-                        index: get(state.accountInfo, `${action.payload.accountName}.index`),
-                        meta: get(state.accountInfo, `${action.payload.accountName}.meta`) || { type: 'keychain' },
+                        index: get(state.accountInfo, [action.payload.accountName, 'index']),
+                        meta: get(state.accountInfo, [action.payload.accountName, 'meta']) || { type: 'keychain' },
                         balance: action.payload.balance,
                         addresses: setAddressData(
-                            get(state.accountInfo, `${action.payload.accountName}.addresses`),
+                            get(state.accountInfo, [action.payload.accountName, 'addresses']),
                             action.payload.addresses,
                         ),
                         transfers: action.payload.transfers,
@@ -380,7 +380,7 @@ const account = (
                 tasks: {
                     ...state.tasks,
                     [action.payload.accountName]: {
-                        ...get(state.tasks, `${action.payload.accountName}`),
+                        ...get(state.tasks, [action.payload.accountName]),
                         [action.payload.task]: true,
                     },
                 },


### PR DESCRIPTION
# Description

Selector `get(state.accountInfo, '${payload.accountName}.index')` for account names containing special characters that match a valid path e.g. `Foo [bar]` resolve as undefined.
The selector path should be defined as an array of each path level defined separately.

Fixes #675

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
