### PR TITLE
Mobile: Fix deep link behaviour

### DIFF
--- a/src/mobile/src/ui/components/DeepLinking.js
+++ b/src/mobile/src/ui/components/DeepLinking.js
@@ -4,7 +4,7 @@ import { withNamespaces } from 'react-i18next';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { initiateDeepLinkRequest, setSetting } from 'shared-modules/actions/wallet';
-import { parseAddress } from 'shared-modules/libs/iota/utils';
+import { parseAddress, ADDRESS_LENGTH } from 'shared-modules/libs/iota/utils';
 import { generateAlert } from 'shared-modules/actions/alerts';
 import { changeHomeScreenRoute } from 'shared-modules/actions/home';
 
@@ -31,9 +31,11 @@ export default () => (C) => {
             const { t, generateAlert, deepLinking } = this.props;
 
             if (!deepLinking) {
+                this.props.initiateDeepLinkRequest();
                 this.navigateToSettings();
                 return generateAlert('info', t('deepLink:deepLinkingInfoTitle'), t('deepLink:deepLinkingInfoMessage'));
             }
+            this.props.changeHomeScreenRoute('send');
             const parsedData = parseAddress(data.url);
             if (parsedData) {
                 this.props.initiateDeepLinkRequest(
@@ -41,9 +43,8 @@ export default () => (C) => {
                     parsedData.address,
                     parsedData.message || null,
                 );
-                this.props.changeHomeScreenRoute('send');
             } else {
-                generateAlert('error', t('send:invalidAddress'), t('send:invalidAddressExplanation1'));
+                generateAlert('error', t('send:invalidAddress'), t('send:invalidAddressExplanation1'), { maxLength: ADDRESS_LENGTH });
             }
         }
 

--- a/src/mobile/src/ui/components/DeepLinking.js
+++ b/src/mobile/src/ui/components/DeepLinking.js
@@ -44,7 +44,7 @@ export default () => (C) => {
                     parsedData.message || null,
                 );
             } else {
-                generateAlert('error', t('send:invalidAddress'), t('send:invalidAddressExplanation1'), { maxLength: ADDRESS_LENGTH });
+                generateAlert('error', t('send:invalidAddress'), t('send:invalidAddressExplanation1', { maxLength: ADDRESS_LENGTH }));
             }
         }
 

--- a/src/mobile/src/ui/views/wallet/Loading.js
+++ b/src/mobile/src/ui/views/wallet/Loading.js
@@ -163,9 +163,9 @@ class Loading extends Component {
         } else {
             timer.setTimeout('waitTimeout', () => this.onWaitTimeout(), 15000);
         }
-        this.props.setSetting('mainSettings');
         this.getWalletData();
         if (!deepLinkRequestActive) {
+            this.props.setSetting('mainSettings');
             this.props.changeHomeScreenRoute('balance');
         }
         if (addingAdditionalAccount) {


### PR DESCRIPTION
# Description

- Ensure user is directed to deep link settings if a deep link is opened but deep linking is not enabled
- Fix invalid address alert

Fixes #1382 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on iOS

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
