### PR TITLE
Fix account index issue

### DIFF
--- a/src/shared/libs/migrations.js
+++ b/src/shared/libs/migrations.js
@@ -108,9 +108,12 @@ export const migrateAccounts = (accounts) => {
     const { accountInfo, failedBundleHashes, setupInfo, tasks } = accounts;
     const accountNames = keys(accountInfo);
 
+    const manuallyAssignAccountIndex = (accountIndex, fallbackIndex) =>
+        !isUndefined(accountIndex) ? accountIndex : fallbackIndex;
+
     return reduce(
         accountNames,
-        (promise, accountName) => {
+        (promise, accountName, idx) => {
             return promise.then(() => {
                 const thisAccountInfo = accountInfo[accountName];
                 const { addresses } = thisAccountInfo;
@@ -132,7 +135,9 @@ export const migrateAccounts = (accounts) => {
                         accountName,
                         assign({}, accountData, {
                             meta: get(thisAccountInfo, 'meta'),
-                            index: !isUndefined(index) ? index : get(thisAccountInfo, 'accountIndex'),
+                            index: !isUndefined(index)
+                                ? index
+                                : manuallyAssignAccountIndex(get(thisAccountInfo, 'accountIndex'), idx),
                             usedExistingSeed: get(setupInfo, `${accountName}.usedExistingSeed`) || false,
                             displayedSnapshotTransitionGuide:
                                 get(tasks, `${accountName}.hasDisplayedTransitionGuide`) || false,


### PR DESCRIPTION
# Description

Manually assign account index as a fallback strategy during AsyncStorage to Realm migration. 

If a user is migrating from a version where `index` or `accountIndex` wasn't introduced, he/she could face an exception during migration. This PR fixes the issue by manually assigning account indexes in such cases. 

## Type of change

- Bug fix 

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
