### PR TITLE
Remove unresponsive nodes from default nodes list

### DIFF
--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -8,10 +8,7 @@ export const nodesWithPoWEnabled = [
     'https://pow1.iota.community:443',
     'https://pow2.iota.community:443',
     'https://pow3.iota.community:443',
-    'https://pow4.iota.community:443',
     'https://pow5.iota.community:443',
-    'https://pow6.iota.community:443',
-    'https://nodes.iota.fm:443',
     'https://iotanode.us:443',
 ];
 
@@ -20,7 +17,6 @@ const nodesWithPoWDisabled = [
     'https://potato.iotasalad.org:14265',
     'https://tuna.iotasalad.org:14265',
     'https://durian.iotasalad.org:14265',
-    'https://nodes.iota.cafe:443',
     'https://nodes.thetangle.org:443',
 ];
 


### PR DESCRIPTION
# Description

This PR removes unresponsive nodes from the default nodes list. Note that once any of these nodes become active, it would automatically be available in wallet via [this](https://nodes.iota.works/api/ssl/live) endpoint.

## Type of change

- Enhancement

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
