### PR TITLE
Desktop: Set default value for ​max​ as 256 in random byte generation

### DIFF
--- a/src/desktop/src/libs/crypto.js
+++ b/src/desktop/src/libs/crypto.js
@@ -12,7 +12,7 @@ export const MAX_ACC_LENGTH = 250;
  * @param {number} Max - Random byte max range
  * @returns {array} Random number array
  */
-export const randomBytes = (size, max) => {
+export const randomBytes = (size, max = 256) => {
     if (size !== parseInt(size, 10) || size < 0) {
         return false;
     }


### PR DESCRIPTION
# Description

- Adds random bytes default max param of 256

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
