### PR TITLE
Mobile/iOS: Fix Xcode 10.2 build

### DIFF
--- a/src/mobile/patches/react-native+0.57.5.patch
+++ b/src/mobile/patches/react-native+0.57.5.patch
@@ -11,6 +11,37 @@ index 1af6fec..f8e81fc 100644
  
  const ModalEventEmitter =
    Platform.OS === 'ios' && NativeModules.ModalManager
+diff --git a/node_modules/react-native/React/Base/RCTBridgeModule.h b/node_modules/react-native/React/Base/RCTBridgeModule.h
+index 1da937e..1d2c131 100644
+--- a/node_modules/react-native/React/Base/RCTBridgeModule.h
++++ b/node_modules/react-native/React/Base/RCTBridgeModule.h
+@@ -73,6 +73,17 @@ RCT_EXTERN void RCTRegisterModule(Class); \
+ + (NSString *)moduleName { return @#js_name; } \
+ + (void)load { RCTRegisterModule(self); }
+ 
++/**
++ * Same as RCT_EXPORT_MODULE, but uses __attribute__((constructor)) for module
++ * registration. Useful for registering swift classes that forbids use of load
++ * Used in RCT_EXTERN_REMAP_MODULE
++ */
++#define RCT_EXPORT_MODULE_NO_LOAD(js_name, objc_name) \
++RCT_EXTERN void RCTRegisterModule(Class); \
+++ (NSString *)moduleName { return @#js_name; } \
++__attribute__((constructor)) static void \
++RCT_CONCAT(initialize_, objc_name)() { RCTRegisterModule([objc_name class]); }
++
+ /**
+  * To improve startup performance users may want to generate their module lists
+  * at build time and hook the delegate to merge with the runtime list. This
+@@ -250,7 +261,7 @@ RCT_EXTERN void RCTRegisterModule(Class); \
+   @interface objc_name (RCTExternModule) <RCTBridgeModule> \
+   @end \
+   @implementation objc_name (RCTExternModule) \
+-  RCT_EXPORT_MODULE(js_name)
++  RCT_EXPORT_MODULE_NO_LOAD(js_name, objc_name)
+ 
+ /**
+  * Use this macro in accordance with RCT_EXTERN_MODULE to export methods
 diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
 index 5534eb6..dba31c9 100644
 --- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java

--- a/src/mobile/patches/realm+2.21.1.patch
+++ b/src/mobile/patches/realm+2.21.1.patch
@@ -1,0 +1,28 @@
+diff --git a/node_modules/realm/src/jsc/jsc_value.hpp b/node_modules/realm/src/jsc/jsc_value.hpp
+index 5c113e5..6b74ec2 100644
+--- a/node_modules/realm/src/jsc/jsc_value.hpp
++++ b/node_modules/realm/src/jsc/jsc_value.hpp
+@@ -50,6 +50,9 @@ inline const char *jsc::Value::typeof(JSContextRef ctx, const JSValueRef &value)
+         case kJSTypeString: return "string";
+         case kJSTypeBoolean: return "boolean";
+         case kJSTypeUndefined: return "undefined";
++        #if defined __IPHONE_12_2 || defined __MAC_10_14_4
++            case kJSTypeSymbol: return "symbol";
++        #endif
+     }
+ }
+ 
+diff --git a/node_modules/realm/src/rpc.cpp b/node_modules/realm/src/rpc.cpp
+index 0c7bce4..e830b63 100644
+--- a/node_modules/realm/src/rpc.cpp
++++ b/node_modules/realm/src/rpc.cpp
+@@ -552,6 +552,9 @@ json RPCServer::serialize_json_value(JSValueRef js_value) {
+         case kJSTypeString:
+             return {{"value", jsc::Value::to_string(m_context, js_value)}};
+         case kJSTypeObject:
++        #if defined __IPHONE_12_2 || defined __MAC_10_14_4
++            case kJSTypeSymbol:
++        #endif
+             break;
+     }
+ 


### PR DESCRIPTION
# Description
Fixes build issues introduced by Xcode 10.2 release. These changes are backwards-compatible with Xcode 10.1

Fixes #1223 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Builds successfully on Xcode 10.2
- Builds successfully on Xcode 10.1 (Bitrise)
- Tested on iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes