### PR TITLE
#508 Increasing margin of inner div to be able to show all characters…

### DIFF
--- a/src/desktop/src/ui/components/input/input.scss
+++ b/src/desktop/src/ui/components/input/input.scss
@@ -233,6 +233,7 @@
     &.seed {
         fieldset .editable {
             padding: 0 32px 0 21px;
+            margin-left: 20px;
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/iotaledger/trinity-wallet/issues/508

## Type of change
- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
Following the steps in the original issue and stating that when the user types more characters than the size of the field he'll be able to go back with the left arrow and see all of the typed characters.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works