### PR TITLE
Mobile: Ensure seed reentry input only accepts A-Z9

### DIFF
--- a/src/mobile/src/ui/views/onboarding/SeedReentry.js
+++ b/src/mobile/src/ui/views/onboarding/SeedReentry.js
@@ -87,7 +87,7 @@ class SeedReentry extends Component {
     constructor() {
         super();
         this.state = {
-            reenteredSeed: null,
+            reenteredSeed: '',
         };
     }
 


### PR DESCRIPTION
# Description

- Ensure seed reentry input only accepts A-Z9

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS Simulator

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
