### PR TITLE
Assign Realm constructor within realm initialistation function

### DIFF
--- a/src/shared/storage/index.js
+++ b/src/shared/storage/index.js
@@ -37,6 +37,9 @@ const getStoragePath = (schemaVersion = SCHEMA_VERSION) =>
 // Initialise realm instance
 let realm = {}; // eslint-disable-line import/no-mutable-exports
 
+// Initialise Realm constructor as null and reinitialise after importing the correct (platform) Realm dependency
+let Realm = null;
+
 /**
  * Imports Realm dependency
  *
@@ -54,8 +57,6 @@ export const getRealm = () => {
 
     return Electron.getRealm();
 };
-
-const Realm = getRealm();
 
 /**
  * Model for Account.
@@ -773,17 +774,15 @@ const purge = () =>
  *
  * @returns {Promise}
  */
-const initialise = (getEncryptionKeyPromise) =>
-    getEncryptionKeyPromise().then((encryptionKey) => {
-        // For some reason `getRealm` doesn't get called before this function when running in the Chrome debugger
-        if (__MOBILE__ && /Chrome/.test(navigator.userAgent)) {
-            const Realm = getRealm();
-            realm = new Realm(assign({}, config, { encryptionKey }));
-        } else {
-            realm = new Realm(assign({}, config, { encryptionKey }));
-        }
+const initialise = (getEncryptionKeyPromise) => {
+    Realm = getRealm();
+
+    return getEncryptionKeyPromise().then((encryptionKey) => {
+        realm = new Realm(assign({}, config, { encryptionKey }));
+
         initialiseSync(encryptionKey);
     });
+};
 
 /**
  * Initialises storage.


### PR DESCRIPTION
# Description

Fix realm initialisation issue with chrome debugging on. 

https://github.com/iotaledger/trinity-wallet/pull/1174#discussion_r264649504

## Type of change

- Bug fix

# How Has This Been Tested?

- Manually tested iOS (debug)
- Manually tested desktop (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
