### PR TITLE
Blacklist nodejs-assets and platform folders for react native packager

### DIFF
--- a/src/mobile/rn-cli.config.js
+++ b/src/mobile/rn-cli.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const metroBlacklist = require('metro-config/src/defaults/blacklist');
 
 const alternateRoots = [path.join(__dirname, '../shared')];
-const blacklist = metroBlacklist([/nodejs-project\/.*/]);
+const blacklist = metroBlacklist([/nodejs-assets\/.*/, /android\/.*/, /ios\/.*/]);
 
 module.exports = {
     watchFolders: alternateRoots,


### PR DESCRIPTION
# Description

 Instruct the react-native packager to ignore the `nodejs-project`

Fixes occasionally seen error during development `Error: jest-haste-map: @providesModule naming collision`. 

## Type of change

- Bug fix

# Checklist:

- [x] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
