### PR TITLE
Mobile: Fix Android secure text entry for seed inputs

### DIFF
--- a/src/mobile/src/ui/views/onboarding/EnterSeed.js
+++ b/src/mobile/src/ui/views/onboarding/EnterSeed.js
@@ -234,7 +234,6 @@ class EnterSeed extends React.Component {
                                         label={t('global:seed')}
                                         onValidTextChange={(seed) => this.setState({ seed })}
                                         theme={theme}
-                                        autoCapitalize="characters"
                                         autoCorrect={false}
                                         enablesReturnKeyAutomatically
                                         returnKeyType="done"

--- a/src/mobile/src/ui/views/onboarding/SeedReentry.js
+++ b/src/mobile/src/ui/views/onboarding/SeedReentry.js
@@ -230,7 +230,6 @@ class SeedReentry extends Component {
                                             label={t('global:seed')}
                                             onValidTextChange={(text) => this.setState({ reenteredSeed: text })}
                                             maxLength={MAX_SEED_LENGTH}
-                                            autoCapitalize="characters"
                                             autoCorrect={false}
                                             enablesReturnKeyAutomatically
                                             returnKeyType="done"
@@ -293,7 +292,7 @@ const mapStateToProps = (state) => ({
 const mapDispatchToProps = {
     generateAlert,
     toggleModalActivity,
-    setDoNotMinimise
+    setDoNotMinimise,
 };
 
 export default WithUserActivity()(

--- a/src/mobile/src/ui/views/wallet/Send.js
+++ b/src/mobile/src/ui/views/wallet/Send.js
@@ -704,7 +704,6 @@ export class Send extends Component {
                                     this.props.setSendAddressField(text);
                                 }
                             }}
-                            autoCapitalize="characters"
                             autoCorrect={false}
                             enablesReturnKeyAutomatically
                             returnKeyType="next"

--- a/src/mobile/src/ui/views/wallet/UseExistingSeed.js
+++ b/src/mobile/src/ui/views/wallet/UseExistingSeed.js
@@ -276,7 +276,6 @@ class UseExistingSeed extends Component {
                             label={t('global:seed')}
                             onValidTextChange={(text) => this.setState({ seed: text })}
                             containerStyle={{ width: Styling.contentWidth }}
-                            autoCapitalize="characters"
                             maxLength={MAX_SEED_LENGTH}
                             value={seed}
                             autoCorrect={false}


### PR DESCRIPTION
# Description

- Fixes failure to mask seed inputs on Android

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on iOS and Android simulators

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
