### PR TITLE
Desktop: Fix snapshot transition

### DIFF
--- a/src/desktop/src/ui/views/settings/account/Tools.js
+++ b/src/desktop/src/ui/views/settings/account/Tools.js
@@ -13,6 +13,8 @@ import {
     generateAddressesAndGetBalance,
 } from 'actions/wallet';
 
+import { getAddressesForSelectedAccount } from 'selectors/accounts';
+
 import { formatValue, formatUnit } from 'libs/iota/utils';
 import { round } from 'libs/utils';
 import SeedStore from 'libs/SeedStore';
@@ -36,6 +38,8 @@ class Tools extends PureComponent {
         ui: PropTypes.object.isRequired,
         /** @ignore */
         account: PropTypes.object.isRequired,
+        /** Addresses for selected account */
+        addresses: PropTypes.array.isRequired,
         /** @ignore */
         completeSnapshotTransition: PropTypes.func.isRequired,
         /** @ignore */
@@ -103,12 +107,12 @@ class Tools extends PureComponent {
      * @returns {Promise}
      */
     startSnapshotTransition = async () => {
-        const { wallet } = this.props;
-        const { accountName, meta, addressData } = this.props.account;
+        const { wallet, addresses } = this.props;
+        const { accountName, meta } = this.props.account;
 
         const seedStore = await new SeedStore[meta.type](wallet.password, accountName, meta);
 
-        this.props.transitionForSnapshot(seedStore, addressData);
+        this.props.transitionForSnapshot(seedStore, addresses);
     };
 
     /**
@@ -235,6 +239,7 @@ const mapStateToProps = (state) => ({
     ui: state.ui,
     wallet: state.wallet,
     settings: state.settings,
+    addresses: getAddressesForSelectedAccount(state),
     activeStepIndex: state.progress.activeStepIndex,
     activeSteps: state.progress.activeSteps,
 });


### PR DESCRIPTION
# Description
Passes addresses from selector instead of from `addressData` object

Fixes #1134 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on macOS (debug)


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes