### PR TITLE
Fix propType warnings

### DIFF
--- a/src/mobile/__tests__/ui/components/Poll.spec.js
+++ b/src/mobile/__tests__/ui/components/Poll.spec.js
@@ -39,6 +39,9 @@ const getProps = (overrides) =>
             promoteTransfer: noop,
             removeBundleFromUnconfirmedBundleTails: noop,
             fetchNodeList: noop,
+            failedBundleHashes: {},
+            retryFailedTransaction: noop,
+            password: new Uint8Array(),
         },
         overrides,
     );


### PR DESCRIPTION
# Description

Fix propType warnings in (mobile) tests

## Type of change

- Bug fix 

# How Has This Been Tested?

Manually tested by `yarn test` in `mobile/` directory

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
