### PR TITLE
Make sure we reorder account indexes (in realm) on account deletion

### DIFF
--- a/src/shared/libs/storageToStateMappers.js
+++ b/src/shared/libs/storageToStateMappers.js
@@ -11,7 +11,9 @@ import { Account, Node, Wallet } from '../storage';
  * @returns {object}
  */
 export const mapStorageToState = () => {
+    Account.orderAccountsByIndex();
     const accountsData = Account.getDataAsArray();
+
     const { settings, onboardingComplete, errorLog, accountInfoDuringSetup } = Wallet.latestData;
     const nodes = Node.getDataAsArray();
 


### PR DESCRIPTION
# Description

Deleting account doesn't reorder indexes in realm db leading to gaps in account indexes. This PR fixes the issue. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
