### PR TITLE
Shared: Add iota.org node cluster to default list

### DIFF
--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -8,8 +8,9 @@ export const defaultNode = __TEST__ ? 'http://localhost:14265' : 'https://nodes.
 export const nodesWithPowDisabled = ['https://trinity.iota-tangle.io:14265', 'https://node.iota-tangle.io:14265'];
 
 export const nodesWithPowEnabled = [
-    'https://iotanode.us:443',
+    'https://nodes.iota.org',
     'https://nodes.thetangle.org:443',
+    'https://iotanode.us:443',
     'https://pool.trytes.eu',
     'https://pow.iota.community:443',
 ];


### PR DESCRIPTION
# Description

- Adds nodes.iota.org to list of default nodes

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

No testing

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
