### PR TITLE
Correctly pass closeInterval param to dropdown alert

### DIFF
--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -765,6 +765,7 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
                             'error',
                             i18next.t('global:rebroadcastError'),
                             i18next.t('global:signedTrytesBroadcastErrorExplanation'),
+                            20000,
                             error,
                         ),
                     );


### PR DESCRIPTION
# Description

[generateAlert](https://github.com/iotaledger/trinity-wallet/blob/develop/src/shared/actions/alerts.js#L55) accepts `closeInterval<number>` as fourth parameter but it wasn't being passed correctly. This PR fixes the issue by correctly passing the `closeInterval` parameter. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
