### PR TITLE
Remove all realm files in directory during tests

### DIFF
--- a/src/shared/__tests__/actions/transfers.spec.js
+++ b/src/shared/__tests__/actions/transfers.spec.js
@@ -11,7 +11,6 @@ import * as accountsUtils from '../../libs/iota/accounts';
 import * as inputUtils from '../../libs/iota/inputs';
 import { iota, quorum, SwitchingConfig } from '../../libs/iota';
 import { realm, Account, Wallet, getRealm, initialise } from '../../storage';
-import schemas from '../../schemas';
 import accounts from '../__samples__/accounts';
 import { addressData, latestAddressObject } from '../__samples__/addresses';
 import { newZeroValueTransactionTrytes, newValueTransactionTrytes } from '../__samples__/trytes';
@@ -36,7 +35,7 @@ describe('actions: transfers', () => {
         let seedStore;
 
         before(() => {
-            Realm.deleteFile(schemas[schemas.length - 1]);
+            Realm.clearTestState();
             initialise(() => Promise.resolve(new Int8Array(64)));
             seedStore = {
                 performPow: () =>
@@ -61,7 +60,7 @@ describe('actions: transfers', () => {
         });
 
         after(() => {
-            Realm.deleteFile(schemas[schemas.length - 1]);
+            Realm.clearTestState();
         });
 
         describe('when called', () => {
@@ -295,7 +294,7 @@ describe('actions: transfers', () => {
         let seedStore;
 
         before(() => {
-            Realm.deleteFile(schemas[schemas.length - 1]);
+            Realm.clearTestState();
             initialise(() => Promise.resolve(new Int8Array(64)));
             seedStore = {
                 generateAddress: () => Promise.resolve('A'.repeat(81)),
@@ -344,7 +343,7 @@ describe('actions: transfers', () => {
         });
 
         after(() => {
-            Realm.deleteFile(schemas[schemas.length - 1]);
+            Realm.clearTestState();
         });
 
         describe('zero value transactions', () => {

--- a/src/shared/__tests__/storage/node.spec.js
+++ b/src/shared/__tests__/storage/node.spec.js
@@ -1,12 +1,11 @@
 import { expect } from 'chai';
 import { getRealm, realm, Node, initialise } from '../../storage';
-import schemas from '../../schemas';
 
 const Realm = getRealm();
 
 describe('storage: Node', () => {
     before(() => {
-        Realm.deleteFile(schemas[schemas.length - 1]);
+        Realm.clearTestState();
 
         initialise(() => Promise.resolve(new Int8Array(64)));
     });
@@ -32,7 +31,7 @@ describe('storage: Node', () => {
     });
 
     after(() => {
-        Realm.deleteFile(schemas[schemas.length - 1]);
+        Realm.clearTestState();
     });
 
     describe('#getObjectForId', () => {

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -11,6 +11,7 @@
     ],
     "scripts": {
         "test": "NODE_ENV=test ./node_modules/.bin/mocha --timeout 5000 --exit --require @babel/register \"__tests__/**/*.spec.js\"",
+        "posttest": "rimraf realm-object-server",
         "test:watch": "yarn test --watch",
         "test:coverage": "nyc --check-coverage --lines 50 --statements 50 --functions 50 --branches 50 yarn test",
         "auditjs": "./../../node_modules/.bin/auditjs -n -l error -w whitelist.json",
@@ -61,6 +62,7 @@
         "realm": "^2.21.0",
         "redux-logger": "^3.0.6",
         "redux-mock-store": "^1.5.1",
+        "rimraf": "^2.6.3",
         "sinon": "^7.2.7",
         "svg2ttf": "^4.1.0",
         "svgicons2svgfont": "^9.0.2",

--- a/src/shared/yarn.lock
+++ b/src/shared/yarn.lock
@@ -3174,7 +3174,7 @@ resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
-rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==


### PR DESCRIPTION
# Description

`Realm.deleteFile` does not remove all realm files from the shared directory. Use `Realm.clearTestState` for removing all realm files from the shared directory during tests.

Source: https://github.com/realm/realm-js/issues/363#issuecomment-205964809

## Type of change

- Enhancement

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
