### PR TITLE
Wait for SeedStore constructor promise to resolve before making a retry attempt

### DIFF
--- a/src/mobile/src/ui/components/Poll.js
+++ b/src/mobile/src/ui/components/Poll.js
@@ -164,7 +164,7 @@ export class Poll extends Component {
      *
      * @returns {undefined}
      */
-    retryFailedTransaction() {
+    async retryFailedTransaction() {
         const { failedBundleHashes, password } = this.props;
 
         if (!isEmpty(failedBundleHashes)) {
@@ -172,7 +172,9 @@ export class Poll extends Component {
             const bundleForRetry = head(bundleHashes);
             const { name, type } = failedBundleHashes[bundleForRetry];
 
-            this.props.retryFailedTransaction(name, bundleForRetry, new SeedStore[type](password, name));
+            const seedStore = await new SeedStore[type](password, name);
+
+            this.props.retryFailedTransaction(name, bundleForRetry, seedStore);
         } else {
             this.moveToNextPollService();
         }


### PR DESCRIPTION
# Description

We didn't wait for for seedStore instantiation promise to resolve before passing it to prop method `retryFailedTransaction` in `Poll` component (mobile) leading to unhandled exceptions. This PR fixes the issue. 

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
