### PR TITLE
Mobile: Adjust seed migration timeout

### DIFF
--- a/src/mobile/src/ui/components/Migration.js
+++ b/src/mobile/src/ui/components/Migration.js
@@ -143,7 +143,7 @@ class Migration extends Component {
     executeSeedMigration() {
         const { t } = this.props;
         migrateSeedStorage(global.passwordHash)
-            .then(() => timer.setTimeout('delayNavigation', () => this.navigateToLoadingScreen(), 7500))
+            .then(() => timer.setTimeout('delayNavigation', () => this.navigateToLoadingScreen(), 10000))
             .catch(() => this.props.generateAlert('error', t('somethingWentWrong'), t('somethingWentWrongTryAgain')));
     }
 

--- a/src/shared/libs/migrations.js
+++ b/src/shared/libs/migrations.js
@@ -122,7 +122,7 @@ export const migrateAccounts = (accounts) => {
                 const addressData = map(addresses, (data, address) => assign({}, data, { address }));
                 const index = get(thisAccountInfo, 'index');
 
-                return syncAccount()({
+                return syncAccount(undefined, false)({
                     addressData,
                     // Transactions structure has been changed in the updated Account schema model. See schema/index.js.
                     // Previously, transactions were normalised before they were added to storage


### PR DESCRIPTION
# Description

- Increase seed migration arbitrary timeout to give user time to read text

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

No need to test

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
