### PR TITLE
Convert all nested properties of address data from RealmObject to plain object

### DIFF
--- a/src/shared/storage/index.js
+++ b/src/shared/storage/index.js
@@ -76,9 +76,9 @@ class Account {
 
         return map(accounts, (account) =>
             assign({}, account, {
-                addressData: map(account.addressData, (data) => assign({}, data)),
-                transactions: map(account.transactions, (transaction) => assign({}, transaction)),
-                meta: assign({}, account.meta),
+                addressData: map(account.addressData, (data) => parse(serialise(data))),
+                transactions: map(account.transactions, (transaction) => parse(serialise(transaction))),
+                meta: parse(serialise(account.meta)),
             }),
         );
     }
@@ -247,7 +247,7 @@ class Node {
      * @return {array}
      */
     static getDataAsArray() {
-        return map(Node.data, (node) => assign({}, node));
+        return map(Node.data, (node) => parse(serialise(node)));
     }
 
     /**


### PR DESCRIPTION
# Description

Nested properties in account data don't get converted to plain object. While realm -> plain object conversion was ensured with https://github.com/iotaledger/trinity-wallet/pull/1394 but the nested property e.g., `spent` in address object was still carrying `RealmObject` type. This PR fixes this. 

## Type of change

- Bug fix 

# How Has This Been Tested?

- Manually tested iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
