### PR TITLE
Use lodash.map for converting RealmObjects to plain array

### DIFF
--- a/src/shared/storage/index.js
+++ b/src/shared/storage/index.js
@@ -8,7 +8,6 @@ import isUndefined from 'lodash/isUndefined';
 import map from 'lodash/map';
 import merge from 'lodash/merge';
 import omit from 'lodash/omit';
-import values from 'lodash/values';
 import size from 'lodash/size';
 import {
     TransactionSchema,
@@ -96,8 +95,9 @@ class Account {
 
         return map(accounts, (account) =>
             assign({}, account, {
-                addressData: values(account.addressData),
-                transactions: values(account.transactions),
+                addressData: map(account.addressData, (data) => assign({}, data)),
+                transactions: map(account.transactions, (transaction) => assign({}, transaction)),
+                meta: assign({}, account.meta),
             }),
         );
     }
@@ -154,7 +154,10 @@ class Account {
                 name,
                 addressData: isEmpty(data.addressData)
                     ? existingData.addressData
-                    : preserveAddressLocalSpendStatus(values(existingData.addressData), data.addressData),
+                    : preserveAddressLocalSpendStatus(
+                          map(existingData.addressData, (data) => assign({}, data)),
+                          data.addressData,
+                      ),
             });
 
             realm.create('Account', updatedData, true);


### PR DESCRIPTION
# Description

[lodash.values](https://lodash.com/docs/4.17.11#values) doesn't seem to work anymore on desktop for converting objects of type `RealmObject` to plain objects. 

## Type of change

- Bug fix

# How Has This Been Tested?

- Manually tested desktop
- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
