### PR TITLE
Mobile: Exclude Android JS bundle from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ build/
 .gradle/
 local.properties
 *.iml
+index.android.bundle
 
 # node.js
 #


### PR DESCRIPTION
# Description
Removes `index.android.bundle` from git as it shouldn't be checked in

## Type of change

- Chore

# How Has This Been Tested?
N/A


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
