### PR TITLE
Mobile: Improve write seed down UX

### DIFF
--- a/src/mobile/src/libs/navigation.js
+++ b/src/mobile/src/libs/navigation.js
@@ -29,7 +29,7 @@ const getDefaultOptions = (nextScreen) => {
 
 export const navigator = {
     push: (nextScreen, options = {}, delay = 300) => {
-        const currentScreen = last(store.getState().ui.navStack);
+        const currentScreen = last(store.getState().wallet.navStack);
         store.dispatch({ type: ActionTypes.PUSH_ROUTE, payload: nextScreen });
         return timer.setTimeout(
             currentScreen,
@@ -37,6 +37,7 @@ export const navigator = {
                 Navigation.push('appStack', {
                     component: {
                         name: nextScreen,
+                        id: nextScreen,
                         options: merge({}, getDefaultOptions(nextScreen), options),
                     },
                 }),
@@ -44,12 +45,17 @@ export const navigator = {
         );
     },
     pop: (componentId, delay = 300) => {
-        const currentScreen = last(store.getState().ui.navStack);
+        const currentScreen = last(store.getState().wallet.navStack);
         store.dispatch({ type: ActionTypes.POP_ROUTE });
         return timer.setTimeout(currentScreen, () => Navigation.pop(componentId), delay);
     },
+    popTo: (componentId, delay = 300) => {
+        const currentScreen = last(store.getState().wallet.navStack);
+        store.dispatch({ type: ActionTypes.POP_TO_ROUTE });
+        return timer.setTimeout(currentScreen, () => Navigation.popTo(componentId), delay);
+    },
     setStackRoot: (nextScreen, options = {}, delay = 300) => {
-        const currentScreen = last(store.getState().ui.navStack);
+        const currentScreen = last(store.getState().wallet.navStack);
         store.dispatch({ type: ActionTypes.RESET_ROUTE, payload: nextScreen });
         return timer.setTimeout(
             currentScreen,
@@ -57,6 +63,7 @@ export const navigator = {
                 Navigation.setStackRoot('appStack', {
                     component: {
                         name: nextScreen,
+                        id: nextScreen,
                         options: merge({}, options, getDefaultOptions(nextScreen)),
                     },
                 }),

--- a/src/mobile/src/ui/routes/navigation.js
+++ b/src/mobile/src/ui/routes/navigation.js
@@ -13,6 +13,7 @@ import LanguageSetup from 'ui/views/onboarding/LanguageSetup';
 import EnterSeed from 'ui/views/onboarding/EnterSeed';
 import SaveYourSeed from 'ui/views/onboarding/SaveYourSeed';
 import SetPassword from 'ui/views/onboarding/SetPassword';
+import PrintBlankTemplate from 'ui/views/onboarding/PrintBlankTemplate';
 import WriteSeedDown from 'ui/views/onboarding/WriteSeedDown';
 import SaveSeedConfirmation from 'ui/views/onboarding/SaveSeedConfirmation';
 import Login from 'ui/views/wallet/Login';
@@ -54,6 +55,7 @@ export default function registerScreens(store, Provider) {
     Navigation.registerComponentWithRedux('setPassword', () => applyHOCs(SetPassword), Provider, store);
     Navigation.registerComponentWithRedux('login', () => applyHOCs(Login), Provider, store);
     Navigation.registerComponentWithRedux('writeSeedDown', () => applyHOCs(WriteSeedDown), Provider, store);
+    Navigation.registerComponentWithRedux('printBlankTemplate', () => applyHOCs(PrintBlankTemplate), Provider, store);
     Navigation.registerComponentWithRedux('languageSetup', () => applyHOCs(LanguageSetup), Provider, store);
     Navigation.registerComponentWithRedux(
         'walletResetConfirm',

--- a/src/mobile/src/ui/views/onboarding/PrintBlankTemplate.js
+++ b/src/mobile/src/ui/views/onboarding/PrintBlankTemplate.js
@@ -1,0 +1,237 @@
+import React, { Component } from 'react';
+import { withNamespaces } from 'react-i18next';
+import { StyleSheet, View, Text } from 'react-native';
+import { Navigation } from 'react-native-navigation';
+import { navigator } from 'libs/navigation';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import RNPrint from 'react-native-print';
+import { paperWallet } from 'shared-modules/images/PaperWallets.js';
+import { toggleModalActivity } from 'shared-modules/actions/ui';
+import { getThemeFromState } from 'shared-modules/selectors/global';
+import DualFooterButtons from 'ui/components/DualFooterButtons';
+import AnimatedComponent from 'ui/components/AnimatedComponent';
+import { height } from 'libs/dimensions';
+import { Styling } from 'ui/theme/general';
+import { isAndroid } from 'libs/device';
+import Header from 'ui/components/Header';
+import InfoBox from 'ui/components/InfoBox';
+import { leaveNavigationBreadcrumb } from 'libs/bugsnag';
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    topContainer: {
+        flex: 1.4,
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+    },
+    midContainer: {
+        flex: 2.6,
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+    bottomContainer: {
+        flex: 0.5,
+        justifyContent: 'flex-end',
+    },
+    infoText: {
+        color: 'white',
+        fontFamily: 'SourceSansPro-Light',
+        fontSize: Styling.fontSize3,
+        textAlign: 'center',
+        backgroundColor: 'transparent',
+        width: Styling.contentWidth,
+    },
+    infoTextBold: {
+        fontFamily: 'SourceSansPro-SemiBold',
+        fontSize: Styling.fontSize3,
+        textAlign: 'center',
+        backgroundColor: 'transparent',
+        paddingTop: height / 30,
+    },
+});
+
+/** Print Blank Template component */
+class PrintBlankTemplate extends Component {
+    static propTypes = {
+        /** Component ID */
+        componentId: PropTypes.string.isRequired,
+        /** @ignore */
+        t: PropTypes.func.isRequired,
+        /** @ignore */
+        theme: PropTypes.object.isRequired,
+    };
+
+    constructor(props) {
+        super(props);
+        Navigation.events().bindComponent(this);
+        this.state = {
+            hasPressedPrint: false,
+        };
+    }
+
+    componentDidMount() {
+        leaveNavigationBreadcrumb('PrintBlankTemplate');
+    }
+
+    /**
+     * Wrapper method for printing a blank paper wallet
+     * @method onPrintPress
+     */
+    onPrintPress() {
+        this.print();
+    }
+
+    /**
+     * Navigates back to the previous active screen in navigation stack
+     * @method onBackPress
+     */
+    onBackPress() {
+        navigator.pop(this.props.componentId);
+    }
+
+    /**
+     * Navigates to write seed down page
+     * @method onBackPress
+     */
+    onNextPress() {
+        navigator.push('writeSeedDown');
+    }
+
+    /**
+     *  Triggers blank paper wallet print
+     *  @method print
+     */
+    async print() {
+        const { theme: { body } } = this.props;
+        const blankWalletHTML = `
+            <!DOCTYPE html>
+            <html>
+            <head>
+               <meta charset="utf-8">
+               <style>
+                  html,
+                  body,
+                  #wallet {
+                     padding: 0px;
+                     margin: 0px;
+                     text-align: center;
+                     overflow: hidden;
+                     height: ${isAndroid ? '100vh' : null};
+                     width: ${isAndroid ? '100vw' : null};
+                  }
+                  svg{
+                     height: ${isAndroid ? '100vh' : '110vh'};
+                     width: 100vw;
+                  }
+               </style>
+            </head>
+            <body>
+              ${paperWallet}
+            </body>
+            </html>`;
+        try {
+            Navigation.mergeOptions('appStack', {
+                topBar: {
+                    barStyle: 'default',
+                    visible: true,
+                    animate: false,
+                    buttonColor: '#ffffff',
+                    drawBehind: true,
+                    noBorder: true,
+                    title: {
+                        color: '#ffffff',
+                    },
+                    backButton: {
+                        visible: false,
+                    },
+                    background: {
+                        color: body.bg,
+                        translucent: true,
+                    },
+                },
+            });
+            await RNPrint.print({ html: blankWalletHTML });
+            this.onNextPress();
+        } catch (err) {
+            console.error(err); // eslint-disable-line no-console
+        }
+    }
+
+    /**
+     * Hides navigation bar
+     *
+     * @method componentDidAppear
+     */
+    componentDidAppear() {
+        Navigation.mergeOptions('appStack', {
+            topBar: {
+                visible: false,
+            },
+        });
+    }
+
+    render() {
+        const { t, theme } = this.props;
+        const { hasPressedPrint } = this.state;
+
+        return (
+            <View style={[styles.container, { backgroundColor: theme.body.bg }]}>
+                <View>
+                    <View style={styles.topContainer}>
+                        <AnimatedComponent
+                            animationInType={['slideInRight', 'fadeIn']}
+                            animationOutType={['slideOutLeft', 'fadeOut']}
+                            delay={400}
+                        >
+                            <Header textColor={theme.body.color}>{t('printTemplateQuestion')}</Header>
+                        </AnimatedComponent>
+                    </View>
+                    <View style={styles.midContainer}>
+                        <AnimatedComponent
+                            animationInType={['slideInRight', 'fadeIn']}
+                            animationOutType={['slideOutLeft', 'fadeOut']}
+                            delay={200}
+                        >
+                            <InfoBox>
+                                {/* FIXME: Add illustration */}
+                                <Text style={[styles.infoText, { color: theme.body.color }]}>
+                                    {t('printTemplateInfo')}
+                                </Text>
+                                <Text style={[styles.infoTextBold, { color: theme.body.color }]}>
+                                    {t('printTemplateWarning')}
+                                </Text>
+                            </InfoBox>
+                        </AnimatedComponent>
+                    </View>
+                    <View style={styles.bottomContainer}>
+                        <AnimatedComponent animationInType={['fadeIn']} animationOutType={['fadeOut']} delay={0}>
+                            <DualFooterButtons
+                                onLeftButtonPress={() => (hasPressedPrint ? this.onBackPress() : this.onNextPress())}
+                                onRightButtonPress={() => this.onPrintPress()}
+                                leftButtonText={hasPressedPrint ? t('back') : t('skip')}
+                                rightButtonText={t('print')}
+                            />
+                        </AnimatedComponent>
+                    </View>
+                </View>
+            </View>
+        );
+    }
+}
+
+const mapStateToProps = (state) => ({
+    theme: getThemeFromState(state),
+});
+
+const mapDispatchToProps = {
+    toggleModalActivity,
+};
+
+export default withNamespaces(['printBlankTemplate', 'global'])(
+    connect(mapStateToProps, mapDispatchToProps)(PrintBlankTemplate),
+);

--- a/src/mobile/src/ui/views/onboarding/SaveYourSeed.js
+++ b/src/mobile/src/ui/views/onboarding/SaveYourSeed.js
@@ -126,7 +126,7 @@ class SaveYourSeed extends Component {
      * @method onWriteSeedDownPress
      */
     onWriteSeedDownPress() {
-        navigator.push('writeSeedDown');
+        navigator.push('printBlankTemplate');
     }
 
     /**
@@ -267,24 +267,24 @@ class SaveYourSeed extends Component {
                 'delayPrint',
                 () => {
                     Navigation.mergeOptions('appStack', {
-                      topBar: {
-                          barStyle: 'default',
-                          visible: true,
-                          animate: false,
-                          buttonColor: '#ffffff',
-                          drawBehind: true,
-                          noBorder: true,
-                          title: {
-                              color: '#ffffff',
-                          },
-                          backButton: {
-                              visible: true,
-                          },
-                          background: {
-                              color: body.bg,
-                              translucent: true,
-                          }
-                      },
+                        topBar: {
+                            barStyle: 'default',
+                            visible: true,
+                            animate: false,
+                            buttonColor: '#ffffff',
+                            drawBehind: true,
+                            noBorder: true,
+                            title: {
+                                color: '#ffffff',
+                            },
+                            backButton: {
+                                visible: true,
+                            },
+                            background: {
+                                color: body.bg,
+                                translucent: true,
+                            },
+                        },
                     });
                     RNPrint.print({ html: paperWalletHTML });
                 },

--- a/src/mobile/src/ui/views/onboarding/WriteSeedDown.js
+++ b/src/mobile/src/ui/views/onboarding/WriteSeedDown.js
@@ -1,13 +1,10 @@
 import React, { Component } from 'react';
 import { withNamespaces, Trans } from 'react-i18next';
 import { StyleSheet, View, Text } from 'react-native';
-import { Navigation } from 'react-native-navigation';
 import { navigator } from 'libs/navigation';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import FlagSecure from 'react-native-flag-secure-android';
-import RNPrint from 'react-native-print';
-import { paperWallet } from 'shared-modules/images/PaperWallets.js';
 import { toggleModalActivity } from 'shared-modules/actions/ui';
 import { getThemeFromState } from 'shared-modules/selectors/global';
 import SeedPicker from 'ui/components/SeedPicker';
@@ -86,7 +83,6 @@ class WriteSeedDown extends Component {
     constructor(props) {
         super(props);
         this.openModal = this.openModal.bind(this);
-        Navigation.events().bindComponent(this);
     }
 
     componentDidMount() {
@@ -103,14 +99,6 @@ class WriteSeedDown extends Component {
     }
 
     /**
-     * Wrapper method for printing a blank paper wallet
-     * @method onPrintPress
-     */
-    onPrintPress() {
-        this.print();
-    }
-
-    /**
      * Navigates back to the previous active screen in navigation stack
      * @method onBackPress
      */
@@ -119,75 +107,11 @@ class WriteSeedDown extends Component {
     }
 
     /**
-     *  Triggers blank paper wallet print
-     *  @method print
+     * Navigates back to save your seed
+     * @method onBackPress
      */
-    async print() {
-        const { theme: { body } } = this.props;
-        const blankWalletHTML = `
-            <!DOCTYPE html>
-            <html>
-            <head>
-               <meta charset="utf-8">
-               <style>
-                  html,
-                  body,
-                  #wallet {
-                     padding: 0px;
-                     margin: 0px;
-                     text-align: center;
-                     overflow: hidden;
-                     height: ${isAndroid ? '100vh' : null};
-                     width: ${isAndroid ? '100vw' : null};
-                  }
-                  svg{
-                     height: ${isAndroid ? '100vh' : '110vh'};
-                     width: 100vw;
-                  }
-               </style>
-            </head>
-            <body>
-              ${paperWallet}
-            </body>
-            </html>`;
-        try {
-            Navigation.mergeOptions('appStack', {
-                topBar: {
-                    barStyle: 'default',
-                    visible: true,
-                    animate: false,
-                    buttonColor: '#ffffff',
-                    drawBehind: true,
-                    noBorder: true,
-                    title: {
-                        color: '#ffffff',
-                    },
-                    backButton: {
-                        visible: true,
-                    },
-                    background: {
-                        color: body.bg,
-                        translucent: true,
-                    },
-                },
-            });
-            await RNPrint.print({ html: blankWalletHTML });
-        } catch (err) {
-            console.error(err); // eslint-disable-line no-console
-        }
-    }
-
-    /**
-     * Hides navigation bar
-     *
-     * @method componentDidAppear
-     */
-    componentDidAppear() {
-        Navigation.mergeOptions('appStack', {
-            topBar: {
-                visible: false,
-            },
-        });
+    onDonePress() {
+        navigator.popTo('saveYourSeed');
     }
 
     openModal() {
@@ -263,10 +187,10 @@ class WriteSeedDown extends Component {
                         <View style={styles.bottomContainer}>
                             <AnimatedComponent animationInType={['fadeIn']} animationOutType={['fadeOut']} delay={0}>
                                 <DualFooterButtons
-                                    onLeftButtonPress={() => this.onPrintPress()}
-                                    onRightButtonPress={() => this.onBackPress()}
+                                    onLeftButtonPress={() => this.onBackPress()}
+                                    onRightButtonPress={() => this.onDonePress()}
                                     leftButtonText={t('saveYourSeed:printBlankWallet')}
-                                    rightButtonText={t('global:back')}
+                                    rightButtonText={t('done')}
                                 />
                             </AnimatedComponent>
                         </View>

--- a/src/shared/actions/wallet.js
+++ b/src/shared/actions/wallet.js
@@ -54,6 +54,7 @@ export const ActionTypes = {
     ADDRESS_VALIDATION_SUCCESS: 'IOTA/APP/WALLET/ADDRESS_VALIDATION_SUCCESS',
     PUSH_ROUTE: 'IOTA/APP/WALLET/PUSH_ROUTE',
     POP_ROUTE: 'IOTA/APP/WALLET/POP_ROUTE',
+    POP_TO_ROUTE: 'IOTA/APP/WALLET/POP_TO_ROUTE',
     RESET_ROUTE: 'IOTA/APP/WALLET/RESET_ROUTE',
 };
 
@@ -591,6 +592,21 @@ export const pushRoute = (payload) => {
 export const popRoute = () => {
     return {
         type: ActionTypes.POP_ROUTE,
+    };
+};
+
+/**
+ * Dispatch to pop to a particular route in the navigation stack
+ *
+ * @method popToRoute
+ * @param {string} payload
+ *
+ * @returns {{type: {string}}}
+ */
+export const popToRoute = (payload) => {
+    return {
+        type: ActionTypes.POP_TO_ROUTE,
+        payload,
     };
 };
 

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -57,6 +57,7 @@
         "yes": "Yes",
         "no": "No",
         "okay": "Okay",
+        "skip": "Skip",
         "password": "Password",
         "unrecognisedPassword": "Unrecognised password",
         "unrecognisedPasswordExplanation": "The password was not recognised. Please try again.",
@@ -288,6 +289,12 @@
         "pleaseCheck": "Please check and confirm before you print",
         "wifiConfirmation": "I am not on on public wifi",
         "printerConfirmation": "I am not printing on a public printer"
+    },
+    "printBlankTemplate": {
+        "printTemplateQuestion": "Would you like to print a blank template?",
+        "printTemplateInfo": "You can print a blank template to help you write your seed down.",
+        "printTemplateWarning": "Make sure that you store your seed in a safe place. Do not show it to anyone.",
+        "print": "Yes, print"
     },
     "receive": {
         "yourAddress": "Your address",

--- a/src/shared/reducers/wallet.js
+++ b/src/shared/reducers/wallet.js
@@ -179,6 +179,11 @@ export default (state = initialState, action) => {
                 ...state,
                 navStack: state.navStack.slice(0, state.navStack.length - 1),
             };
+        case ActionTypes.POP_TO_ROUTE:
+            return {
+                ...state,
+                navStack: state.navStack.slice(0, state.navStack.indexOf(action.payload) - 1),
+            };
         case ActionTypes.RESET_ROUTE:
             return {
                 ...state,


### PR DESCRIPTION
# Description

- First navigate to print paper wallet option before write seed down

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested on Android and iOS

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes