### PR TITLE
Redirect to welcome screen only when wallet data is successfully deleted

### DIFF
--- a/src/mobile/src/ui/views/wallet/WalletResetRequirePassword.js
+++ b/src/mobile/src/ui/views/wallet/WalletResetRequirePassword.js
@@ -138,10 +138,10 @@ class WalletResetRequirePassword extends Component {
     async resetWallet() {
         const { t } = this.props;
         if (await this.isAuthenticated()) {
-            this.redirectToInitialScreen();
             purgeStoredState(persistConfig)
                 .then(() => clearKeychain())
                 .then(() => {
+                    this.redirectToInitialScreen();
                     // resetWallet action creator resets the whole state object to default values
                     // https://github.com/iotaledger/trinity-wallet/blob/develop/src/shared/store.js#L37
                     this.props.resetWallet();


### PR DESCRIPTION
# Description

Reset wallet operation redirects to welcome screen even if there is an error clearing the wallet data. This PR fixes the issue. 

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
