### PR TITLE
Disable quorum for getLatestInclusion

### DIFF
--- a/src/shared/libs/iota/accounts.js
+++ b/src/shared/libs/iota/accounts.js
@@ -39,7 +39,7 @@ import {
     formatAddressData,
     findSpendStatusesFromTransactionObjects,
 } from './addresses';
-import { EMPTY_HASH_TRYTES } from './utils';
+import { EMPTY_HASH_TRYTES, throwIfNodeNotHealthy } from './utils';
 
 /**
  *   Takes in account data fetched from ledger.
@@ -109,7 +109,8 @@ export const getAccountData = (provider) => (seedStore, accountName) => {
         hashes: [],
     };
 
-    return getFullAddressHistory(provider)(seedStore)
+    return throwIfNodeNotHealthy(provider)
+        .then(() => getFullAddressHistory(provider)(seedStore))
         .then((history) => {
             data = { ...data, ...history };
 
@@ -172,10 +173,17 @@ export const syncAccount = (provider) => (existingAccountState, seedStore, notif
     const thisStateCopy = cloneDeep(existingAccountState);
     const rescanAddresses = typeof seedStore === 'object';
 
-    return (rescanAddresses
-        ? syncAddresses(provider)(seedStore, thisStateCopy.addresses, map(thisStateCopy.transfers, (tx) => tx))
-        : Promise.resolve(thisStateCopy.addresses)
-    )
+    return throwIfNodeNotHealthy(provider)
+        .then(
+            () =>
+                rescanAddresses
+                    ? syncAddresses(provider)(
+                          seedStore,
+                          thisStateCopy.addresses,
+                          map(thisStateCopy.transfers, (tx) => tx),
+                      )
+                    : Promise.resolve(thisStateCopy.addresses),
+        )
         .then((latestAddressData) => {
             thisStateCopy.addresses = latestAddressData;
 

--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -137,7 +137,7 @@ const findTransactionsAsync = (provider) => (args) =>
  *
  * @returns {function(array): Promise<array>}
  */
-const getLatestInclusionAsync = (provider, withQuorum = true) => (hashes) =>
+const getLatestInclusionAsync = (provider, withQuorum = false) => (hashes) =>
     withQuorum
         ? quorum.getLatestInclusion(hashes)
         : new Promise((resolve, reject) => {


### PR DESCRIPTION
# Description

Also, add node health checks for account sync utils because `getLatestInclusion` support for quorum is (temporarily) disabled.

## Type of change

- Enhancement

# How Has This Been Tested?

- Manually tested iOS (debug mode)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
