### PR TITLE
Mobile: Fix CustomTextField mask bugs

### DIFF
--- a/src/mobile/__tests__/ui/components/CustomTextInput.spec.js
+++ b/src/mobile/__tests__/ui/components/CustomTextInput.spec.js
@@ -43,6 +43,10 @@ describe('Testing CustomTextInput component', () => {
             expect(CustomTextInput.propTypes.containerStyle).toEqual(PropTypes.object);
         });
 
+        it('should accept a widgets array as a prop', () => {
+            expect(CustomTextInput.propTypes.widgets).toEqual(PropTypes.array);
+        });
+
         it('should accept a onDenominationPress function as a prop', () => {
             expect(CustomTextInput.propTypes.onDenominationPress).toEqual(PropTypes.func);
         });
@@ -113,6 +117,22 @@ describe('Testing CustomTextInput component', () => {
 
             const wrapper = shallow(<CustomTextInput {...props} />);
             expect(wrapper.find('TextInput').length).toEqual(1);
+        });
+
+        it('should mask input when "mask" is specified in the "widgets" prop', () => {
+            const props = getProps();
+            props.widgets = ['mask'];
+
+            const wrapper = shallow(<CustomTextInput {...props} />);
+            expect(wrapper.find('Icon').prop('name')).toEqual('eyeSlash');
+            expect(wrapper.find('TextInput').prop('secureTextEntry')).toEqual(true);
+        });
+
+        it('should not mask input when "mask" is not specified in the "widgets" prop', () => {
+            const props = getProps();
+
+            const wrapper = shallow(<CustomTextInput {...props} />);
+            expect(wrapper.find('TextInput').prop('secureTextEntry')).toEqual(false);
         });
     });
 

--- a/src/mobile/src/ui/components/CustomTextInput.js
+++ b/src/mobile/src/ui/components/CustomTextInput.js
@@ -181,11 +181,11 @@ class CustomTextInput extends Component {
         isPasswordInput: false,
     };
 
-    constructor() {
+    constructor(props) {
         super();
         this.state = {
             isFocused: false,
-            isSecretMasked: true,
+            isSecretMasked: props.widgets.indexOf('mask') > -1,
         };
     }
 

--- a/src/mobile/src/ui/views/onboarding/EnterSeed.js
+++ b/src/mobile/src/ui/views/onboarding/EnterSeed.js
@@ -238,7 +238,6 @@ class EnterSeed extends React.Component {
                                         autoCorrect={false}
                                         enablesReturnKeyAutomatically
                                         returnKeyType="done"
-                                        secureTextEntry
                                         onSubmitEditing={() => this.onDonePress()}
                                         maxLength={MAX_SEED_LENGTH}
                                         value={this.state.seed}
@@ -301,7 +300,7 @@ const mapDispatchToProps = {
     generateAlert,
     toggleModalActivity,
     setAccountInfoDuringSetup,
-    setDoNotMinimise
+    setDoNotMinimise,
 };
 
 export default WithUserActivity()(


### PR DESCRIPTION
# Description

- Fix seed always being masked on EnterSeed screen
- Prevent masking on text fields that aren't supposed to be masked

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on iOS (debug)
- Unit tests

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes