### PR TITLE
Mobile: Fix Android splash screen hang when activity context is destroyed

### DIFF
--- a/src/mobile/src/ui/routes/entry.js
+++ b/src/mobile/src/ui/routes/entry.js
@@ -31,6 +31,8 @@ import { mapStorageToState } from 'shared-modules/libs/storageToStateMappers';
 // Assign Realm to global RN variable
 global.Realm = Realm;
 
+let firstLaunch = true;
+
 const launch = () => {
     // Disable auto node switching.
     SwitchingConfig.autoSwitch = false;
@@ -57,26 +59,37 @@ const launch = () => {
     // Set default language
     i18next.changeLanguage(getLocaleFromLabel(state.settings.language));
 
-    // FIXME: Temporarily needed for password migration
-    const updatedState = reduxStore.getState();
-
-    const navigateToForceChangePassword =
-        updatedState.settings.versions.version === '0.5.0' && !updatedState.settings.completedForcedPasswordUpdate;
-
-    // Select initial screen
-    const initialScreen = state.accounts.onboardingComplete
-        ? navigateToForceChangePassword ? 'forceChangePassword' : 'login'
-        : 'languageSetup';
-
-    renderInitialScreen(initialScreen, state);
+    renderInitialScreen(getInitialScreen());
 };
 
 const onAppStart = () => {
     registerScreens(reduxStore, Provider);
-    return new Promise((resolve) => Navigation.events().registerAppLaunchedListener(resolve));
+    return new Promise((resolve) => {
+        Navigation.events().registerAppLaunchedListener(() => {
+            if (firstLaunch) {
+                firstLaunch = false;
+                return;
+            }
+            delete global.passwordHash;
+            return renderInitialScreen(getInitialScreen());
+        });
+        resolve();
+    });
 };
 
-const renderInitialScreen = (initialScreen, state) => {
+const getInitialScreen = () => {
+    const state = reduxStore.getState();
+    // FIXME: Temporarily needed for password migration
+    const navigateToForceChangePassword =
+        state.settings.versions.version === '0.5.0' && !state.settings.completedForcedPasswordUpdate;
+    // Select initial screen
+    return state.accounts.onboardingComplete
+        ? navigateToForceChangePassword ? 'forceChangePassword' : 'login'
+        : 'languageSetup';
+};
+
+const renderInitialScreen = (initialScreen) => {
+    const state = reduxStore.getState();
     const theme = Themes[state.settings.themeName] || Themes.Default;
 
     const options = {
@@ -197,11 +210,11 @@ onAppStart()
             version: getVersion(),
             buildNumber: Number(getBuildNumber()),
         };
-
         // Get persisted data in AsyncStorage
         return reduxPersistStorageAdapter.get().then((storedData) => {
             const buildNumber = get(storedData, 'settings.versions.buildNumber');
             const completedMigration = get(storedData, 'settings.completedMigration', false);
+
             if (
                 buildNumber < 58 &&
                 !completedMigration &&


### PR DESCRIPTION
# Description

- Fixes an issue where Android activity context is destroyed but js context remains, leading to a hang on the splash screen 
- It _may_ also inadvertently resolve the issues with Language reset

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Android and iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes