### PR TITLE
Shared: Remove deprecated bundle traversal check

### DIFF
--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -1056,9 +1056,7 @@ export const isBundleTraversable = (bundle, trunkTransaction, branchTransaction)
         (transaction, index, transactions) =>
             index
                 ? transaction.trunkTransaction === transactions[index - 1].hash &&
-                  // In IRI, tx at lastIndex has branch and trunk swapped, while Entangled pow-bundle does not. See https://github.com/iotaledger/entangled/issues/1008#issuecomment-476608211
-                  (transaction.branchTransaction === trunkTransaction ||
-                      transaction.branchTransaction === branchTransaction)
+                  transaction.branchTransaction === trunkTransaction
                 : transaction.trunkTransaction === trunkTransaction &&
                   transaction.branchTransaction === branchTransaction,
     );


### PR DESCRIPTION
# Description

- Entangled previously constructed bundles differently to IRI (see https://github.com/iotaledger/entangled/issues/1008#issuecomment-476608211)
- Since https://github.com/iotaledger/entangled/commit/639dff5 is merged, the associated bundle traversal check is no longer required

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?


# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
