### PR TITLE
Make sure all realm objects are converted to plain objects

### DIFF
--- a/src/shared/libs/storageToStateMappers.js
+++ b/src/shared/libs/storageToStateMappers.js
@@ -14,7 +14,7 @@ export const mapStorageToState = () => {
     Account.orderAccountsByIndex();
     const accountsData = Account.getDataAsArray();
 
-    const { settings, onboardingComplete, errorLog, accountInfoDuringSetup } = Wallet.latestData;
+    const { settings, onboardingComplete, errorLog, accountInfoDuringSetup } = Wallet.latestDataAsPlainObject;
     const nodes = Node.getDataAsArray();
 
     return {
@@ -53,6 +53,7 @@ export const mapStorageToState = () => {
         },
         settings: assign({}, settings, {
             nodes: map(nodes, (node) => node.url),
+            availableCurrencies: map(settings.availableCurrencies, (currency) => currency),
             customNodes: map(filter(nodes, (node) => node.custom === true), (node) => node.url),
         }),
         alerts: { notificationLog: map(errorLog, (error) => error) },

--- a/src/shared/storage/index.js
+++ b/src/shared/storage/index.js
@@ -11,6 +11,7 @@ import merge from 'lodash/merge';
 import orderBy from 'lodash/orderBy';
 import size from 'lodash/size';
 import some from 'lodash/some';
+import { serialise, parse } from '../libs/utils';
 import schemas, { getDeprecatedStoragePath, STORAGE_PATH as latestStoragePath, v0Schema, v1Schema } from '../schemas';
 import { __MOBILE__, __TEST__ } from '../config';
 import { preserveAddressLocalSpendStatus } from '../libs/iota/addresses';
@@ -334,6 +335,15 @@ class Wallet {
         const dataForCurrentVersion = Wallet.getObjectForId();
 
         return dataForCurrentVersion.settings;
+    }
+
+    /**
+     * Wallet data (as plain object) for most recent version.
+     */
+    static get latestDataAsPlainObject() {
+        const data = Wallet.latestData;
+
+        return parse(serialise(data));
     }
 
     /**


### PR DESCRIPTION
# Description

Make sure all objects and array in realm results are converted to plain JavaScript object and array before they are mapped to state.

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
