### PR TITLE
Mobile: Fix "Realm is not a constructor" in Chrome debugger

### DIFF
--- a/src/shared/storage/index.js
+++ b/src/shared/storage/index.js
@@ -37,6 +37,9 @@ const getStoragePath = (schemaVersion = SCHEMA_VERSION) =>
 // Initialise realm instance
 let realm = {}; // eslint-disable-line import/no-mutable-exports
 
+// Initialise Realm constructor as null and reinitialise after importing the correct (platform) Realm dependency
+let Realm = null;
+
 /**
  * Imports Realm dependency
  *
@@ -54,8 +57,6 @@ export const getRealm = () => {
 
     return Electron.getRealm();
 };
-
-const Realm = getRealm();
 
 /**
  * Model for Account.
@@ -773,17 +774,15 @@ const purge = () =>
  *
  * @returns {Promise}
  */
-const initialise = (getEncryptionKeyPromise) =>
-    getEncryptionKeyPromise().then((encryptionKey) => {
-        // For some reason `getRealm` doesn't get called before this function when running in the Chrome debugger
-        if (__MOBILE__ && /Chrome/.test(navigator.userAgent)) {
-            const Realm = getRealm();
-            realm = new Realm(assign({}, config, { encryptionKey }));
-        } else {
-            realm = new Realm(assign({}, config, { encryptionKey }));
-        }
+const initialise = (getEncryptionKeyPromise) => {
+    Realm = getRealm();
+
+    return getEncryptionKeyPromise().then((encryptionKey) => {
+        realm = new Realm(assign({}, config, { encryptionKey }));
+
         initialiseSync(encryptionKey);
     });
+};
 
 /**
  * Initialises storage.

--- a/src/shared/storage/index.js
+++ b/src/shared/storage/index.js
@@ -775,7 +775,13 @@ const purge = () =>
  */
 const initialise = (getEncryptionKeyPromise) =>
     getEncryptionKeyPromise().then((encryptionKey) => {
-        realm = new Realm(assign({}, config, { encryptionKey }));
+        // For some reason `getRealm` doesn't get called before this function when running in the Chrome debugger
+        if (__MOBILE__ && /Chrome/.test(navigator.userAgent)) {
+            const Realm = getRealm();
+            realm = new Realm(assign({}, config, { encryptionKey }));
+        } else {
+            realm = new Realm(assign({}, config, { encryptionKey }));
+        }
         initialiseSync(encryptionKey);
     });
 


### PR DESCRIPTION
# Description

When running in the Chrome debugger, `Realm` is undefined when `initialise` is called. This is because (for some reason) the assignment is never evaluated:
https://github.com/iotaledger/trinity-wallet/blob/29be9a12db3742188e5269916177bac791335d08/src/shared/storage/index.js#L58

When the Chrome debugger is detected, `Realm` (a local variable inside the `initialise` block) is assigned to the value of `getRealm`. This forces the debugger to call `getRealm`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on iOS (`Debug` without debugger, `Debug` with debugger, and `Release`) 

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes