### PR TITLE
Desktop: Fix info alert colour

### DIFF
--- a/src/desktop/src/ui/global/alerts.scss
+++ b/src/desktop/src/ui/global/alerts.scss
@@ -58,11 +58,11 @@
         }
 
         &.info {
-            background: var(--positive);
-            color: var(--positive-body);
-            border-color: var(--positive-hover);
+            background: var(--secondary);
+            color: var(--secondary-body);
+            border-color: var(--secondary-hover);
             span:hover {
-                color: var(--positive-hover);
+                color: var(--secondary-hover);
             }
         }
 


### PR DESCRIPTION
# Description

- Fixes info alert colour using secondary colour from theme

Fixes #1158

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Desktop in debug.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
