### PR TITLE
Update max milestone threshold value

### DIFF
--- a/src/shared/__tests__/libs/iota/extendedApi.spec.js
+++ b/src/shared/__tests__/libs/iota/extendedApi.spec.js
@@ -7,7 +7,7 @@ import { getIotaInstance, isNodeHealthy, allowsRemotePow } from '../../../libs/i
 import { iota, SwitchingConfig } from '../../../libs/iota/index';
 import { newZeroValueTransactionTrytes } from '../../__samples__/trytes';
 import { EMPTY_HASH_TRYTES } from '../../../libs/iota/utils';
-import { IRI_API_VERSION } from '../../../config';
+import { IRI_API_VERSION, MAX_MILESTONE_FALLBEHIND } from '../../../config';
 
 describe('libs: iota/extendedApi', () => {
     before(() => {
@@ -150,7 +150,7 @@ describe('libs: iota/extendedApi', () => {
             });
         });
 
-        describe('when latestSolidSubtangleMilestoneIndex is 1 less than latestMilestoneIndex', () => {
+        describe(`when latestSolidSubtangleMilestoneIndex is ${MAX_MILESTONE_FALLBEHIND} less than latestMilestoneIndex`, () => {
             describe('when "timestamp" on trytes is from five minutes ago', () => {
                 beforeEach(() => {
                     nock('http://localhost:14265', {
@@ -169,7 +169,7 @@ describe('libs: iota/extendedApi', () => {
                                 getNodeInfo: {
                                     appVersion: '0.0.0',
                                     latestMilestoneIndex: 426550,
-                                    latestSolidSubtangleMilestoneIndex: 426550 - 1,
+                                    latestSolidSubtangleMilestoneIndex: 426550 - MAX_MILESTONE_FALLBEHIND,
                                     latestMilestone: 'U'.repeat(81),
                                     latestSolidSubtangleMilestone: 'A'.repeat(81),
                                 },
@@ -207,7 +207,7 @@ describe('libs: iota/extendedApi', () => {
                                 getNodeInfo: {
                                     appVersion: '0.0.0',
                                     latestMilestoneIndex: 426550,
-                                    latestSolidSubtangleMilestoneIndex: 426550 - 1,
+                                    latestSolidSubtangleMilestoneIndex: 426550 - MAX_MILESTONE_FALLBEHIND,
                                     latestMilestone: 'U'.repeat(81),
                                     latestSolidSubtangleMilestone: 'A'.repeat(81),
                                 },

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -3,7 +3,7 @@ export const __TEST__ = process.env.NODE_ENV === 'test';
 export const __MOBILE__ = typeof navigator !== 'undefined' && navigator.product === 'ReactNative';
 
 /** Default IRI node */
-export const defaultNode = __TEST__ ? 'http://localhost:14265' : 'https://nodes.thetangle.org:443';
+export const defaultNode = __TEST__ ? 'http://localhost:14265' : 'https://nodes.iota.org';
 
 export const nodesWithPowDisabled = ['https://trinity.iota-tangle.io:14265', 'https://node.iota-tangle.io:14265'];
 

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -50,3 +50,6 @@ export const IRI_API_VERSION = '1';
 export const QUORUM_THRESHOLD = 67;
 export const QUORUM_SIZE = 4;
 export const QUORUM_SYNC_CHECK_INTERVAL = 120;
+
+/** Maximum milestone fallbehind threshold for node sync checks */
+export const MAX_MILESTONE_FALLBEHIND = 2;

--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -20,6 +20,7 @@ import {
     ATTACH_TO_TANGLE_REQUEST_TIMEOUT,
     GET_TRANSACTIONS_TO_APPROVE_REQUEST_TIMEOUT,
     IRI_API_VERSION,
+    MAX_MILESTONE_FALLBEHIND,
 } from '../../config';
 import {
     sortTransactionTrytesArray,
@@ -620,7 +621,7 @@ const isNodeHealthy = (provider) => {
                 cached.latestMilestone = latestMilestone;
                 if (
                     (cached.latestMilestone === latestSolidSubtangleMilestone ||
-                        latestMilestoneIndex - 1 === latestSolidSubtangleMilestoneIndex) &&
+                        latestMilestoneIndex - MAX_MILESTONE_FALLBEHIND === latestSolidSubtangleMilestoneIndex) &&
                     cached.latestMilestone !== EMPTY_HASH_TRYTES
                 ) {
                     return getTrytesAsync(provider)([cached.latestMilestone]);


### PR DESCRIPTION
# Description

- Update wallet's default node to `https://nodes.iota.org`
- Update max milestone threshold value. Max milestone threshold is the value used for node sync checks. This value determines how far behind in milestones a node can be. Previously, it was set to 1 which is quite restrictive and often leads to "out of sync" errors.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Updated unit tests

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
