### PR TITLE
Mobile: Fix SeedVault export name

### DIFF
--- a/src/mobile/src/ui/components/SeedVaultExportComponent.js
+++ b/src/mobile/src/ui/components/SeedVaultExportComponent.js
@@ -1,3 +1,4 @@
+import isEmpty from 'lodash/isEmpty';
 import values from 'lodash/values';
 import isEqual from 'lodash/isEqual';
 import React, { Component } from 'react';
@@ -168,8 +169,12 @@ class SeedVaultExportComponent extends Component {
             await getAndroidFileSystemPermissions();
         }
         const { t, selectedAccountName } = this.props;
-
-        const path = SeedVaultExportComponent.getPath(removeNonAlphaNumeric(selectedAccountName, 'SeedVault').trim());
+        const path = SeedVaultExportComponent.getPath(
+            removeNonAlphaNumeric(
+                isEmpty(global.onboardingSeed) ? selectedAccountName : '',
+                SEED_VAULT_DEFAULT_TITLE,
+            ).trim(),
+        );
 
         this.setState({ path });
 
@@ -261,7 +266,10 @@ class SeedVaultExportComponent extends Component {
                 // If it's undefined, use the fallback title
                 serialise({
                     seed: tritsToChars(this.state.seed),
-                    title: removeNonAlphaNumeric(selectedAccountName, SEED_VAULT_DEFAULT_TITLE),
+                    title: removeNonAlphaNumeric(
+                        isEmpty(global.onboardingSeed) ? selectedAccountName : '',
+                        SEED_VAULT_DEFAULT_TITLE,
+                    ),
                 }) +
                 '~' +
                 UInt8ToString(this.state.password),

--- a/src/mobile/src/ui/views/onboarding/NewSeedSetup.js
+++ b/src/mobile/src/ui/views/onboarding/NewSeedSetup.js
@@ -163,6 +163,7 @@ class NewSeedSetup extends Component {
     }
 
     onBackPress() {
+        delete global.onboardingSeed;
         navigator.pop(this.props.componentId);
     }
 

--- a/src/mobile/src/ui/views/onboarding/SetAccountName.js
+++ b/src/mobile/src/ui/views/onboarding/SetAccountName.js
@@ -136,6 +136,7 @@ export class SetAccountName extends Component {
         if (onboardingComplete) {
             const seedStore = await new SeedStore.keychain(global.passwordHash);
             seedStore.addAccount(accountName, global.onboardingSeed);
+            delete global.onboardingSeed;
             navigator.setStackRoot('loading');
         } else {
             navigator.push('setPassword');


### PR DESCRIPTION
# Description

- Ensure account name is appended to seed vault file name only when exporting from an existing seed
- Ensure `onboardingSeed` is deleted on all occasions where no longer in use

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS device

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
