### PR TITLE
Shared: Fix node sync check

### DIFF
--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -621,7 +621,7 @@ const isNodeHealthy = (provider) => {
                 cached.latestMilestone = latestMilestone;
                 if (
                     (cached.latestMilestone === latestSolidSubtangleMilestone ||
-                        latestMilestoneIndex - MAX_MILESTONE_FALLBEHIND === latestSolidSubtangleMilestoneIndex) &&
+                        latestMilestoneIndex - MAX_MILESTONE_FALLBEHIND <= latestSolidSubtangleMilestoneIndex) &&
                     cached.latestMilestone !== EMPTY_HASH_TRYTES
                 ) {
                     return getTrytesAsync(provider)([cached.latestMilestone]);


### PR DESCRIPTION
# Description
This fixes the node sync check so that it allows a range of milestones. If the `latestMilestoneIndex` is `5` and the `latestSolidSubtangleMilestoneIndex` is `4`, the node health check should now return `true` because the `latestSolidSubtangleMilestoneIndex` is between `3` (`latestMilestoneIndex - MAX_MILESTONE_FALLBEHIND`) and `5`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Updated unit tests

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
