### PR TITLE
Shared: Minor changes to initial node selection

### DIFF
--- a/src/shared/actions/polling.js
+++ b/src/shared/actions/polling.js
@@ -364,7 +364,7 @@ export const fetchNodeList = (chooseRandomNode = false) => {
 
                     // A temporary addition
                     // Only choose a random node with PoW enabled.
-                    setRandomNode(union(defaultNodesWithPowEnabled, remoteNodesWithPowEnabled));
+                    setRandomNode(remoteNodesWithPowEnabled);
 
                     const nodes = [
                         ...map(defaultNodesWithPowEnabled, (url) => ({ url, pow: true })),

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -3,7 +3,7 @@ export const __TEST__ = process.env.NODE_ENV === 'test';
 export const __MOBILE__ = typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
 
 /** Default IRI node */
-export const defaultNode = __TEST__ ? 'http://localhost:14265' : 'https://nodes.iota.fm:443';
+export const defaultNode = __TEST__ ? 'http://localhost:14265' : 'https://nodes.thetangle.org:443';
 
 export const nodesWithPowDisabled = ['https://trinity.iota-tangle.io:14265', 'https://node.iota-tangle.io:14265'];
 

--- a/src/shared/reducers/settings.js
+++ b/src/shared/reducers/settings.js
@@ -50,7 +50,6 @@ const initialState = {
     themeName: 'Default',
     /**
      * Determines if the wallet has randomised node on initial setup.
-     *
      */
     hasRandomizedNode: false,
     /**


### PR DESCRIPTION
# Description

- Change default node
- If fetched successfully, only use the external node list to select the initial node 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested on iOS simulator

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
