### PR TITLE
Add polling service for automatically retrying failed transactions in wallet

### DIFF
--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -163,10 +163,7 @@ class Polling extends React.PureComponent {
     };
 
     promote = () => {
-        const { unconfirmedBundleTails, allPollingServices, pollFor, autoPromotion } = this.props;
-
-        const index = allPollingServices.indexOf(pollFor);
-        const next = index === size(allPollingServices) - 1 ? 0 : index + 1;
+        const { unconfirmedBundleTails, autoPromotion } = this.props;
 
         const { autoPromoteSkips } = this.state;
 
@@ -185,8 +182,7 @@ class Polling extends React.PureComponent {
             }
         }
 
-        // In case there are no unconfirmed bundle tails or auto-promotion is off, move to the next service item
-        return this.props.setPollFor(allPollingServices[next]);
+        return this.moveToNextPollService();
     };
 
     render() {

--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -1,4 +1,5 @@
 /* global Electron */
+import head from 'lodash/head';
 import filter from 'lodash/filter';
 import React from 'react';
 import isEmpty from 'lodash/isEmpty';
@@ -7,11 +8,13 @@ import random from 'lodash/random';
 import size from 'lodash/size';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import SeedStore from 'libs/SeedStore';
 import {
     getAccountNamesFromState,
     isSettingUpNewAccount,
     getPromotableBundlesFromState,
     getSelectedAccountName,
+    getFailedBundleHashes,
 } from 'selectors/accounts';
 import {
     fetchMarketData,
@@ -22,6 +25,7 @@ import {
     promoteTransfer,
     getAccountInfoForAllAccounts,
 } from 'actions/polling';
+import { retryFailedTransaction } from 'actions/transfers';
 
 /**
  * Background polling component
@@ -54,6 +58,13 @@ class Polling extends React.PureComponent {
         fetchChartData: PropTypes.func.isRequired,
         /** @ignore */
         promoteTransfer: PropTypes.func.isRequired,
+        /** Bundle hashes for failed transactions categorised by account name & type */
+        failedBundleHashes: PropTypes.shape({
+            name: PropTypes.string,
+            type: PropTypes.string,
+        }).isRequired,
+        /** @ignore */
+        retryFailedTransaction: PropTypes.func.isRequired,
     };
 
     state = {
@@ -78,7 +89,8 @@ class Polling extends React.PureComponent {
             props.isGeneratingReceiveAddress ||
             props.isFetchingAccountInfo || // In case the app is already fetching latest account info, stop polling because the market related data is already fetched on login
             props.addingAdditionalAccount ||
-            props.isTransitioning;
+            props.isTransitioning ||
+            props.isRetryingFailedTransaction;
 
         const isAlreadyPollingSomething =
             props.isPollingPrice ||
@@ -89,6 +101,15 @@ class Polling extends React.PureComponent {
 
         return isAlreadyDoingSomeHeavyLifting || isAlreadyPollingSomething;
     }
+
+    moveToNextPollService = () => {
+        const { allPollingServices, pollFor } = this.props;
+
+        const index = allPollingServices.indexOf(pollFor);
+        const next = index === size(allPollingServices) - 1 ? 0 : index + 1;
+
+        this.props.setPollFor(allPollingServices[next]);
+    };
 
     fetch = () => {
         if (this.shouldSkipCycle()) {
@@ -104,6 +125,7 @@ class Polling extends React.PureComponent {
             chartData: this.props.fetchChartData,
             nodeList: this.props.fetchNodeList,
             accountInfo: this.fetchLatestAccountInfo,
+            broadcast: this.retryFailedTransaction,
         };
 
         dict[service] ? dict[service]() : this.props.setPollFor(this.props.allPollingServices[0]);
@@ -115,6 +137,29 @@ class Polling extends React.PureComponent {
             [selectedAccountName, ...filter(accountNames, (name) => name !== selectedAccountName)],
             Electron.notify,
         );
+    };
+
+    /**
+     * Retries (performs proof-of-work & broadcasts) a failed transaction
+     *
+     * @method retryFailedTransaction
+     *
+     * @returns {undefined}
+     */
+    retryFailedTransaction = async () => {
+        const { failedBundleHashes, password } = this.props;
+
+        if (!isEmpty(failedBundleHashes)) {
+            const bundleHashes = keys(failedBundleHashes);
+            const bundleForRetry = head(bundleHashes);
+            const { name, type } = failedBundleHashes[bundleForRetry];
+
+            const seedStore = await new SeedStore[type](password, name);
+
+            this.props.retryFailedTransaction(name, bundleForRetry, seedStore);
+        } else {
+            this.moveToNextPollService();
+        }
     };
 
     promote = () => {
@@ -167,6 +212,8 @@ const mapStateToProps = (state) => ({
     unconfirmedBundleTails: getPromotableBundlesFromState(state),
     selectedAccountName: getSelectedAccountName(state),
     isTransitioning: state.ui.isTransitioning,
+    isRetryingFailedTransaction: state.ui.isRetryingFailedTransaction,
+    failedBundleHashes: getFailedBundleHashes(state),
 });
 
 const mapDispatchToProps = {
@@ -177,6 +224,7 @@ const mapDispatchToProps = {
     setPollFor,
     promoteTransfer,
     getAccountInfoForAllAccounts,
+    retryFailedTransaction,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Polling);

--- a/src/mobile/src/ui/components/Poll.js
+++ b/src/mobile/src/ui/components/Poll.js
@@ -113,6 +113,22 @@ export class Poll extends Component {
         return isAlreadyDoingSomeHeavyLifting || isAlreadyPollingSomething;
     }
 
+    /**
+     * Sets next polling service (in queue) as the active polling service
+     *
+     * @method moveToNextPollService
+     *
+     * @returns {undefined}
+     */
+    moveToNextPollService() {
+        const { allPollingServices, pollFor } = this.props;
+
+        const index = allPollingServices.indexOf(pollFor);
+        const next = index === size(allPollingServices) - 1 ? 0 : index + 1;
+
+        this.props.setPollFor(allPollingServices[next]);
+    }
+
     fetch(service) {
         if (this.shouldSkipCycle()) {
             return;
@@ -149,7 +165,7 @@ export class Poll extends Component {
      * @returns {undefined}
      */
     retryFailedTransaction() {
-        const { allPollingServices, pollFor, failedBundleHashes, password } = this.props;
+        const { failedBundleHashes, password } = this.props;
 
         if (!isEmpty(failedBundleHashes)) {
             const bundleHashes = keys(failedBundleHashes);
@@ -158,11 +174,7 @@ export class Poll extends Component {
 
             this.props.retryFailedTransaction(name, bundleForRetry, new SeedStore[type](password, name));
         } else {
-            const index = allPollingServices.indexOf(pollFor);
-            const next = index === size(allPollingServices) - 1 ? 0 : index + 1;
-
-            // If there are no failed bundle hashes, move to the next polling service.
-            this.props.setPollFor(allPollingServices[next]);
+            this.moveToNextPollService();
         }
     }
 
@@ -183,7 +195,7 @@ export class Poll extends Component {
     }
 
     promote() {
-        const { isAutoPromotionEnabled, unconfirmedBundleTails, allPollingServices, pollFor } = this.props;
+        const { isAutoPromotionEnabled, unconfirmedBundleTails } = this.props;
 
         const { autoPromoteSkips } = this.state;
 
@@ -206,11 +218,7 @@ export class Poll extends Component {
             }
         }
 
-        const index = allPollingServices.indexOf(pollFor);
-        const next = index === size(allPollingServices) - 1 ? 0 : index + 1;
-
-        // In case there are no unconfirmed bundle tails or auto-promotion is disabled, move to the next service item
-        return this.props.setPollFor(allPollingServices[next]);
+        return this.moveToNextPollService();
     }
 
     render() {

--- a/src/mobile/src/ui/components/Poll.js
+++ b/src/mobile/src/ui/components/Poll.js
@@ -1,4 +1,5 @@
 import filter from 'lodash/filter';
+import head from 'lodash/head';
 import isEmpty from 'lodash/isEmpty';
 import keys from 'lodash/keys';
 import size from 'lodash/size';
@@ -8,11 +9,13 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import timer from 'react-native-timer';
 import { AppState } from 'react-native';
+import SeedStore from 'libs/SeedStore';
 import {
     getSelectedAccountName,
     getPromotableBundlesFromState,
     getAccountNamesFromState,
     isSettingUpNewAccount,
+    getFailedBundleHashes,
 } from 'shared-modules/selectors/accounts';
 import {
     fetchMarketData,
@@ -23,6 +26,7 @@ import {
     getAccountInfoForAllAccounts,
     promoteTransfer,
 } from 'shared-modules/actions/polling';
+import { retryFailedTransaction } from 'shared-modules/actions/transfers';
 
 export class Poll extends Component {
     static propTypes = {
@@ -52,6 +56,15 @@ export class Poll extends Component {
         getAccountInfoForAllAccounts: PropTypes.func.isRequired,
         /** @ignore */
         promoteTransfer: PropTypes.func.isRequired,
+        /** Bundle hashes for failed transactions categorised by account name & type */
+        failedBundleHashes: PropTypes.shape({
+            name: PropTypes.string,
+            type: PropTypes.string,
+        }).isRequired,
+        /** @ignore */
+        retryFailedTransaction: PropTypes.func.isRequired,
+        /** @ignore */
+        password: PropTypes.object.isRequired,
     };
 
     constructor() {
@@ -59,6 +72,7 @@ export class Poll extends Component {
 
         this.fetchLatestAccountInfo = this.fetchLatestAccountInfo.bind(this);
         this.promote = this.promote.bind(this);
+        this.retryFailedTransaction = this.retryFailedTransaction.bind(this);
 
         this.state = {
             autoPromoteSkips: 0,
@@ -85,7 +99,8 @@ export class Poll extends Component {
             props.isFetchingAccountInfo || // In case the app is already fetching latest account info, stop polling because the market related data is already fetched on login
             props.addingAdditionalAccount ||
             props.isTransitioning ||
-            props.isPromotingTransaction;
+            props.isPromotingTransaction ||
+            props.isRetryingFailedTransaction;
 
         const isAlreadyPollingSomething =
             props.isPollingPrice ||
@@ -110,6 +125,7 @@ export class Poll extends Component {
             chartData: this.props.fetchChartData,
             nodeList: this.props.fetchNodeList,
             accountInfo: this.fetchLatestAccountInfo,
+            broadcast: this.retryFailedTransaction,
         };
 
         // In case something messed up, reinitialize
@@ -123,6 +139,31 @@ export class Poll extends Component {
             selectedAccountName,
             ...filter(accountNames, (name) => name !== selectedAccountName),
         ]);
+    }
+
+    /**
+     * Retries (performs proof-of-work & broadcasts) a failed transaction
+     *
+     * @method retryFailedTransaction
+     *
+     * @returns {undefined}
+     */
+    retryFailedTransaction() {
+        const { allPollingServices, pollFor, failedBundleHashes, password } = this.props;
+
+        if (!isEmpty(failedBundleHashes)) {
+            const bundleHashes = keys(failedBundleHashes);
+            const bundleForRetry = head(bundleHashes);
+            const { name, type } = failedBundleHashes[bundleForRetry];
+
+            this.props.retryFailedTransaction(name, bundleForRetry, new SeedStore[type](password, name));
+        } else {
+            const index = allPollingServices.indexOf(pollFor);
+            const next = index === size(allPollingServices) - 1 ? 0 : index + 1;
+
+            // If there are no failed bundle hashes, move to the next polling service.
+            this.props.setPollFor(allPollingServices[next]);
+        }
     }
 
     startBackgroundProcesses() {
@@ -188,6 +229,7 @@ const mapStateToProps = (state) => ({
     isAutoPromoting: state.polling.isAutoPromoting,
     isAutoPromotionEnabled: state.settings.autoPromotion,
     isPromotingTransaction: state.ui.isPromotingTransaction,
+    isRetryingFailedTransaction: state.ui.isRetryingFailedTransaction,
     isSyncing: state.ui.isSyncing,
     addingAdditionalAccount: isSettingUpNewAccount(state),
     isGeneratingReceiveAddress: state.ui.isGeneratingReceiveAddress,
@@ -198,6 +240,8 @@ const mapStateToProps = (state) => ({
     unconfirmedBundleTails: getPromotableBundlesFromState(state),
     accountNames: getAccountNamesFromState(state),
     isTransitioning: state.ui.isTransitioning,
+    failedBundleHashes: getFailedBundleHashes(state),
+    password: state.wallet.password,
 });
 
 const mapDispatchToProps = {
@@ -208,6 +252,7 @@ const mapDispatchToProps = {
     setPollFor,
     getAccountInfoForAllAccounts,
     promoteTransfer,
+    retryFailedTransaction,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Poll);

--- a/src/shared/__tests__/__samples__/accounts.js
+++ b/src/shared/__tests__/__samples__/accounts.js
@@ -10,7 +10,7 @@ export default {
         [NAME]: {
             addressData,
             transactions,
-            type: TYPE,
+            meta: { type: TYPE },
         },
     },
     setupInfo: {

--- a/src/shared/__tests__/__samples__/accounts.js
+++ b/src/shared/__tests__/__samples__/accounts.js
@@ -2,6 +2,7 @@ import { addressData } from './addresses';
 import transactions from './transactions';
 
 export const NAME = 'TEST';
+export const TYPE = 'ledger';
 
 export default {
     onboardingComplete: true,
@@ -9,7 +10,7 @@ export default {
         [NAME]: {
             addressData,
             transactions,
-            type: 'ledger',
+            type: TYPE,
         },
     },
     setupInfo: {

--- a/src/shared/__tests__/__samples__/accounts.js
+++ b/src/shared/__tests__/__samples__/accounts.js
@@ -1,7 +1,7 @@
 import { addressData } from './addresses';
 import transactions from './transactions';
 
-const NAME = 'TEST';
+export const NAME = 'TEST';
 
 export default {
     onboardingComplete: true,

--- a/src/shared/__tests__/__samples__/transactions.js
+++ b/src/shared/__tests__/__samples__/transactions.js
@@ -860,6 +860,11 @@ const promotableBundleHashes = map(
     (transaction) => transaction.bundle,
 );
 
+const failedBundleHashes = map(
+    [...failedTransactionsWithCorrectTransactionHashes, ...failedTransactionsWithIncorrectTransactionHashes],
+    (transaction) => transaction.bundle,
+);
+
 const newZeroValueTransaction = [
     {
         hash: 'Q9DFNSOWDZ9BOCOGDLRKKEZQVMZQAVXKAI9JZLKYNAMFLWURAGBLKQPKVKOJOCAOIIREYVYNBBFIYPHFP',
@@ -1074,4 +1079,5 @@ export {
     LATEST_MILESTONE_INDEX,
     LATEST_SOLID_SUBTANGLE_MILESTONE_INDEX,
     latestMilestoneTransactionObject,
+    failedBundleHashes,
 };

--- a/src/shared/__tests__/reducers/polling.spec.js
+++ b/src/shared/__tests__/reducers/polling.spec.js
@@ -6,7 +6,15 @@ import { ActionTypes } from '../../actions/polling';
 describe('Reducer: polling', () => {
     it('should have an initial state', () => {
         const initialState = {
-            allPollingServices: ['promotion', 'marketData', 'price', 'chartData', 'nodeList', 'accountInfo'],
+            allPollingServices: [
+                'promotion',
+                'broadcast',
+                'marketData',
+                'price',
+                'chartData',
+                'nodeList',
+                'accountInfo',
+            ],
             pollFor: 'promotion',
             retryCount: 0,
             isFetchingPrice: false,

--- a/src/shared/__tests__/selectors/accounts.spec.js
+++ b/src/shared/__tests__/selectors/accounts.spec.js
@@ -187,7 +187,7 @@ describe('selectors: accounts', () => {
             expect(selectedAccountStateFactory('TEST')(state)).to.have.keys([
                 'transactions',
                 'addressData',
-                'type',
+                'meta',
                 'accountName',
             ]);
         });

--- a/src/shared/__tests__/selectors/accounts.spec.js
+++ b/src/shared/__tests__/selectors/accounts.spec.js
@@ -24,7 +24,7 @@ import {
     isSettingUpNewAccount,
     getFailedBundleHashes,
 } from '../../selectors/accounts';
-import accounts, { NAME as MOCK_ACCOUNT_NAME } from '../__samples__/accounts';
+import accounts, { NAME as MOCK_ACCOUNT_NAME, TYPE as MOCK_ACCOUNT_TYPE } from '../__samples__/accounts';
 import addresses, { latestAddressWithoutChecksum, latestAddressWithChecksum, balance } from '../__samples__/addresses';
 import { normalisedTransactions, promotableBundleHashes, failedBundleHashes } from '../__samples__/transactions';
 
@@ -490,12 +490,15 @@ describe('selectors: accounts', () => {
     });
 
     describe('#getFailedBundleHashes', () => {
-        it('should return failed bundle hashes categorised by account name', () => {
+        it('should return failed bundle hashes categorised by account name & type', () => {
             const actualResult = getFailedBundleHashes({ accounts });
             const expectedResult = transform(
                 failedBundleHashes,
                 (acc, bundleHash) => {
-                    acc[bundleHash] = MOCK_ACCOUNT_NAME;
+                    acc[bundleHash] = {
+                        name: MOCK_ACCOUNT_NAME,
+                        type: MOCK_ACCOUNT_TYPE,
+                    };
                 },
                 {},
             );

--- a/src/shared/__tests__/selectors/accounts.spec.js
+++ b/src/shared/__tests__/selectors/accounts.spec.js
@@ -1,4 +1,5 @@
 import keys from 'lodash/keys';
+import transform from 'lodash/transform';
 import { expect } from 'chai';
 import {
     getAccountsFromState,
@@ -21,10 +22,11 @@ import {
     getPromotableBundlesFromState,
     getAccountInfoDuringSetup,
     isSettingUpNewAccount,
+    getFailedBundleHashes,
 } from '../../selectors/accounts';
-import accounts from '../__samples__/accounts';
+import accounts, { NAME as MOCK_ACCOUNT_NAME } from '../__samples__/accounts';
 import addresses, { latestAddressWithoutChecksum, latestAddressWithChecksum, balance } from '../__samples__/addresses';
-import { normalisedTransactions, promotableBundleHashes } from '../__samples__/transactions';
+import { normalisedTransactions, promotableBundleHashes, failedBundleHashes } from '../__samples__/transactions';
 
 describe('selectors: accounts', () => {
     describe('#getAccountsFromState', () => {
@@ -484,6 +486,21 @@ describe('selectors: accounts', () => {
                     });
                 });
             });
+        });
+    });
+
+    describe('#getFailedBundleHashes', () => {
+        it('should return failed bundle hashes categorised by account name', () => {
+            const actualResult = getFailedBundleHashes({ accounts });
+            const expectedResult = transform(
+                failedBundleHashes,
+                (acc, bundleHash) => {
+                    acc[bundleHash] = MOCK_ACCOUNT_NAME;
+                },
+                {},
+            );
+
+            expect(expectedResult).to.eql(actualResult);
         });
     });
 });

--- a/src/shared/reducers/polling.js
+++ b/src/shared/reducers/polling.js
@@ -44,7 +44,7 @@ const polling = (
         /**
          * Polling service names
          */
-        allPollingServices: ['promotion', 'marketData', 'price', 'chartData', 'nodeList', 'accountInfo'],
+        allPollingServices: ['promotion', 'broadcast', 'marketData', 'price', 'chartData', 'nodeList', 'accountInfo'],
         /**
          * Determines the service currently being run during the poll cycle
          */

--- a/src/shared/selectors/accounts.js
+++ b/src/shared/selectors/accounts.js
@@ -347,7 +347,7 @@ export const isSettingUpNewAccount = createSelector(
 );
 
 /**
- *   Gets bundle hashes for failed transactions and categorises them by account name
+ *   Gets bundle hashes for failed transactions and categorises them by account name & type
  *
  *   @method getFailedBundleHashes
  *   @param {object} state
@@ -360,7 +360,10 @@ export const getFailedBundleHashes = createSelector(getAccountInfoFromState, (ac
             const failedTransactions = filter(info.transactions, (transaction) => transaction.broadcasted === false);
 
             each(failedTransactions, (transaction) => {
-                acc[transaction.bundle] = accountName;
+                acc[transaction.bundle] = {
+                    name: accountName,
+                    type: info.type,
+                };
             });
         },
         {},

--- a/src/shared/selectors/accounts.js
+++ b/src/shared/selectors/accounts.js
@@ -345,3 +345,24 @@ export const isSettingUpNewAccount = createSelector(
         !isEmpty(accountInfoDuringSetup.name) &&
         !isEmpty(accountInfoDuringSetup.meta),
 );
+
+/**
+ *   Gets bundle hashes for failed transactions and categorises them by account name
+ *
+ *   @method getFailedBundleHashes
+ *   @param {object} state
+ *   @returns {object}
+ **/
+export const getFailedBundleHashes = createSelector(getAccountInfoFromState, (accountInfo) =>
+    transform(
+        accountInfo,
+        (acc, info, accountName) => {
+            const failedTransactions = filter(info.transactions, (transaction) => transaction.broadcasted === false);
+
+            each(failedTransactions, (transaction) => {
+                acc[transaction.bundle] = accountName;
+            });
+        },
+        {},
+    ),
+);

--- a/src/shared/selectors/accounts.js
+++ b/src/shared/selectors/accounts.js
@@ -109,7 +109,10 @@ export const getSelectedAccountMeta = createSelector(
  *   @param {object} state
  *   @returns {string}
  **/
-export const getSelectedAccountType = createSelector(selectAccountInfo, (account) => account.type || 'keychain');
+export const getSelectedAccountType = createSelector(
+    selectAccountInfo,
+    (account) => get(account, 'meta.type') || 'keychain',
+);
 
 /**
  *   Selects transfers from accountInfo object.
@@ -362,7 +365,7 @@ export const getFailedBundleHashes = createSelector(getAccountInfoFromState, (ac
             each(failedTransactions, (transaction) => {
                 acc[transaction.bundle] = {
                     name: accountName,
-                    type: info.type,
+                    type: info.meta.type,
                 };
             });
         },

--- a/src/shared/selectors/global.js
+++ b/src/shared/selectors/global.js
@@ -28,11 +28,24 @@ export const getPollingFromState = (state) => state.polling || {};
  *   @returns {string}
  **/
 export const shouldPreventAction = createSelector(getUiFromState, getPollingFromState, (uiState, pollingState) => {
-    const { isTransitioning, isSendingTransfer, isGeneratingReceiveAddress, isSyncing } = uiState;
+    const {
+        isTransitioning,
+        isSendingTransfer,
+        isGeneratingReceiveAddress,
+        isSyncing,
+        isRetryingFailedTransaction,
+    } = uiState;
 
     const { isFetchingAccountInfo } = pollingState;
 
-    return isSyncing || isSendingTransfer || isGeneratingReceiveAddress || isTransitioning || isFetchingAccountInfo;
+    return (
+        isSyncing ||
+        isSendingTransfer ||
+        isGeneratingReceiveAddress ||
+        isTransitioning ||
+        isFetchingAccountInfo ||
+        isRetryingFailedTransaction
+    );
 });
 
 /**


### PR DESCRIPTION
# Description

Auto retry failed transactions with polling

## Type of change

- Enhancement 

# How Has This Been Tested?

- Unit tests
- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
