### PR TITLE
Fix invalid bundle issue on zero value transaction with bundle size > 1

### DIFF
--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -537,7 +537,7 @@ const attachToTangleAsync = (provider, seedStore) => (
 
             // Batched proof-of-work only returns the attached trytes
             return constructBundleFromAttachedTrytes(result, seedStore).then((transactionObjects) => ({
-                transactionObjects,
+                transactionObjects: transactionObjects.slice().reverse(),
                 trytes: result,
             }));
         })


### PR DESCRIPTION
# Description

An invalid bundle was constructed for zero value transactions with bundle size > 1. This PR fixes the issue. 

## Type of change

- Bug fix 

# How Has This Been Tested?

WIP

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
