### PR TITLE
Mobile/iOS: Argon2 hashing updates

### DIFF
--- a/src/mobile/ios/Argon2/Argon2Core.swift
+++ b/src/mobile/ios/Argon2/Argon2Core.swift
@@ -39,14 +39,14 @@ struct Argon2Core {
   ///   - salt: Salt to be used
   ///   - params: Parameters to initialize Argon2 with
   /// - Returns: Hashed password
-  static func argon2Hash(password: String, salt: String, params: [String: Any]) -> String {
+  static func argon2Hash(password: String, salt: String, params: [String: Any]) -> [UInt8] {
     // Initialize Argon2
     let argon2Crypto = initialize(t_cost: params["t_cost"] as! Int, m_cost: params["m_cost"] as! Int, parallelism: params["parallelism"] as! Int, hashLength: params["hashLength"] as! Int)
     // Add salt to the context
     argon2Crypto.context.salt = salt
-    // Return the hash of the password
-    let hash = argon2Crypto.hash(password: password)
-    return hash.value!
+    // Get the hash of the password
+    let hash = argon2Crypto.hash(password: password, encoded: false).raw
+    return hash as! [UInt8]
   }
 
 }

--- a/src/mobile/ios/Argon2/Argon2IOS.m
+++ b/src/mobile/ios/Argon2/Argon2IOS.m
@@ -11,7 +11,7 @@
 
 @interface RCT_EXTERN_MODULE(Argon2IOS, NSObject)
 // Export hash method to RN
-RCT_EXTERN_METHOD(hash:(NSString *)password salt:(NSString *)salt params:(NSDictionary *)params resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject);
+RCT_EXTERN_METHOD(hash:(NSArray<NSNumber*>*)password salt:(NSString *)salt params:(NSDictionary *)params resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject);
 
 // Create a GCD queue for Argon2
 -(dispatch_queue_t)methodQueue

--- a/src/mobile/ios/Argon2/Argon2IOS.swift
+++ b/src/mobile/ios/Argon2/Argon2IOS.swift
@@ -18,11 +18,13 @@ class Argon2IOS: NSObject {
   ///   - password: Password to hash
   ///   - resolve: A JS Promise resolve block
   ///   - reject: A JS Promise reject block
-  @objc func hash(_ password: String, salt: String, params: [String: Any], resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
+  @objc func hash(_ password: [UInt8], salt: String, params: [String: Any], resolver resolve: RCTPromiseResolveBlock, rejecter reject: RCTPromiseRejectBlock) {
     // Validate parameters
     if params["t_cost"] is Int && params["m_cost"] is Int && params["parallelism"] is Int && params["hashLength"] is Int {
+      // Convert from [UInt8] to String
+      let passwordString = String(bytes: password, encoding: .utf8)!
       // Resolve the hash
-      let h = Argon2Core.argon2Hash(password: password, salt: salt, params: params)
+      let h = Argon2Core.argon2Hash(password: passwordString, salt: salt, params: params)
       resolve(h)
     } else {
       // Reject with an error message containing the parameters passed

--- a/src/mobile/ios/Podfile
+++ b/src/mobile/ios/Podfile
@@ -4,7 +4,7 @@
 target 'iotaWallet' do
     # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
     use_frameworks!
-pod 'CatCrypto', :git => 'https://github.com/rajivshah3/CatCrypto.git', :branch => 'raw-hash'
+pod 'CatCrypto', '~> 0.3.0'
 
     target 'iotaWalletTests' do
         inherit! :search_paths

--- a/src/mobile/ios/Podfile
+++ b/src/mobile/ios/Podfile
@@ -4,7 +4,7 @@
 target 'iotaWallet' do
     # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
     use_frameworks!
-pod 'CatCrypto', '~> 0.3.0'
+pod 'CatCrypto', :git => 'https://github.com/rajivshah3/CatCrypto.git', :branch => 'fix/commoncrypto'
 
     target 'iotaWalletTests' do
         inherit! :search_paths

--- a/src/mobile/ios/Podfile
+++ b/src/mobile/ios/Podfile
@@ -4,7 +4,7 @@
 target 'iotaWallet' do
     # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
     use_frameworks!
-pod 'CatCrypto', :git => 'https://github.com/rajivshah3/CatCrypto.git', :branch => 'fix/commoncrypto'
+pod 'CatCrypto', :git => 'https://github.com/rajivshah3/CatCrypto.git', :branch => 'trinity'
 
     target 'iotaWalletTests' do
         inherit! :search_paths

--- a/src/mobile/ios/Podfile.lock
+++ b/src/mobile/ios/Podfile.lock
@@ -2,15 +2,21 @@ PODS:
   - CatCrypto (0.3.0)
 
 DEPENDENCIES:
-  - CatCrypto (~> 0.3.0)
+  - CatCrypto (from `https://github.com/rajivshah3/CatCrypto.git`, branch `fix/commoncrypto`)
 
-SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
-    - CatCrypto
+EXTERNAL SOURCES:
+  CatCrypto:
+    :branch: fix/commoncrypto
+    :git: https://github.com/rajivshah3/CatCrypto.git
+
+CHECKOUT OPTIONS:
+  CatCrypto:
+    :commit: 138400e0275a3bf11260ebbd94dcec26871ef3f9
+    :git: https://github.com/rajivshah3/CatCrypto.git
 
 SPEC CHECKSUMS:
   CatCrypto: 7e3a6e0a03b699845b38cdc09d34a8127466c5e0
 
-PODFILE CHECKSUM: 8ef9fa30ed5d36626a73a5903390db40838be461
+PODFILE CHECKSUM: 9a82a4f06e15dedde425f22b022cb956bf31c794
 
 COCOAPODS: 1.5.3

--- a/src/mobile/ios/Podfile.lock
+++ b/src/mobile/ios/Podfile.lock
@@ -1,22 +1,16 @@
 PODS:
-  - CatCrypto (0.2.3)
+  - CatCrypto (0.3.0)
 
 DEPENDENCIES:
-  - CatCrypto (from `https://github.com/rajivshah3/CatCrypto.git`, branch `raw-hash`)
+  - CatCrypto (~> 0.3.0)
 
-EXTERNAL SOURCES:
-  CatCrypto:
-    :branch: raw-hash
-    :git: https://github.com/rajivshah3/CatCrypto.git
-
-CHECKOUT OPTIONS:
-  CatCrypto:
-    :commit: 7e4ba07f326cecbce5fa56312ad7d7882a217547
-    :git: https://github.com/rajivshah3/CatCrypto.git
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - CatCrypto
 
 SPEC CHECKSUMS:
-  CatCrypto: d3e607c328f7edc8befdf384515a38168e05c14e
+  CatCrypto: 7e3a6e0a03b699845b38cdc09d34a8127466c5e0
 
-PODFILE CHECKSUM: 1aac56a1029cb147fec99d5d9e4ff22206faae69
+PODFILE CHECKSUM: 8ef9fa30ed5d36626a73a5903390db40838be461
 
 COCOAPODS: 1.5.3

--- a/src/mobile/ios/Podfile.lock
+++ b/src/mobile/ios/Podfile.lock
@@ -2,21 +2,21 @@ PODS:
   - CatCrypto (0.3.0)
 
 DEPENDENCIES:
-  - CatCrypto (from `https://github.com/rajivshah3/CatCrypto.git`, branch `fix/commoncrypto`)
+  - CatCrypto (from `https://github.com/rajivshah3/CatCrypto.git`, branch `trinity`)
 
 EXTERNAL SOURCES:
   CatCrypto:
-    :branch: fix/commoncrypto
+    :branch: trinity
     :git: https://github.com/rajivshah3/CatCrypto.git
 
 CHECKOUT OPTIONS:
   CatCrypto:
-    :commit: 138400e0275a3bf11260ebbd94dcec26871ef3f9
+    :commit: d0eb6e13f19f99144fec8be1455d5a0c0f20a0ad
     :git: https://github.com/rajivshah3/CatCrypto.git
 
 SPEC CHECKSUMS:
   CatCrypto: 7e3a6e0a03b699845b38cdc09d34a8127466c5e0
 
-PODFILE CHECKSUM: 9a82a4f06e15dedde425f22b022cb956bf31c794
+PODFILE CHECKSUM: 9dd38ddc58ea139da62f0c02fc28eecd6a36c7ac
 
 COCOAPODS: 1.5.3

--- a/src/mobile/src/libs/crypto.js
+++ b/src/mobile/src/libs/crypto.js
@@ -5,7 +5,6 @@ import { TextDecoder } from 'text-encoding';
 import nacl from 'tweetnacl';
 import naclUtil from 'tweetnacl-util';
 import { getHashFn } from 'libs/nativeModules';
-import { isAndroid } from 'libs/device';
 
 const DEFAULT_ARGON2_PARAMS = { t_cost: 1, m_cost: 4096, parallelism: 4, hashLength: 32 };
 const SALT_LENGTH = 32;
@@ -26,14 +25,7 @@ export const getRandomBytes = async (quantity) => {
 
 export const generatePasswordHash = async (password, salt) => {
     const salt64 = await encodeBase64(salt);
-    if (isAndroid) {
-        return getHashFn()(values(password), salt64, DEFAULT_ARGON2_PARAMS).then(
-            (result) => new Uint8Array(result),
-            (error) => console.log(error), // eslint-disable-line no-console
-        );
-    }
-    // FIXME: iOS should hash Uint8Array, not string
-    return getHashFn()(UInt8ToString(password), salt64, DEFAULT_ARGON2_PARAMS).then(
+    return getHashFn()(values(password), salt64, DEFAULT_ARGON2_PARAMS).then(
         (result) => new Uint8Array(result),
         (error) => console.log(error), // eslint-disable-line no-console
     );

--- a/src/mobile/src/libs/crypto.js
+++ b/src/mobile/src/libs/crypto.js
@@ -34,7 +34,7 @@ export const generatePasswordHash = async (password, salt) => {
     }
     // FIXME: iOS should hash Uint8Array, not string
     return getHashFn()(UInt8ToString(password), salt64, DEFAULT_ARGON2_PARAMS).then(
-        (result) => new Uint8Array(result.split(',').map((num) => parseInt(num))),
+        (result) => new Uint8Array(result),
         (error) => console.log(error), // eslint-disable-line no-console
     );
 };


### PR DESCRIPTION
# Description

- Bump CatCrypto to 0.3.0
- Return hash as `[UInt8]`
- Accept password as `[UInt8]` (converts to `String` on native side)

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested hashing during onboarding on iOS
- Tested hashing during login (with onboarding completed on `develop` branch) on iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes