### PR TITLE
Fix propType warning in tests

### DIFF
--- a/src/mobile/__tests__/ui/components/EnterPasswordOnLogin.spec.js
+++ b/src/mobile/__tests__/ui/components/EnterPasswordOnLogin.spec.js
@@ -15,7 +15,7 @@ const getProps = (overrides) =>
     assign(
         {},
         {
-            password: '',
+            password: {},
             theme,
             onLoginPress: noop,
             navigateToNodeOptions: noop,

--- a/src/mobile/__tests__/ui/components/EnterPasswordOnLogin.spec.js
+++ b/src/mobile/__tests__/ui/components/EnterPasswordOnLogin.spec.js
@@ -91,7 +91,7 @@ describe('Testing EnterPasswordOnLogin component', () => {
             describe('#handleLogin', () => {
                 it('should call prop method "onLoginPress" with prop "password"', () => {
                     const props = getProps({
-                        password: 'foo',
+                        password: {},
                         onLoginPress: jest.fn(),
                     });
 
@@ -100,7 +100,7 @@ describe('Testing EnterPasswordOnLogin component', () => {
 
                     instance.handleLogin();
 
-                    expect(props.onLoginPress).toHaveBeenCalledWith('foo');
+                    expect(props.onLoginPress).toHaveBeenCalledWith({});
                 });
             });
 


### PR DESCRIPTION
# Description

Fixes the following warning 

<img width="676" alt="screenshot 2019-02-28 at 9 12 45 pm" src="https://user-images.githubusercontent.com/20437468/53582423-47affc80-3ba1-11e9-9598-057068070280.png">

## Type of change

- Bug fix 

# How Has This Been Tested?

N/A

# Checklist:

- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
