### PR TITLE
Mobile: Add try catch to delete account

### DIFF
--- a/src/mobile/src/ui/views/wallet/DeleteAccount.js
+++ b/src/mobile/src/ui/views/wallet/DeleteAccount.js
@@ -178,7 +178,9 @@ class DeleteAccount extends Component {
     async delete() {
         const { selectedAccountName, selectedAccountMeta } = this.props;
         const seedStore = await new SeedStore[selectedAccountMeta.type](global.passwordHash, selectedAccountName);
-        await seedStore.removeAccount();
+        try {
+            await seedStore.removeAccount();
+        } catch (err) { }
         this.props.deleteAccount(selectedAccountName);
     }
 


### PR DESCRIPTION
# Description

- Adds try catch to delete account to accommodate for situations where there is no keychain entry yet account remains in state

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS 

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
