### PR TITLE
Shared: Catch error and show alert if node is not synced

### DIFF
--- a/src/shared/actions/accounts.js
+++ b/src/shared/actions/accounts.js
@@ -511,6 +511,10 @@ export const getAccountInfo = (seedStore, accountName, notificationFn, withQuoru
             .catch((err) => {
                 if (err.message === Errors.LEDGER_CANCELLED) {
                     dispatch(generateLedgerCancelledAlert());
+                } else if (err.message === Errors.NODE_NOT_SYNCED) {
+                    dispatch(generateNodeOutOfSyncErrorAlert());
+                } else if (err.message === Errors.UNSUPPORTED_NODE) {
+                    dispatch(generateUnsupportedNodeErrorAlert());
                 } else {
                     setTimeout(() => dispatch(generateAccountInfoErrorAlert(err)), 500);
                 }


### PR DESCRIPTION
# Description

`getAccountInfo` calls `syncAccount`, which calls `throwIfNodeNotHealthy`. The error that `throwIfNodeNotHealthy` would throw was not being caught by `getAccountInfo`. As a result, a generic error message was shown (and a message was written to the error log) instead of the one intended to tell the user that the selected node is not in sync.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on macOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
