### PR TITLE
Shared: Disable quorum on first account load and manual sync

### DIFF
--- a/src/shared/actions/accounts.js
+++ b/src/shared/actions/accounts.js
@@ -377,7 +377,7 @@ export const assignAccountIndex = () => ({
  *
  * @returns {function} dispatch
  */
-export const getFullAccountInfo = (seedStore, accountName, withQuorum = true) => {
+export const getFullAccountInfo = (seedStore, accountName, withQuorum = false) => {
     return (dispatch, getState) => {
         dispatch(fullAccountInfoFetchRequest());
 
@@ -442,7 +442,7 @@ export const getFullAccountInfo = (seedStore, accountName, withQuorum = true) =>
  *
  * @returns {function} dispatch
  */
-export const manuallySyncAccount = (seedStore, accountName, withQuorum = true) => {
+export const manuallySyncAccount = (seedStore, accountName, withQuorum = false) => {
     return (dispatch, getState) => {
         dispatch(manualSyncRequest());
 


### PR DESCRIPTION
# Description

-  Disables quorum on first account load and manual sync

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested on iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
