### PR TITLE
[mobile] Fix migration issue

### DIFF
--- a/src/mobile/src/ui/routes/entry.js
+++ b/src/mobile/src/ui/routes/entry.js
@@ -189,6 +189,8 @@ const hasConnection = (
 onAppStart()
     //  Initialise persistent storage
     .then(() => initialiseStorage(getEncryptionKey))
+    // Reset persisted state if keychain has no entries
+    .then(() => resetIfKeychainIsEmpty(reduxStore))
     // Restore persistent storage (Map to redux store)
     .then(() => {
         const latestVersions = {
@@ -233,8 +235,6 @@ onAppStart()
             return reduxStore.dispatch(mapStorageToStateAction(mapStorageToState()));
         });
     })
-    // Reset persisted state if keychain has no entries
-    .then(() => resetIfKeychainIsEmpty(reduxStore))
     .then(() => versionCheck(reduxStore))
     // Launch application
     .then(() => {


### PR DESCRIPTION
# Description

We reset the wallet (persisted) state if there are no keychain entries found. However, the resetting was happening after migration checks purging the migration statuses. This commit fixes the issue by making sure wallet reset happens before migration checks.

## Type of change

- Bug fix

# How Has This Been Tested?

- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
