### PR TITLE
Mobile: Fix crash on empty password fields

### DIFF
--- a/src/mobile/src/ui/components/PasswordFields.js
+++ b/src/mobile/src/ui/components/PasswordFields.js
@@ -74,7 +74,7 @@ class PasswordFields extends Component {
      */
     checkPassword() {
         const { t, password, reentry } = this.props;
-        const { score: { score, feedback: { warning } } } = this.state;
+        const { score: { score } } = this.state;
         if (isEmpty(password)) {
             return this.props.generateAlert('error', t('login:emptyPassword'), t('emptyPasswordExplanation'));
         } else if (size(password) >= MIN_PASSWORD_LENGTH && isEqual(password, reentry) && score === 4) {
@@ -91,6 +91,7 @@ class PasswordFields extends Component {
                 }),
             );
         } else if (score < 4) {
+            const { feedback: { warning } } = this.state;
             const reason = warning
                 ? t(`changePassword:${passwordReasons[warning]}`)
                 : t('changePassword:passwordTooWeakReason');


### PR DESCRIPTION
# Description

Fixes error on empty password fields

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS simulator

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
