### PR TITLE
Make sure we do not reconstruct and validate stored reattachments

### DIFF
--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -442,20 +442,36 @@ export const syncTransactions = (provider) => (diff, existingTransactions) => {
                 return findTransactionObjectsAsync(provider)({ bundles: Array.from(bundleHashes) });
             })
             .then((transactionObjects) => {
-                return flatMap(
-                    filterInvalidBundles(
-                        constructBundlesFromTransactions(
-                            map(transactionObjects, (transaction) => ({
-                                ...transaction,
-                                // Assign broadcasted as true as all these transactions were pulled in from the ledger
-                                broadcasted: true,
-                                // Temporarily assign persistence false
-                                // In the next step, communicate with the ledger to get correct inclusion state (persistence) and assign those
-                                persistence: false,
-                            })),
-                        ),
-                    ),
+                const existingTransactionHashes = map(existingTransactions, (transaction) => transaction.hash);
+
+                // In the previous step, we pulled all transactions against the bundle hash
+                // Querying by bundle hash retrieves all transactions including reattachments
+                // It is possible that we have already retrieved and validated some of these reattachments
+                // Therefore, there is no need to reconstruct bundles for the transactions that are already stored locally
+                // Bundle validation is expensive and could lead to performance issues
+                const newTransactions = filter(
+                    transactionObjects,
+                    (transaction) => !includes(existingTransactionHashes, transaction.hash),
                 );
+
+                // Construct bundles only for newer (not yet seen/stored) transactions
+                const bundles = constructBundlesFromTransactions(
+                    map(newTransactions, (transaction) => ({
+                        ...transaction,
+                        // Assign broadcasted as true as all these transactions were pulled in from the ledger
+                        broadcasted: true,
+                        // Temporarily assign persistence false
+                        // In the next step, communicate with the ledger to get correct inclusion state (persistence) and assign those
+                        persistence: false,
+                    })),
+                );
+
+                const transactions = flatMap(
+                    // Get rid of invalid bundles
+                    filterInvalidBundles(bundles),
+                );
+
+                return transactions;
             });
     };
 


### PR DESCRIPTION
# Description

Constructing and validating bundles is an expensive operation. If we reconstruct seen reattachments, it affects the overall performance. This PR fixes the issue by only reconstructing and validating transactions that are unknown to the wallet. 

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
