### PR TITLE
Mobile: Fix AsyncStorage migration

### DIFF
--- a/src/mobile/src/ui/routes/entry.js
+++ b/src/mobile/src/ui/routes/entry.js
@@ -200,9 +200,10 @@ onAppStart()
 
         // Get persisted data in AsyncStorage
         return reduxPersistStorageAdapter.get().then((storedData) => {
-            const { settings: { versions, completedMigration } } = storedData;
+            const buildNumber = get(storedData, 'settings.versions.buildNumber');
+            const completedMigration = get(storedData, 'settings.completedMigration', false);
             if (
-                versions.buildNumber < 43 &&
+                buildNumber < 43 &&
                 !completedMigration &&
                 // Also check if there is persisted data in AsyncStorage that needs to be migrated
                 // If this check is omitted, the condition will be satisfied on a fresh install.


### PR DESCRIPTION
# Description
Fixes AsyncStorage migration issues. When data is already migrated, there is no data in the AsyncStorage state. Therefore, destructuring assignment (`const { settings: { versions, completedMigration } } = storedData;`) without checking to see if these properties exist will fail.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on iOS simulator (migration from 0.6.2 (52))
- Tested on iOS simulator (migration from 0.6.0 (39))

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes