### PR TITLE
Add (missing) password prop to Polling component

### DIFF
--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -65,6 +65,8 @@ class Polling extends React.PureComponent {
         }).isRequired,
         /** @ignore */
         retryFailedTransaction: PropTypes.func.isRequired,
+        /** @ignore */
+        password: PropTypes.object.isRequired,
     };
 
     state = {
@@ -210,6 +212,7 @@ const mapStateToProps = (state) => ({
     isTransitioning: state.ui.isTransitioning,
     isRetryingFailedTransaction: state.ui.isRetryingFailedTransaction,
     failedBundleHashes: getFailedBundleHashes(state),
+    password: state.wallet.password,
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
# Description

`password` prop is now used in `Polling` component but was missing leading to an exception when `SeedStore` was instantiated with `undefined` password.  

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
