### PR TITLE
Fix findSyncedNodes implementation

### DIFF
--- a/src/shared/libs/iota/quorum.js
+++ b/src/shared/libs/iota/quorum.js
@@ -152,8 +152,12 @@ const findSyncedNodes = (nodes, quorumSize, selectedNodes = [], blacklistedNodes
             return findSyncedNodes(
                 nodes,
                 quorumSize,
-                // Add active nodes to synced nodes
-                union(selectedNodes, syncedNodes),
+                // Update selected nodes
+                union(
+                    // Filter selected nodes that are unsynced
+                    filter(selectedNodes, (node) => !includes(unsyncedNodes, node)),
+                    syncedNodes,
+                ),
                 // Add inactive nodes to blacklisted nodes
                 [...blacklistedNodes, ...unsyncedNodes],
             );


### PR DESCRIPTION
# Description

#findSyncedNodes wasn't removing unsynced nodes from `selectedNodes` in one case. This bug could've lead to unnecessary delays. This PR fixes the issue and removes unsynced nodes from `selectedNodes` in each iteration.

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested on iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
