### PR TITLE
Shared: Do not store invalid bundles constructed with local PoW

### DIFF
--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -716,6 +716,10 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
             .catch((error) => {
                 dispatch(sendTransferError());
                 dispatch(resetProgress());
+                // If local PoW produces an invalid bundle we do not need to store it or mark the address as spent because the signature has not been broadcast.
+                if (message === Errors.INVALID_BUNDLE_CONSTRUCTED_WITH_LOCAL_POW) {
+                    isValidBundle = false;
+                }
                 // Only keep the failed trytes locally if the bundle was valid
                 // In case the bundle is invalid, discard the signing as it was never broadcast
                 if (hasSignedInputs && isValidBundle) {

--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -717,6 +717,8 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
                 dispatch(sendTransferError());
                 dispatch(resetProgress());
                 // If local PoW produces an invalid bundle we do not need to store it or mark the address as spent because the signature has not been broadcast.
+                const message = error.message;
+
                 if (message === Errors.INVALID_BUNDLE_CONSTRUCTED_WITH_LOCAL_POW) {
                     isValidBundle = false;
                 }
@@ -745,8 +747,6 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
                         ),
                     );
                 }
-
-                const message = error.message;
 
                 if (message === Errors.NODE_NOT_SYNCED) {
                     return dispatch(generateNodeOutOfSyncErrorAlert());

--- a/src/shared/libs/errors.js
+++ b/src/shared/libs/errors.js
@@ -17,8 +17,8 @@ export default {
     NODE_NOT_SYNCED: 'Node not synced',
     UNSUPPORTED_NODE: 'Node version not supported',
     INVALID_BUNDLE: 'Invalid bundle',
-    INVALID_BUNDLE_CONSTRUCTED: (remotePow) =>
-        `Invalid bundle constructed with ${remotePow ? 'remote' : 'local'} proof-of-work.`,
+    INVALID_BUNDLE_CONSTRUCTED_WITH_REMOTE_POW: 'Invalid bundle constructed with remote proof-of-work.',
+    INVALID_BUNDLE_CONSTRUCTED_WITH_LOCAL_POW: 'Invalid bundle constructed with local proof-of-work.',
     INVALID_PARAMETERS: 'Invalid parameters',
     ALREADY_SPENT_FROM_ADDRESSES: 'Already spent from addresses',
     TRANSACTION_IS_INCONSISTENT: 'Transaction is inconsistent.',

--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -511,7 +511,7 @@ const attachToTangleAsync = (provider, seedStore) => (
                                         trytes: attachedTrytes,
                                     });
                                 } else {
-                                    reject(new Error(Errors.INVALID_BUNDLE_CONSTRUCTED(shouldOffloadPow)));
+                                    reject(new Error(Errors.INVALID_BUNDLE_CONSTRUCTED_WITH_REMOTE_POW));
                                 }
                             })
                             .catch(reject);
@@ -541,8 +541,7 @@ const attachToTangleAsync = (provider, seedStore) => (
                     trytes,
                 };
             }
-
-            throw new Error(Errors.INVALID_BUNDLE_CONSTRUCTED(shouldOffloadPow));
+            throw new Error(Errors.INVALID_BUNDLE_CONSTRUCTED_WITH_LOCAL_POW);
         });
 };
 


### PR DESCRIPTION
# Description

- Do not store invalid bundles constructed with local PoW
- Do not mark addresses as spent if bundle is invalid and constructed with local PoW

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Android device.

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
