### PR TITLE
Mobile: Fix fingerprint widget bugs on login

### DIFF
--- a/src/mobile/__tests__/ui/components/EnterPasswordOnLogin.spec.js
+++ b/src/mobile/__tests__/ui/components/EnterPasswordOnLogin.spec.js
@@ -52,6 +52,10 @@ describe('Testing EnterPasswordOnLogin component', () => {
         it('should require a t function as a prop', () => {
             expect(EnterPasswordOnLogin.propTypes.t).toEqual(PropTypes.func.isRequired);
         });
+
+        it('should require an isFingerprintEnabled boolean as a prop', () => {
+            expect(EnterPasswordOnLogin.propTypes.isFingerprintEnabled).toEqual(PropTypes.bool.isRequired);
+        });
     });
 
     describe('when renders', () => {
@@ -68,6 +72,34 @@ describe('Testing EnterPasswordOnLogin component', () => {
             const wrapper = shallow(<EnterPasswordOnLogin {...props} />);
 
             expect(wrapper.find('CustomTextInput').length).toEqual(1);
+        });
+
+        it('should not pass "fingerprintDisabled" in the widget prop if isFingerprintEnabled is false', () => {
+            const props = getProps();
+
+            const wrapper = shallow(<EnterPasswordOnLogin {...props} />);
+
+            expect(
+                wrapper
+                    .find('CustomTextInput')
+                    .prop('widgets')
+                    .indexOf('fingerprintDisabled'),
+            ).toEqual(-1);
+        });
+
+        it('should pass "fingerprintDisabled" in the widget prop if isFingerprintEnabled is true', () => {
+            const props = getProps({
+                isFingerprintEnabled: true,
+            });
+
+            const wrapper = shallow(<EnterPasswordOnLogin {...props} />);
+
+            expect(
+                wrapper
+                    .find('CustomTextInput')
+                    .prop('widgets')
+                    .indexOf('fingerprintDisabled'),
+            ).toBeGreaterThan(-1);
         });
     });
 

--- a/src/mobile/src/ui/components/EnterPassword.js
+++ b/src/mobile/src/ui/components/EnterPassword.js
@@ -141,7 +141,7 @@ class EnterPassword extends Component {
                             secureTextEntry
                             onSubmitEditing={this.handleLogin}
                             theme={theme}
-                            widgets={['fingerprint']}
+                            widgets={isFingerprintEnabled ? ['fingerprint'] : []}
                             fingerprintAuthentication={isFingerprintEnabled}
                             onFingerprintPress={this.activateFingerprintScanner}
                             value={this.state.password}
@@ -166,4 +166,9 @@ const mapDispatchToProps = {
     toggleModalActivity,
 };
 
-export default withNamespaces(['login', 'global'])(connect(mapStateToProps, mapDispatchToProps)(EnterPassword));
+export default withNamespaces(['login', 'global'])(
+    connect(
+        mapStateToProps,
+        mapDispatchToProps,
+    )(EnterPassword),
+);

--- a/src/mobile/src/ui/components/EnterPasswordOnLogin.js
+++ b/src/mobile/src/ui/components/EnterPasswordOnLogin.js
@@ -107,7 +107,7 @@ export class EnterPasswordOnLogin extends Component {
                             onSubmitEditing={this.handleLogin}
                             theme={theme}
                             value={password}
-                            widgets={['fingerprintDisabled']}
+                            widgets={isFingerprintEnabled ? ['fingerprintDisabled'] : []}
                             fingerprintAuthentication={isFingerprintEnabled}
                             onFingerprintPress={this.openModal}
                             isPasswordInput
@@ -131,4 +131,9 @@ const mapDispatchToProps = {
     toggleModalActivity,
 };
 
-export default withNamespaces(['login', 'global'])(connect(null, mapDispatchToProps)(EnterPasswordOnLogin));
+export default withNamespaces(['login', 'global'])(
+    connect(
+        null,
+        mapDispatchToProps,
+    )(EnterPasswordOnLogin),
+);


### PR DESCRIPTION
# Description

Only show `fingerprintDisabled` and `fingerprint` widgets if `isFingerprintEnabled` is true (Biometric authentication is enabled)

Fixes #1342 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested manually on iOS
- Added unit tests for `EnterPasswordOnLogin` component

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes