### PR TITLE
Mobile: Fix unit info modal theming

### DIFF
--- a/src/mobile/src/ui/views/wallet/Send.js
+++ b/src/mobile/src/ui/views/wallet/Send.js
@@ -506,10 +506,8 @@ export class Send extends Component {
                 return this.props.toggleModalActivity(modalContent, {
                     hideModal: () => this.hideModal(),
                     theme,
-                    textColor: { color: theme.bar.color },
-                    lineColor: { borderLeftColor: theme.bar.color },
-                    borderColor: { borderColor: theme.bar.color },
-                    bar: theme.bar.color,
+                    textColor: { color: theme.body.color },
+                    lineColor: { borderBottomColor: theme.body.color },
                 });
             case 'usedAddress':
                 return this.props.toggleModalActivity(modalContent, {


### PR DESCRIPTION
# Description

- Fixes incorrect theme usage on unit info modal

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS device

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes