### PR TITLE
Move to next (poll) service item if auto-retrying of failed transaction errors out

### DIFF
--- a/src/shared/reducers/polling.js
+++ b/src/shared/reducers/polling.js
@@ -2,6 +2,7 @@ import findIndex from 'lodash/findIndex';
 import isNumber from 'lodash/isNumber';
 import size from 'lodash/size';
 import { ActionTypes } from '../actions/polling';
+import { ActionTypes as TransfersActionTypes } from '../actions/transfers';
 
 export const setNextPollIfSuccessful = (state) => {
     const { allPollingServices, pollFor } = state;
@@ -181,6 +182,16 @@ const polling = (
             return {
                 ...state,
                 isAutoPromoting: false,
+                ...setNextPollIfUnsuccessful(state),
+            };
+        case TransfersActionTypes.RETRY_FAILED_TRANSACTION_SUCCESS:
+            return {
+                ...state,
+                ...setNextPollIfSuccessful(state),
+            };
+        case TransfersActionTypes.RETRY_FAILED_TRANSACTION_ERROR:
+            return {
+                ...state,
                 ...setNextPollIfUnsuccessful(state),
             };
         case ActionTypes.SET_POLL_FOR:


### PR DESCRIPTION
# Description

Auto-retrying of transaction get stuck in an endless loop if it errors out. This PR fixes the issue by making sure polling moves to next service item if auto-retrying fails. 

## Type of change

- Bug fix

# How Has This Been Tested?

- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
