### PR TITLE
Shared: Adjust deep linking behaviour

### DIFF
--- a/src/desktop/src/ui/Index.js
+++ b/src/desktop/src/ui/Index.js
@@ -177,7 +177,7 @@ class App extends React.Component {
         const { deepLinking, generateAlert, t } = this.props;
 
         if (!deepLinking) {
-            return;
+            return this.props.history.push('/settings/advanced');
         }
 
         const parsedData = parseAddress(data);

--- a/src/desktop/src/ui/Index.js
+++ b/src/desktop/src/ui/Index.js
@@ -177,7 +177,8 @@ class App extends React.Component {
         const { deepLinking, generateAlert, t } = this.props;
 
         if (!deepLinking) {
-            return this.props.history.push('/settings/advanced');
+            this.props.history.push('/settings/advanced');
+            return generateAlert('info', t('deepLink:deepLinkingInfoTitle'), t('deepLink:deepLinkingInfoMessage'));
         }
 
         const parsedData = parseAddress(data);

--- a/src/desktop/src/ui/views/settings/Advanced.js
+++ b/src/desktop/src/ui/views/settings/Advanced.js
@@ -169,6 +169,19 @@ class Advanced extends PureComponent {
             <div className={css.scroll}>
                 <Scrollbar>
                     <article>
+                        <React.Fragment>
+                            <h3>{t('advancedSettings:deepLinking')}</h3>
+                            <Toggle
+                                checked={settings.deepLinking}
+                                onChange={() => changeDeepLinkingSettings()}
+                                on={t('enabled')}
+                                off={t('disabled')}
+                            />
+                            <p>{t('deepLink:deepLinkingOverview')}</p>
+                            <p>{t('deepLink:deepLinkingWarning')}</p>
+                            <hr />
+                        </React.Fragment>
+
                         {wallet && wallet.ready ? (
                             <React.Fragment>
                                 <h3>{t('pow:powUpdated')}</h3>
@@ -191,17 +204,6 @@ class Advanced extends PureComponent {
                                     off={t('disabled')}
                                 />
                                 <p>{t('advancedSettings:autoPromotionExplanation')}</p>
-                                <hr />
-
-                                <h3>{t('advancedSettings:deepLinking')}</h3>
-                                <Toggle
-                                    checked={settings.deepLinking}
-                                    onChange={() => changeDeepLinkingSettings()}
-                                    on={t('enabled')}
-                                    off={t('disabled')}
-                                />
-                                <p>{t('deepLink:deepLinkingOverview')}</p>
-                                <p>{t('deepLink:deepLinkingWarning')}</p>
                                 <hr />
 
                                 {Electron.getOS() === 'darwin' && (

--- a/src/mobile/src/ui/components/DeepLinking.js
+++ b/src/mobile/src/ui/components/DeepLinking.js
@@ -31,7 +31,8 @@ export default () => (C) => {
             const { t, generateAlert, deepLinking } = this.props;
 
             if (!deepLinking) {
-                return this.navigateToSettings();
+                this.navigateToSettings();
+                return generateAlert('info', t('deepLink:deepLinkingInfoTitle'), t('deepLink:deepLinkingInfoMessage'));
             }
             const parsedData = parseAddress(data.url);
             if (parsedData) {

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -718,7 +718,10 @@
         "deepLinkingWarning": "Be aware of phishing scams. Make sure the link you open navigates to the official Trinity app.",
         "deepLinkingUpdated": "Deep linking settings",
         "deepLinkingEnabled": "You have enabled deep linking.",
-        "deepLinkingDisabled": "You have disabled deep linking."
+        "deepLinkingDisabled": "You have disabled deep linking.",
+        "deepLinkingInfoTitle": "Deep linking is not enabled",
+        "deepLinkingInfoMessage": "You opened an iota link but deep linking is not enabled."
+
     },
     "updates": {
         "errorRetrievingUpdateData": "Error retrieving update data",

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -720,7 +720,7 @@
         "deepLinkingEnabled": "You have enabled deep linking.",
         "deepLinkingDisabled": "You have disabled deep linking.",
         "deepLinkingInfoTitle": "Deep linking is not enabled",
-        "deepLinkingInfoMessage": "You opened a deep link but deep linking is not enabled."
+        "deepLinkingInfoMessage": "You opened an iota:// deep link but deep linking is not enabled."
 
     },
     "updates": {

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -720,7 +720,7 @@
         "deepLinkingEnabled": "You have enabled deep linking.",
         "deepLinkingDisabled": "You have disabled deep linking.",
         "deepLinkingInfoTitle": "Deep linking is not enabled",
-        "deepLinkingInfoMessage": "You opened an iota link but deep linking is not enabled."
+        "deepLinkingInfoMessage": "You opened a deep link but deep linking is not enabled."
 
     },
     "updates": {


### PR DESCRIPTION
# Description

- Reorder advanced settings
- Open advanced settings when a deep link is initiated if deep linking is not enabled 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on Mac debug


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
