### PR TITLE
Desktop: Update notification trigger rules

### DIFF
--- a/src/shared/libs/iota/accounts.js
+++ b/src/shared/libs/iota/accounts.js
@@ -134,10 +134,13 @@ export const syncAccount = (provider, withQuorum) => (existingAccountState, seed
         .then((transactions) => {
             if (notificationFn) {
                 // Trigger notification callback with new incoming transactions and confirmed value transactions
-                // TODO: New incoming transactions & confirmed value transactions should be detected within selectors or component update lifecycle methods.
                 const existingNormalisedTransactions = mapNormalisedTransactions(
                     thisStateCopy.transactions,
                     thisStateCopy.addressData,
+                );
+                const latestTimestamp = Object.values(existingNormalisedTransactions).reduce(
+                    (max, tx) => Math.max(max, tx.timestamp),
+                    0,
                 );
 
                 const allNormalisedTransactions = mapNormalisedTransactions(transactions, thisStateCopy.addressData);
@@ -146,7 +149,10 @@ export const syncAccount = (provider, withQuorum) => (existingAccountState, seed
                     thisStateCopy.accountName,
                     filter(
                         allNormalisedTransactions,
-                        (transfer) => transfer.incoming && !existingNormalisedTransactions[transfer.bundle],
+                        (transfer) =>
+                            transfer.incoming &&
+                            !existingNormalisedTransactions[transfer.bundle] &&
+                            transfer.timestamp > latestTimestamp,
                     ),
                     filter(
                         allNormalisedTransactions,


### PR DESCRIPTION
# Description

Trigger notifications only for transactions that have a newer timestamp than already existing transactions (to prevent notifications for older transactions fetched from a node with longer history)

Fixes #684 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested manually on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
