### PR TITLE
Block untraversable bundles from getting broadcasted

### DIFF
--- a/src/shared/__tests__/__samples__/transactions.js
+++ b/src/shared/__tests__/__samples__/transactions.js
@@ -973,6 +973,11 @@ const newValueTransaction = [
     },
 ];
 
+const newValueAttachedTransactionBaseTrunk =
+    'LHPBIUXOUJFVXDXOH9RAFDHPZHKKQXOBWWWRAYBKSYFZGEFRYWJBTCETHFUMJUTWGTNXTIPVJTOM99999';
+const newValueAttachedTransactionBaseBranch =
+    'VEZTEROA9IUNBSIKJMZRDFYAVNCZAGQJEERLZIFCSHISPKATHRPLOQGECZWLWFAMBX9DRLUUPNI999999';
+
 const newValueAttachedTransaction = [
     {
         hash: 'MHZUAFTZZPZUSLO9QUVSQJEDKCVOQJYIKPNHICGYBJGHTLSPMZMKKWMMFGKOHLHQEMS9HMJFOUXUZ9999',
@@ -1079,6 +1084,8 @@ export {
     newZeroValueAttachedTransactionBaseTrunk,
     newZeroValueAttachedTransactionBaseBranch,
     newValueTransaction,
+    newValueAttachedTransactionBaseTrunk,
+    newValueAttachedTransactionBaseBranch,
     newValueAttachedTransaction,
     LATEST_MILESTONE,
     LATEST_SOLID_SUBTANGLE_MILESTONE,

--- a/src/shared/__tests__/__samples__/transactions.js
+++ b/src/shared/__tests__/__samples__/transactions.js
@@ -887,6 +887,10 @@ const newZeroValueTransaction = [
     },
 ];
 
+const newZeroValueAttachedTransactionBaseTrunk =
+    'LHPBIUXOUJFVXDXOH9RAFDHPZHKKQXOBWWWRAYBKSYFZGEFRYWJBTCETHFUMJUTWGTNXTIPVJTOM99999';
+const newZeroValueAttachedTransactionBaseBranch =
+    'VEZTEROA9IUNBSIKJMZRDFYAVNCZAGQJEERLZIFCSHISPKATHRPLOQGECZWLWFAMBX9DRLUUPNI999999';
 const newZeroValueAttachedTransaction = [
     {
         hash: 'GQG9HINYS9PGQOVMGVNDBIETZ99JBHGIJTWYPFANQ9KOOCJJMEHWMZLVTWUIKMQGERYOXUYWDJFB99999',
@@ -899,8 +903,8 @@ const newZeroValueAttachedTransaction = [
         currentIndex: 0,
         lastIndex: 0,
         bundle: '9TRXZYWHZF9LKWWUXWZLER9SGDIUXDIXLNPNJKEZDWIHKFGBNCLYNJOYTALRWZSYUZCYFESFLCVQSGKZW',
-        trunkTransaction: 'LHPBIUXOUJFVXDXOH9RAFDHPZHKKQXOBWWWRAYBKSYFZGEFRYWJBTCETHFUMJUTWGTNXTIPVJTOM99999',
-        branchTransaction: 'VEZTEROA9IUNBSIKJMZRDFYAVNCZAGQJEERLZIFCSHISPKATHRPLOQGECZWLWFAMBX9DRLUUPNI999999',
+        trunkTransaction: newZeroValueAttachedTransactionBaseTrunk,
+        branchTransaction: newZeroValueAttachedTransactionBaseBranch,
         tag: 'TRINITY99999999999999999999',
         attachmentTimestamp: 1548684259457,
         attachmentTimestampLowerBound: 0,
@@ -1072,6 +1076,8 @@ export {
     promotableBundleHashes,
     newZeroValueTransaction,
     newZeroValueAttachedTransaction,
+    newZeroValueAttachedTransactionBaseTrunk,
+    newZeroValueAttachedTransactionBaseBranch,
     newValueTransaction,
     newValueAttachedTransaction,
     LATEST_MILESTONE,

--- a/src/shared/__tests__/actions/transfers.spec.js
+++ b/src/shared/__tests__/actions/transfers.spec.js
@@ -324,10 +324,8 @@ describe('actions: transfers', () => {
                 .reply(200, (_, body) => {
                     if (body.command === 'getTransactionsToApprove') {
                         return {
-                            branchTransaction:
-                                'MFZXHOXKGVVBDGSVXIGEFBFDXICQDK9UQFVSQCAJMZICRXDGBRZMHHJUGTDPWTEHWSREZFDCRRYD99999',
-                            trunkTransaction:
-                                'OAAMETLECXOVQNTTAKCNWPZSQALUYEGTO9QGEQL9ST9RFJ9JPNBHTOABJQTCIHKMNUMHEKZJSFYT99999',
+                            branchTransaction: '9'.repeat(81),
+                            trunkTransaction: '9'.repeat(81),
                         };
                     }
 

--- a/src/shared/__tests__/libs/iota/addresses.spec.js
+++ b/src/shared/__tests__/libs/iota/addresses.spec.js
@@ -21,6 +21,8 @@ import {
 } from '../../__samples__/addresses';
 import transactions, {
     newZeroValueAttachedTransaction,
+    newZeroValueAttachedTransactionBaseBranch,
+    newZeroValueAttachedTransactionBaseTrunk,
     confirmedZeroValueTransactions,
     unconfirmedValueTransactions,
     LATEST_MILESTONE,
@@ -2358,8 +2360,8 @@ describe('libs: iota/addresses', () => {
                             return { hashes: map(addresses, () => EMPTY_HASH_TRYTES) };
                         } else if (body.command === 'getTransactionsToApprove') {
                             return {
-                                trunkTransaction: EMPTY_HASH_TRYTES,
-                                branchTransaction: EMPTY_HASH_TRYTES,
+                                trunkTransaction: newZeroValueAttachedTransactionBaseTrunk,
+                                branchTransaction: newZeroValueAttachedTransactionBaseBranch,
                             };
                         } else if (body.command === 'attachToTangle') {
                             return { trytes: newZeroValueTransactionTrytes };
@@ -2429,8 +2431,8 @@ describe('libs: iota/addresses', () => {
                             return { hashes: [] };
                         } else if (body.command === 'getTransactionsToApprove') {
                             return {
-                                trunkTransaction: EMPTY_HASH_TRYTES,
-                                branchTransaction: EMPTY_HASH_TRYTES,
+                                trunkTransaction: newZeroValueAttachedTransactionBaseTrunk,
+                                branchTransaction: newZeroValueAttachedTransactionBaseBranch,
                             };
                         } else if (body.command === 'attachToTangle') {
                             return { trytes: newZeroValueTransactionTrytes };

--- a/src/shared/__tests__/libs/iota/recovery.spec.js
+++ b/src/shared/__tests__/libs/iota/recovery.spec.js
@@ -318,6 +318,14 @@ describe('libs: iota/recovery', () => {
                                     )
                                 ) {
                                     return { trytes: milestoneTrytes };
+                                } else if (body.command === 'getTransactionsToApprove') {
+                                    return {
+                                        // Extracted from attachedTrytes
+                                        trunkTransaction:
+                                            'QGXGXHHDLBKBVX9BXRUSWRKIOWJQSDNTZCGAQOY9MAAIPFXIBCCBKJVHA9KOMPOBFZUIFRIFDLBFZ9999',
+                                        branchTransaction:
+                                            'HUBZQRKUTAPZNQZIFNYH9YZFJVWOJZXJKSKCLQIGSJNAATOLYZDMEZPLWKQG9XEEHQRSJWCOGNHR99999',
+                                    };
                                 }
 
                                 return resultMap[body.command] || {};
@@ -377,6 +385,13 @@ describe('libs: iota/recovery', () => {
                         },
                         getTrytes: {
                             trytes: invalidTrytes,
+                        },
+                        getTransactionsToApprove: {
+                            // Extracted from attachedTrytes
+                            trunkTransaction:
+                                'QGXGXHHDLBKBVX9BXRUSWRKIOWJQSDNTZCGAQOY9MAAIPFXIBCCBKJVHA9KOMPOBFZUIFRIFDLBFZ9999',
+                            branchTransaction:
+                                'HUBZQRKUTAPZNQZIFNYH9YZFJVWOJZXJKSKCLQIGSJNAATOLYZDMEZPLWKQG9XEEHQRSJWCOGNHR99999',
                         },
                     });
 
@@ -477,6 +492,13 @@ describe('libs: iota/recovery', () => {
                         // signedTrytes do not have the valid hash, so the bundle should be invalid
                         // and input addresses should not be blocked from spending
                         getTrytes: { trytes: validSignedTrytes },
+                        getTransactionsToApprove: {
+                            // Extracted from attachedTrytes
+                            trunkTransaction:
+                                'QGXGXHHDLBKBVX9BXRUSWRKIOWJQSDNTZCGAQOY9MAAIPFXIBCCBKJVHA9KOMPOBFZUIFRIFDLBFZ9999',
+                            branchTransaction:
+                                'HUBZQRKUTAPZNQZIFNYH9YZFJVWOJZXJKSKCLQIGSJNAATOLYZDMEZPLWKQG9XEEHQRSJWCOGNHR99999',
+                        },
                     });
 
                     nock('http://localhost:14265', {
@@ -574,7 +596,17 @@ describe('libs: iota/recovery', () => {
 
         describe('when signed bundle is valid', () => {
             beforeEach(() => {
-                setupNock();
+                setupNock(
+                    merge({}, defaultResultMap, {
+                        getTransactionsToApprove: {
+                            // Extracted from attachedTrytes
+                            trunkTransaction:
+                                'QGXGXHHDLBKBVX9BXRUSWRKIOWJQSDNTZCGAQOY9MAAIPFXIBCCBKJVHA9KOMPOBFZUIFRIFDLBFZ9999',
+                            branchTransaction:
+                                'HUBZQRKUTAPZNQZIFNYH9YZFJVWOJZXJKSKCLQIGSJNAATOLYZDMEZPLWKQG9XEEHQRSJWCOGNHR99999',
+                        },
+                    }),
+                );
             });
 
             afterEach(() => {

--- a/src/shared/__tests__/libs/iota/transfers.spec.js
+++ b/src/shared/__tests__/libs/iota/transfers.spec.js
@@ -30,16 +30,18 @@ import { confirmedValueBundles, unconfirmedValueBundles, confirmedZeroValueBundl
 import { iota, SwitchingConfig } from '../../../libs/iota';
 import {
     newValueTransactionTrytes,
+    newValueAttachedTransactionTrytes,
     failedTrytesWithCorrectTransactionHashes,
-    failedTrytesWithIncorrectTransactionHashes,
     milestoneTrytes,
 } from '../../__samples__/trytes';
 import {
+    newValueAttachedTransactionBaseTrunk,
+    newValueAttachedTransactionBaseBranch,
+    newValueAttachedTransaction,
     confirmedValueTransactions,
     unconfirmedValueTransactions,
     failedTransactionsWithCorrectTransactionHashes,
     failedTransactionsWithIncorrectTransactionHashes,
-    newValueAttachedTransaction,
     LATEST_MILESTONE,
     LATEST_SOLID_SUBTANGLE_MILESTONE,
     LATEST_MILESTONE_INDEX,
@@ -880,14 +882,14 @@ describe('libs: iota/transfers', () => {
         describe('when any transaction object has an invalid hash', () => {
             it('should perform proof of work', () => {
                 sinon.stub(seedStore, 'performPow').resolves({
-                    trytes: failedTrytesWithIncorrectTransactionHashes,
-                    transactionObjects: failedTransactionsWithIncorrectTransactionHashes,
+                    trytes: newValueAttachedTransactionTrytes,
+                    transactionObjects: newValueAttachedTransaction,
                 });
 
                 const storeAndBroadcast = sinon.stub(iota.api, 'storeAndBroadcast').yields(null, []);
                 const getTransactionToApprove = sinon.stub(iota.api, 'getTransactionsToApprove').yields(null, {
-                    trunkTransaction: '9'.repeat(81),
-                    branchTransaction: '9'.repeat(81),
+                    trunkTransaction: newValueAttachedTransactionBaseTrunk,
+                    branchTransaction: newValueAttachedTransactionBaseBranch,
                 });
 
                 return retryFailedTransaction()(failedTransactionsWithIncorrectTransactionHashes, seedStore).then(
@@ -905,14 +907,14 @@ describe('libs: iota/transfers', () => {
         describe('when any transaction object has an empty hash', () => {
             it('should perform proof of work', () => {
                 sinon.stub(seedStore, 'performPow').resolves({
-                    trytes: failedTrytesWithIncorrectTransactionHashes,
-                    transactionObjects: failedTransactionsWithIncorrectTransactionHashes,
+                    trytes: newValueAttachedTransactionTrytes,
+                    transactionObjects: newValueAttachedTransaction,
                 });
 
                 const storeAndBroadcast = sinon.stub(iota.api, 'storeAndBroadcast').yields(null, []);
                 const getTransactionToApprove = sinon.stub(iota.api, 'getTransactionsToApprove').yields(null, {
-                    trunkTransaction: '9'.repeat(81),
-                    branchTransaction: '9'.repeat(81),
+                    trunkTransaction: newValueAttachedTransactionBaseTrunk,
+                    branchTransaction: newValueAttachedTransactionBaseBranch,
                 });
 
                 return retryFailedTransaction()(

--- a/src/shared/__tests__/libs/iota/transfers.spec.js
+++ b/src/shared/__tests__/libs/iota/transfers.spec.js
@@ -24,6 +24,7 @@ import {
     categoriseInclusionStatesByBundleHash,
     assignInclusionStatesToBundles,
     filterZeroValueBundles,
+    isBundleTraversable,
 } from '../../../libs/iota/transfers';
 import { confirmedValueBundles, unconfirmedValueBundles, confirmedZeroValueBundles } from '../../__samples__/bundles';
 import { iota, SwitchingConfig } from '../../../libs/iota';
@@ -38,6 +39,7 @@ import {
     unconfirmedValueTransactions,
     failedTransactionsWithCorrectTransactionHashes,
     failedTransactionsWithIncorrectTransactionHashes,
+    newValueAttachedTransaction,
     LATEST_MILESTONE,
     LATEST_SOLID_SUBTANGLE_MILESTONE,
     LATEST_MILESTONE_INDEX,
@@ -1250,6 +1252,40 @@ describe('libs: iota/transfers', () => {
             const expectedResult = [...confirmedValueBundles, ...unconfirmedValueBundles];
 
             expect(result).to.eql(expectedResult);
+        });
+    });
+
+    describe('#isBundleTraversable', () => {
+        let trunkTransaction;
+        let branchTransaction;
+
+        before(() => {
+            // See trunk/branch transactions of newValueAttachedTransaction transaction object with currentIndex 2
+            trunkTransaction = 'LHPBIUXOUJFVXDXOH9RAFDHPZHKKQXOBWWWRAYBKSYFZGEFRYWJBTCETHFUMJUTWGTNXTIPVJTOM99999';
+            branchTransaction = 'VEZTEROA9IUNBSIKJMZRDFYAVNCZAGQJEERLZIFCSHISPKATHRPLOQGECZWLWFAMBX9DRLUUPNI999999';
+        });
+
+        it('should return true for bundle with correct trunk/branch assignment', () => {
+            expect(isBundleTraversable(newValueAttachedTransaction, trunkTransaction, branchTransaction)).to.equal(
+                true,
+            );
+        });
+
+        it('should return false for bundle with incorrect trunk/branch assignment', () => {
+            expect(
+                isBundleTraversable(
+                    map(
+                        newValueAttachedTransaction,
+                        (transaction, index) =>
+                            index % 2 === 0
+                                ? {
+                                      ...transaction,
+                                      trunkTransaction: '9'.repeat(81),
+                                  }
+                                : transaction,
+                    ),
+                ),
+            ).to.equal(false);
         });
     });
 });

--- a/src/shared/__tests__/libs/iota/transfers.spec.js
+++ b/src/shared/__tests__/libs/iota/transfers.spec.js
@@ -886,8 +886,8 @@ describe('libs: iota/transfers', () => {
 
                 const storeAndBroadcast = sinon.stub(iota.api, 'storeAndBroadcast').yields(null, []);
                 const getTransactionToApprove = sinon.stub(iota.api, 'getTransactionsToApprove').yields(null, {
-                    trunkTransaction: 'R'.repeat(81),
-                    branchTransaction: 'A'.repeat(81),
+                    trunkTransaction: '9'.repeat(81),
+                    branchTransaction: '9'.repeat(81),
                 });
 
                 return retryFailedTransaction()(failedTransactionsWithIncorrectTransactionHashes, seedStore).then(
@@ -911,8 +911,8 @@ describe('libs: iota/transfers', () => {
 
                 const storeAndBroadcast = sinon.stub(iota.api, 'storeAndBroadcast').yields(null, []);
                 const getTransactionToApprove = sinon.stub(iota.api, 'getTransactionsToApprove').yields(null, {
-                    trunkTransaction: 'R'.repeat(81),
-                    branchTransaction: 'A'.repeat(81),
+                    trunkTransaction: '9'.repeat(81),
+                    branchTransaction: '9'.repeat(81),
                 });
 
                 return retryFailedTransaction()(

--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -19,7 +19,7 @@ import {
     ATTACH_TO_TANGLE_REQUEST_TIMEOUT,
     IRI_API_VERSION,
 } from '../../config';
-import { sortTransactionTrytesArray, constructBundleFromAttachedTrytes } from './transfers';
+import { sortTransactionTrytesArray, constructBundleFromAttachedTrytes, isBundleTraversable } from './transfers';
 import { EMPTY_HASH_TRYTES } from './utils';
 
 /**
@@ -505,7 +505,10 @@ const attachToTangleAsync = (provider, seedStore) => (
                     } else {
                         constructBundleFromAttachedTrytes(attachedTrytes, seedStore)
                             .then((transactionObjects) => {
-                                if (iota.utils.isBundle(transactionObjects)) {
+                                if (
+                                    iota.utils.isBundle(transactionObjects) &&
+                                    isBundleTraversable(transactionObjects, trunkTransaction, branchTransaction)
+                                ) {
                                     resolve({
                                         transactionObjects,
                                         trytes: attachedTrytes,
@@ -535,12 +538,16 @@ const attachToTangleAsync = (provider, seedStore) => (
             }));
         })
         .then(({ transactionObjects, trytes }) => {
-            if (iota.utils.isBundle(transactionObjects)) {
+            if (
+                iota.utils.isBundle(transactionObjects) &&
+                isBundleTraversable(transactionObjects, trunkTransaction, branchTransaction)
+            ) {
                 return {
                     transactionObjects,
                     trytes,
                 };
             }
+
             throw new Error(Errors.INVALID_BUNDLE_CONSTRUCTED_WITH_LOCAL_POW);
         });
 };

--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -3,6 +3,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import clone from 'lodash/clone';
 import get from 'lodash/get';
 import each from 'lodash/each';
+import every from 'lodash/every';
 import find from 'lodash/find';
 import findIndex from 'lodash/findIndex';
 import flatMap from 'lodash/flatMap';
@@ -1033,7 +1034,8 @@ export const constructBundleFromAttachedTrytes = (attachedTrytes, seedStore) => 
  * @returns {boolean}
  */
 export const isBundleTraversable = (bundle, trunkTransaction, branchTransaction) =>
-    some(
+    !isEmpty(bundle) &&
+    every(
         orderBy(bundle, ['currentIndex'], ['desc']),
         (transaction, index, transactions) =>
             index

--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -1020,3 +1020,25 @@ export const constructBundleFromAttachedTrytes = (attachedTrytes, seedStore) => 
         Promise.resolve([]),
     );
 };
+
+/**
+ * Checks if bundle can be traversed
+ *
+ * @method isBundleTraversable
+ *
+ * @param {array} bundle
+ * @param {string} trunkTransaction
+ * @param {string} branchTransaction
+ *
+ * @returns {boolean}
+ */
+export const isBundleTraversable = (bundle, trunkTransaction, branchTransaction) =>
+    some(
+        orderBy(bundle, ['currentIndex'], ['desc']),
+        (transaction, index, transactions) =>
+            index
+                ? transaction.trunkTransaction === transactions[index - 1].hash &&
+                  transaction.branchTransaction === trunkTransaction
+                : transaction.trunkTransaction === trunkTransaction &&
+                  transaction.branchTransaction === branchTransaction,
+    );


### PR DESCRIPTION
# Description

Do not allow bundles with inconsistent trunk/branch assignment to be broadcasted to the tangle. 

## Type of change

- Enhancement

# How Has This Been Tested?

- Unit test coverage
- Manually tested desktop (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
