### PR TITLE
Mobile: Fix empty dropdown items crash

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -69,7 +69,7 @@
     "react-native-navigation": "https://github.com/rajivshah3/react-native-navigation#2.0.255-0.57",
     "react-native-optimized-flatlist": "^1.0.4",
     "react-native-os": "git+https://github.com/laumair/react-native-os.git#527b0ae",
-    "react-native-picker-select": "^6.1.0",
+    "react-native-picker-select": "git+https://github.com/cvarley100/react-native-picker-select#master",
     "react-native-print": "^0.5.0",
     "react-native-progress": "^3.4.0",
     "react-native-qr-generator": "^1.0.3",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -7303,10 +7303,9 @@ react-native-optimized-flatlist@^1.0.4:
   version "1.1.0"
   resolved "git+https://github.com/laumair/react-native-os.git#527b0aef4e30041b5230f5b901767dd9f54903fe"
 
-react-native-picker-select@^6.1.0:
+"react-native-picker-select@git+https://github.com/cvarley100/react-native-picker-select#master":
   version "6.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-picker-select/-/react-native-picker-select-6.1.0.tgz#0ae6ba1578e3edc8b89660b81fdd85eef2226a35"
-  integrity sha512-JYD0nMr9lXwcW/xxxf09TF8SN5ZqDlfIyr96Q4248ElvPpxVrSNlNNcZMo4OPnfogu1zBBVbrZzURh0oG+BV6g==
+  resolved "git+https://github.com/cvarley100/react-native-picker-select#a9ee590565b46e2f97669367920d4ce007c218d6"
   dependencies:
     lodash.isequal "^4.5.0"
 


### PR DESCRIPTION
# Description

- Fixes issue with react-native-picker-select that caused dropdown component to error on empty `items` prop

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS simulator

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
