### PR TITLE
Mobile 0.6.2 (53) Release

### DIFF
--- a/src/mobile/android/app/build.gradle
+++ b/src/mobile/android/app/build.gradle
@@ -92,7 +92,7 @@ android {
     buildToolsVersion '27.0.3'
     defaultConfig {
         applicationId "com.iota.trinity"
-        versionCode 52
+        versionCode 53
         versionName "0.6.2"
         minSdkVersion 21
         targetSdkVersion 26

--- a/src/mobile/ios/iotaWallet-tvOS/Info.plist
+++ b/src/mobile/ios/iotaWallet-tvOS/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>52</string>
+	<string>53</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/src/mobile/ios/iotaWallet-tvOSTests/Info.plist
+++ b/src/mobile/ios/iotaWallet-tvOSTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>52</string>
+	<string>53</string>
 </dict>
 </plist>

--- a/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
+++ b/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
@@ -2894,7 +2894,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
@@ -3281,7 +3281,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 52;
+				CURRENT_PROJECT_VERSION = 53;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/src/mobile/ios/iotaWallet/Info.plist
+++ b/src/mobile/ios/iotaWallet/Info.plist
@@ -34,7 +34,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>52</string>
+	<string>53</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/src/mobile/ios/iotaWalletTests/Info.plist
+++ b/src/mobile/ios/iotaWalletTests/Info.plist
@@ -19,6 +19,6 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>52</string>
+	<string>53</string>
 </dict>
 </plist>

--- a/src/mobile/ios/iotaWalletUITests/Info.plist
+++ b/src/mobile/ios/iotaWalletUITests/Info.plist
@@ -17,6 +17,6 @@
 	<key>CFBundleShortVersionString</key>
 	<string>0.6.2</string>
 	<key>CFBundleVersion</key>
-	<string>52</string>
+	<string>53</string>
 </dict>
 </plist>


### PR DESCRIPTION
# Changelog

- Large history performance improvements (#1293, #1276)
- Remove 2FA from all versions (#1292)
- Re-enable deep-linking: useful feature for iota-centric e-commerce, where clicking a deep link prefills transaction data in Trinity (e.g. iota://XNGPUCURQLLJFGXNDCMROGYNWAZP9AFWSVEUAIWIESOSPYDUPWSPSREEBWJPD9ZWZPAJKBHPLG99DJWJCZUHWTQTDD/?amount=1000000&message=happybirthdayrajiv) (#1143)
- Add native dropdown component (#1275)
- New Crowdin translations (#1220, #1251, #1307)
- Fix bug where wallet resets itself (#1240)
- If fetched successfully, only use the external node list to select the initial node (#1238)
- Fix SeedVault export name (#1312)
- Fix wallet reset on migration from 0.6.0 to 0.6.2 (#1260)
- Add seed migration validation check (#1236)
- Add unit tests for crypto utils (#1200)
- Disable quorum on first account load and manual sync (#1258)
- Rewrite flexible Realm version to version migration setup (#1168)
- Add node request timeouts for getTransactionsToApprove endpoint (#1284)
- Align Entangled trunk/branch assignment with IRI (iotaledger/entangled@639dff5) (#1280, #1281)
- Autoretry with increased timeouts for getTransactionsToApprove and attachToTangle endpoints (#1285)
- Various other fixes and improvements (#1239, #1219, #1272, #1274, #1244, #1283, #1291, #1308, #1311)