### PR TITLE
[#662] Increasing space between columns

### DIFF
--- a/src/mobile/src/ui/components/SettingsContent.js
+++ b/src/mobile/src/ui/components/SettingsContent.js
@@ -100,6 +100,9 @@ const styles = StyleSheet.create({
         fontFamily: 'SourceSansPro-Light',
         fontSize: Styling.fontSize3,
         backgroundColor: 'transparent',
+        marginLeft: 5,
+        flex: 1,
+        textAlign: 'right',
     },
     backText: {
         fontFamily: 'SourceSansPro-Regular',
@@ -113,7 +116,6 @@ export const renderSettingsRows = (rows, theme) => {
     const textColor = { color: theme.body.color };
     const bodyColor = theme.body.color;
     const borderBottomColor = { borderBottomColor: theme.body.color };
-    const marginLeft = { marginLeft: 5 };
     return (
         <View style={{ flex: 1 }}>
             {map(rows, (row, index) => {
@@ -135,7 +137,7 @@ export const renderSettingsRows = (rows, theme) => {
                                     <View style={styles.content}>
                                         <Text style={[styles.titleText, textColor]}>{row.name}</Text>
                                         {row.currentSetting && (
-                                            <Text numberOfLines={1} style={[styles.settingText, textColor, marginLeft]}>
+                                            <Text numberOfLines={1} style={[styles.settingText, textColor]}>
                                                 {row.currentSetting}
                                             </Text>
                                         )}

--- a/src/mobile/src/ui/components/SettingsContent.js
+++ b/src/mobile/src/ui/components/SettingsContent.js
@@ -113,6 +113,7 @@ export const renderSettingsRows = (rows, theme) => {
     const textColor = { color: theme.body.color };
     const bodyColor = theme.body.color;
     const borderBottomColor = { borderBottomColor: theme.body.color };
+    const marginLeft = { marginLeft: 5 };
     return (
         <View style={{ flex: 1 }}>
             {map(rows, (row, index) => {
@@ -134,7 +135,7 @@ export const renderSettingsRows = (rows, theme) => {
                                     <View style={styles.content}>
                                         <Text style={[styles.titleText, textColor]}>{row.name}</Text>
                                         {row.currentSetting && (
-                                            <Text numberOfLines={1} style={[styles.settingText, textColor]}>
+                                            <Text numberOfLines={1} style={[styles.settingText, textColor, marginLeft]}>
                                                 {row.currentSetting}
                                             </Text>
                                         )}


### PR DESCRIPTION
# Description
Increasing the space between all two-columns line managed by SettingsContent.js
Fixes #662 

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
- Open the app with selected language as English
- Change it to Portuguese (Brazil) or other in witch 'Selected server' can be translated to something larger.
- Now instead of touching each other, the two columns are slightly separated when the contents are large enough to this.

![screenshot_20190121-213711_trinity](https://user-images.githubusercontent.com/2289068/51510495-47b32480-1dcb-11e9-8928-9022bbc3f3c2.jpg)
