### PR TITLE
Mobile/iOS: Fix NSLocationAlwaysUsageDescription purpose string

### DIFF
--- a/src/mobile/ios/iotaWallet/Info.plist
+++ b/src/mobile/ios/iotaWallet/Info.plist
@@ -60,6 +60,8 @@
 	<string>Trinity requires access to Face ID in order to enable biometric authentication.</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>2018 IOTA Foundation. All rights reserved.</string>
+	<key>NSLocationAlwaysUsageDescription</key>
+	<string>Trinity does not require this permission for any functionality. This permission is solely listed in order to satisfy App Store requirements.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Trinity does not require this permission for any functionality. This permission is solely listed in order to satisfy App Store requirements.</string>
 	<key>NSMotionUsageDescription</key>


### PR DESCRIPTION
# Description

Fixes `NSLocationAlwaysUsageDescription` purpose string to satisfy App Store requirements. Build 50 was rejected because this was not specified in the Info.plist.

**Note**: This string should not appear during normal app use because Trinity never needs access to your location. This is simply to satisfy App Store requirements.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?
N/A

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
