### PR TITLE
Shared: Fix order in which bundles are stored

### DIFF
--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -659,7 +659,7 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
             })
             .then(({ trytes, transactionObjects }) => {
                 cached.trytes = trytes;
-                cached.transactionObjects = transactionObjects;
+                cached.transactionObjects = transactionObjects.slice().reverse();
 
                 // Progressbar step => (Broadcasting)
                 dispatch(setNextStepAsActive());


### PR DESCRIPTION
# Description

- Fix order in which bundles are stored

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on android simulator

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
