### PR TITLE
Fix RC1 -> RC2 installation issue on Windows

### DIFF
--- a/src/shared/storage/index.js
+++ b/src/shared/storage/index.js
@@ -793,8 +793,6 @@ const migrateToNewStoragePath = (config) => {
     });
 
     oldRealm.write(() => oldRealm.deleteAll());
-
-    Realm.deleteFile(config);
 };
 
 /**


### PR DESCRIPTION
Installing RC2 on top of RC1 build leads to an app crash throwing `Error: resource busy or locked`. This commit fixes the issue.

[Realm.schemaVersion(path)](https://github.com/iotaledger/trinity-wallet/blob/develop/src/shared/storage/index.js#L817) creates unnecessary realm files. Therefore we had to manually [remove](https://github.com/iotaledger/trinity-wallet/blob/develop/src/shared/storage/index.js#L852-L859) these files. On Windows 10 however, it was conflicting with the `Realm.deleteFile` operation [here](https://github.com/iotaledger/trinity-wallet/blob/develop/src/shared/storage/index.js#L797) which was rather unnecessary as we are manually deleting the files anyways in the next step.
# Description

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested Windows 10

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
