### PR TITLE
Disable redux-logger by default

### DIFF
--- a/src/shared/store.js
+++ b/src/shared/store.js
@@ -1,6 +1,8 @@
 import assign from 'lodash/assign';
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
+/* eslint-disable no-unused-vars */
 import logger from 'redux-logger';
+/* eslint-enable no-unused-vars */
 import thunk from 'redux-thunk';
 import marketData from './reducers/marketData';
 import wallet from './reducers/wallet';
@@ -24,7 +26,7 @@ const developmentMiddleware = [thunk, networkMiddleware, versionMiddleware, aler
 const productionMiddleware = [thunk, networkMiddleware, versionMiddleware, alertsMiddleware, modalMiddleware];
 
 if (__MOBILE__) {
-    developmentMiddleware.unshift(logger);
+    /* developmentMiddleware.unshift(logger); */
 }
 
 const reducers = combineReducers({


### PR DESCRIPTION
# Description

Disable redux-logger in debug mode by default/

## Type of change

- Enhancement

# How Has This Been Tested?

N/A

# Checklist:
- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
