### PR TITLE
Desktop: Fix update bar drag region on Windows

### DIFF
--- a/src/desktop/src/ui/global/alerts.scss
+++ b/src/desktop/src/ui/global/alerts.scss
@@ -103,6 +103,7 @@
             text-decoration: underline;
             cursor: pointer;
             margin-right: 10px;
+            -webkit-app-region: no-drag;
 
             @media screen and (max-width: 860px) {
                 display: block;
@@ -112,6 +113,7 @@
 
         &.win {
             top: 40px;
+            -webkit-app-region: no-drag;
         }
 
         > a {


### PR DESCRIPTION
# Description

Remove drag region from update bar on Windows to make it clickable.

Fixes #817 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually on Windows 10

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code