### PR TITLE
Mobile: Fix Android QR overlap

### DIFF
--- a/src/mobile/src/ui/views/wallet/Receive.js
+++ b/src/mobile/src/ui/views/wallet/Receive.js
@@ -65,6 +65,7 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         borderTopRightRadius: 6,
         borderTopLeftRadius: 6,
+        zIndex: 1
     },
     qrContainerFront: {
         flex: 3.75,


### PR DESCRIPTION
# Description

- Fixes Android QR padding overlap

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on Android and iOS simulators

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
