### PR TITLE
Change the way attachToTangle is checked on a node

### DIFF
--- a/src/shared/actions/settings.js
+++ b/src/shared/actions/settings.js
@@ -4,7 +4,7 @@ import { changeIotaNode } from '../libs/iota/index';
 import i18next from '../libs/i18next';
 import { generateAlert, generateNodeOutOfSyncErrorAlert, generateUnsupportedNodeErrorAlert } from '../actions/alerts';
 import { fetchNodeList } from '../actions/polling';
-import { checkAttachToTangleAsync } from '../libs/iota/extendedApi';
+import { allowsRemotePow } from '../libs/iota/extendedApi';
 import { getSelectedNodeFromState } from '../selectors/accounts';
 import { throwIfNodeNotHealthy } from '../libs/iota/utils';
 import Errors from '../libs/errors';
@@ -435,15 +435,15 @@ export function setFullNode(node, addingCustomNode = false) {
         dispatch(dispatcher.request());
 
         throwIfNodeNotHealthy(node)
-            .then(() => checkAttachToTangleAsync(node))
-            .then((res) => {
+            .then(() => allowsRemotePow(node))
+            .then((hasRemotePow) => {
                 // Change IOTA provider on the global iota instance
                 changeIotaNode(node);
 
                 // Update node in redux store
                 dispatch(dispatcher.success(node));
 
-                if (res.error.includes(Errors.INVALID_PARAMETERS)) {
+                if (hasRemotePow) {
                     dispatch(
                         generateAlert(
                             'success',
@@ -513,8 +513,8 @@ export function changePowSettings() {
     return (dispatch, getState) => {
         const settings = getState().settings;
         if (!settings.remotePoW) {
-            checkAttachToTangleAsync(settings.node).then((res) => {
-                if (res.error.includes(Errors.ATTACH_TO_TANGLE_UNAVAILABLE)) {
+            allowsRemotePow(settings.node).then((hasRemotePow) => {
+                if (!hasRemotePow) {
                     return dispatch(
                         generateAlert(
                             'error',
@@ -546,8 +546,8 @@ export function changeAutoPromotionSettings() {
     return (dispatch, getState) => {
         const settings = getState().settings;
         if (!settings.autoPromotion) {
-            checkAttachToTangleAsync(settings.node).then((res) => {
-                if (res.error.includes(Errors.ATTACH_TO_TANGLE_UNAVAILABLE)) {
+            allowsRemotePow(settings.node).then((hasRemotePow) => {
+                if (!hasRemotePow) {
                     return dispatch(
                         generateAlert(
                             'error',

--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -1,4 +1,6 @@
+import has from 'lodash/has';
 import head from 'lodash/head';
+import includes from 'lodash/includes';
 import isFunction from 'lodash/isFunction';
 import map from 'lodash/map';
 import reduce from 'lodash/reduce';
@@ -410,6 +412,28 @@ const checkAttachToTangleAsync = (node) => {
 };
 
 /**
+ * Checks if remote pow is allowed on the provided node
+ *
+ * @method allowsRemotePow
+ * @param {string} provider
+ *
+ * @returns {Promise<Boolean>}
+ */
+const allowsRemotePow = (provider) => {
+    return getNodeInfoAsync(provider)().then((info) => {
+        // Check if provided node has upgraded to IRI to a version, where it adds "features" prop in node info
+        if (has(info, 'features')) {
+            return includes(info.features, 'RemotePOW');
+        }
+
+        // Fallback to old way of checking remote pow
+        return checkAttachToTangleAsync(provider).then((response) =>
+            includes(response.error, Errors.INVALID_PARAMETERS),
+        );
+    });
+};
+
+/**
  * Promisified version of iota.api.attachToTangle
  *
  * @method attachToTangleAsync
@@ -572,6 +596,7 @@ export {
     storeAndBroadcastAsync,
     attachToTangleAsync,
     checkAttachToTangleAsync,
+    allowsRemotePow,
     isNodeHealthy,
     isPromotable,
 };


### PR DESCRIPTION
# Description

Leverage "features" prop in getNodeInfo to check if a node allows remote pow

## Type of change
- Enhancement 

# How Has This Been Tested?

- With unit tests

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
