### PR TITLE
Desktop: Settings and Onboarding fixes

### DIFF
--- a/src/desktop/native/Menu.js
+++ b/src/desktop/native/Menu.js
@@ -214,6 +214,7 @@ export const initMenu = (app, getWindowFunc) => {
                             {
                                 label: language.advanced,
                                 click: () => navigate('settings/advanced'),
+                                enabled: state.enabled,
                             },
                         ],
                     },

--- a/src/desktop/src/ui/views/onboarding/Index.js
+++ b/src/desktop/src/ui/views/onboarding/Index.js
@@ -6,6 +6,7 @@ import { Switch, Route, withRouter } from 'react-router-dom';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
 import { setAccountInfoDuringSetup } from 'actions/accounts';
+import { isSettingUpNewAccount } from 'selectors/accounts';
 
 import Icon from 'ui/components/Icon';
 import Waves from 'ui/components/Waves';
@@ -146,7 +147,7 @@ class Onboarding extends React.PureComponent {
 }
 
 const mapStateToProps = (state) => ({
-    complete: state.accounts.onboardingComplete,
+    complete: state.accounts.onboardingComplete || isSettingUpNewAccount(state),
     isAuthorised: state.wallet.ready,
 });
 

--- a/src/desktop/src/ui/views/settings/Index.js
+++ b/src/desktop/src/ui/views/settings/Index.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { NavLink, Switch, Route, Redirect } from 'react-router-dom';
 import { withI18n } from 'react-i18next';
@@ -29,169 +30,165 @@ import css from './index.scss';
 /**
  * Settings wrapper component
  **/
-class Settings extends React.PureComponent {
-    static propTypes = {
-        /** @ignore */
-        accounts: PropTypes.object,
-        /** Wallet account names */
-        accountNames: PropTypes.array.isRequired,
-        /** @ignore */
-        wallet: PropTypes.object,
-        /** @ignore */
-        location: PropTypes.object,
-        /** @ignore */
-        match: PropTypes.object,
-        /** @ignore */
-        history: PropTypes.shape({
-            push: PropTypes.func.isRequired,
-        }).isRequired,
-        /** @ignore */
-        t: PropTypes.func.isRequired,
-    };
+const Settings = ({ accounts, accountNames, location, match, wallet, history, t }) => {
+    const [walletBusy, setWalletBusy] = useState(false);
 
-    render() {
-        const { accounts, accountNames, location, wallet, history, t } = this.props;
-        const { accountIndex } = this.props.match.params;
+    const { accountIndex } = match.params;
+    const backRoute = wallet.ready ? '/wallet/' : '/onboarding/';
+    const accountSettings = typeof accountIndex === 'string';
 
-        const backRoute = wallet.ready ? '/wallet/' : '/onboarding/';
+    const account = accountSettings
+        ? { ...accounts[accountNames[accountIndex]], ...{ accountName: accountNames[accountIndex], accountIndex } }
+        : null;
 
-        const accountSettings = typeof accountIndex === 'string';
-
-        const account = accountSettings
-            ? { ...accounts[accountNames[accountIndex]], ...{ accountName: accountNames[accountIndex], accountIndex } }
-            : null;
-
-        return (
-            <main className={css.settings}>
-                <aside>
-                    <Scrollbar>
-                        <h1>{t('settings:general')}</h1>
-                        <a
-                            aria-current={!accountSettings ? 'true' : 'false'}
-                            onClick={() => history.push('/settings/language')}
-                        >
-                            Trinity
-                            <Icon icon="settingsAlt" size={14} />
-                        </a>
-                        <nav className={!accountSettings ? css.open : css.closed}>
-                            <NavLink to="/settings/language">
-                                <Icon icon="language" size={16} /> <strong>{t('settings:language')}</strong>
-                            </NavLink>
-                            <NavLink to="/settings/node">
-                                <Icon icon="node" size={16} /> <strong>{t('node')}</strong>
-                            </NavLink>
-                            <NavLink to="/settings/theme">
-                                <Icon icon="theme" size={16} /> <strong>{t('settings:theme')}</strong>
-                            </NavLink>
-                            <NavLink to="/settings/currency">
-                                <Icon icon="currency" size={16} /> <strong>{t('settings:currency')}</strong>
-                            </NavLink>
-                            {wallet.ready && (
-                                <React.Fragment>
-                                    <hr />
-                                    <NavLink to="/settings/password">
-                                        <Icon icon="password" size={16} />{' '}
-                                        <strong>{t('settings:changePassword')}</strong>
-                                    </NavLink>
-                                    <hr />
-                                    <NavLink to="/settings/mode">
-                                        <Icon icon="mode" size={16} /> <strong>{t('settings:mode')}</strong>
-                                    </NavLink>
-                                </React.Fragment>
-                            )}
-                            <NavLink to="/settings/advanced">
-                                <Icon icon="advanced" size={16} /> <strong>{t('settings:advanced')}</strong>
-                            </NavLink>
-                        </nav>
+    return (
+        <main className={classNames(css.settings, walletBusy ? css.busy : null)}>
+            <aside>
+                <Scrollbar>
+                    <h1>{t('settings:general')}</h1>
+                    <a
+                        aria-current={!accountSettings ? 'true' : 'false'}
+                        onClick={() => history.push('/settings/language')}
+                    >
+                        Trinity
+                        <Icon icon="settingsAlt" size={14} />
+                    </a>
+                    <nav className={!accountSettings ? css.open : css.closed}>
+                        <NavLink to="/settings/language">
+                            <Icon icon="language" size={16} /> <strong>{t('settings:language')}</strong>
+                        </NavLink>
+                        <NavLink to="/settings/node">
+                            <Icon icon="node" size={16} /> <strong>{t('node')}</strong>
+                        </NavLink>
+                        <NavLink to="/settings/theme">
+                            <Icon icon="theme" size={16} /> <strong>{t('settings:theme')}</strong>
+                        </NavLink>
+                        <NavLink to="/settings/currency">
+                            <Icon icon="currency" size={16} /> <strong>{t('settings:currency')}</strong>
+                        </NavLink>
                         {wallet.ready && (
                             <React.Fragment>
-                                <h1>{t('settings:account')}</h1>
-                                {accountNames.map((account, index) => {
-                                    return (
-                                        <React.Fragment key={`account-${index}`}>
-                                            <a
-                                                aria-current={accountIndex === String(index) ? 'true' : 'false'}
-                                                onClick={() => history.push(`/settings/account/name/${index}`)}
-                                            >
-                                                {shorten(account, 24)}
-                                                <Icon icon="settingsAlt" size={14} />
-                                            </a>
-                                            <nav className={accountIndex === String(index) ? css.open : css.closed}>
-                                                <NavLink to={`/settings/account/name/${accountIndex}`}>
-                                                    <Icon icon="user" size={16} />{' '}
-                                                    <strong>{t('addAdditionalSeed:accountName')}</strong>
-                                                </NavLink>
-                                                <NavLink to={`/settings/account/seed/${accountIndex}`}>
-                                                    <Icon icon="eye" size={16} />{' '}
-                                                    <strong>{t('accountManagement:viewSeed')}</strong>
-                                                </NavLink>
-                                                <NavLink to={`/settings/account/addresses/${accountIndex}`}>
-                                                    <Icon icon="bookmark" size={16} />{' '}
-                                                    <strong>{t('accountManagement:viewAddresses')}</strong>
-                                                </NavLink>
-                                                <hr />
-                                                <NavLink to={`/settings/account/tools/${accountIndex}`}>
-                                                    <Icon icon="settingsAlt" size={16} />{' '}
-                                                    <strong>{t('accountManagement:tools')}</strong>
-                                                </NavLink>
-                                                {accountNames.length > 1 && (
-                                                    <React.Fragment>
-                                                        <hr />
-                                                        <NavLink to={`/settings/account/remove/${accountIndex}`}>
-                                                            <Icon icon="trash" size={16} />{' '}
-                                                            <strong>{t('accountManagement:deleteAccount')}</strong>
-                                                        </NavLink>
-                                                    </React.Fragment>
-                                                )}
-                                            </nav>
-                                        </React.Fragment>
-                                    );
-                                })}
+                                <hr />
+                                <NavLink to="/settings/password">
+                                    <Icon icon="password" size={16} /> <strong>{t('settings:changePassword')}</strong>
+                                </NavLink>
+                                <hr />
+                                <NavLink to="/settings/mode">
+                                    <Icon icon="mode" size={16} /> <strong>{t('settings:mode')}</strong>
+                                </NavLink>
                             </React.Fragment>
                         )}
-                    </Scrollbar>
-                </aside>
-                <section className={css.content}>
-                    <header>
-                        <a onClick={() => history.push(backRoute)}>
-                            <Icon icon="cross" size={24} />
-                        </a>
-                    </header>
-                    <Switch location={location}>
-                        <Route path="/settings/language" component={Language} />
-                        <Route path="/settings/theme" component={Theme} />
-                        <Route path="/settings/node" component={SetNode} />
-                        <Route path="/settings/currency" component={Currency} />
-                        <Route path="/settings/password" component={Password} />
-                        <Route path="/settings/mode" component={Mode} />
-                        <Route path="/settings/advanced" component={Advanced} />
-                        <Route
-                            path="/settings/account/name/:accountIndex"
-                            render={() => <AccountName account={account} />}
-                        />
-                        <Route
-                            path="/settings/account/seed/:accountIndex"
-                            render={() => <AccountSeed account={account} />}
-                        />
-                        <Route
-                            path="/settings/account/addresses/:accountIndex"
-                            render={() => <AccountAddresses account={account} />}
-                        />
-                        <Route
-                            path="/settings/account/tools/:accountIndex"
-                            render={() => <AccountTools account={account} />}
-                        />
-                        <Route
-                            path="/settings/account/remove/:accountIndex"
-                            render={() => <AccountRemove history={history} account={account} />}
-                        />
-                        <Redirect from="/settings/" to="/settings/language" />
-                    </Switch>
-                </section>
-            </main>
-        );
-    }
-}
+                        <NavLink to="/settings/advanced">
+                            <Icon icon="advanced" size={16} /> <strong>{t('settings:advanced')}</strong>
+                        </NavLink>
+                    </nav>
+                    {wallet.ready && (
+                        <React.Fragment>
+                            <h1>{t('settings:account')}</h1>
+                            {accountNames.map((account, index) => {
+                                return (
+                                    <React.Fragment key={`account-${index}`}>
+                                        <a
+                                            aria-current={accountIndex === String(index) ? 'true' : 'false'}
+                                            onClick={() => history.push(`/settings/account/name/${index}`)}
+                                        >
+                                            {shorten(account, 24)}
+                                            <Icon icon="settingsAlt" size={14} />
+                                        </a>
+                                        <nav className={accountIndex === String(index) ? css.open : css.closed}>
+                                            <NavLink to={`/settings/account/name/${accountIndex}`}>
+                                                <Icon icon="user" size={16} />{' '}
+                                                <strong>{t('addAdditionalSeed:accountName')}</strong>
+                                            </NavLink>
+                                            <NavLink to={`/settings/account/seed/${accountIndex}`}>
+                                                <Icon icon="eye" size={16} />{' '}
+                                                <strong>{t('accountManagement:viewSeed')}</strong>
+                                            </NavLink>
+                                            <NavLink to={`/settings/account/addresses/${accountIndex}`}>
+                                                <Icon icon="bookmark" size={16} />{' '}
+                                                <strong>{t('accountManagement:viewAddresses')}</strong>
+                                            </NavLink>
+                                            <hr />
+                                            <NavLink to={`/settings/account/tools/${accountIndex}`}>
+                                                <Icon icon="settingsAlt" size={16} />{' '}
+                                                <strong>{t('accountManagement:tools')}</strong>
+                                            </NavLink>
+                                            {accountNames.length > 1 && (
+                                                <React.Fragment>
+                                                    <hr />
+                                                    <NavLink to={`/settings/account/remove/${accountIndex}`}>
+                                                        <Icon icon="trash" size={16} />{' '}
+                                                        <strong>{t('accountManagement:deleteAccount')}</strong>
+                                                    </NavLink>
+                                                </React.Fragment>
+                                            )}
+                                        </nav>
+                                    </React.Fragment>
+                                );
+                            })}
+                        </React.Fragment>
+                    )}
+                </Scrollbar>
+            </aside>
+            <section className={css.content}>
+                <header>
+                    <a onClick={() => history.push(backRoute)}>
+                        <Icon icon="cross" size={24} />
+                    </a>
+                </header>
+                <Switch location={location}>
+                    <Route path="/settings/language" component={Language} />
+                    <Route path="/settings/theme" component={Theme} />
+                    <Route path="/settings/node" component={SetNode} />
+                    <Route path="/settings/currency" component={Currency} />
+                    <Route path="/settings/password" component={Password} />
+                    <Route path="/settings/mode" component={Mode} />
+                    <Route path="/settings/advanced" component={Advanced} />
+                    <Route
+                        path="/settings/account/name/:accountIndex"
+                        render={() => <AccountName account={account} />}
+                    />
+                    <Route
+                        path="/settings/account/seed/:accountIndex"
+                        render={() => <AccountSeed account={account} />}
+                    />
+                    <Route
+                        path="/settings/account/addresses/:accountIndex"
+                        render={() => <AccountAddresses account={account} />}
+                    />
+                    <Route
+                        path="/settings/account/tools/:accountIndex"
+                        render={() => <AccountTools setWalletBusy={setWalletBusy} account={account} />}
+                    />
+                    <Route
+                        path="/settings/account/remove/:accountIndex"
+                        render={() => <AccountRemove history={history} account={account} />}
+                    />
+                    <Redirect from="/settings/" to="/settings/language" />
+                </Switch>
+            </section>
+        </main>
+    );
+};
+
+Settings.propTypes = {
+    /** @ignore */
+    accounts: PropTypes.object,
+    /** Wallet account names */
+    accountNames: PropTypes.array.isRequired,
+    /** @ignore */
+    wallet: PropTypes.object,
+    /** @ignore */
+    location: PropTypes.object,
+    /** @ignore */
+    match: PropTypes.object,
+    /** @ignore */
+    history: PropTypes.shape({
+        push: PropTypes.func.isRequired,
+    }).isRequired,
+    /** @ignore */
+    t: PropTypes.func.isRequired,
+};
 
 const mapStateToProps = (state) => ({
     accounts: state.accounts.accountInfo,

--- a/src/desktop/src/ui/views/settings/account/Tools.js
+++ b/src/desktop/src/ui/views/settings/account/Tools.js
@@ -49,6 +49,8 @@ class Tools extends PureComponent {
         /** @ignore */
         generateAddressesAndGetBalance: PropTypes.func.isRequired,
         /** @ignore */
+        setWalletBusy: PropTypes.func.isRequired,
+        /** @ignore */
         transitionForSnapshot: PropTypes.func.isRequired,
         /** @ignore */
         activeStepIndex: PropTypes.number.isRequired,
@@ -56,12 +58,6 @@ class Tools extends PureComponent {
         activeSteps: PropTypes.array.isRequired,
         /** @ignore */
         t: PropTypes.func.isRequired,
-        /** @ignore */
-        isTransitioning: PropTypes.bool.isRequired,
-        /** @ignore */
-        isAttachingToTangle: PropTypes.bool.isRequired,
-        /** @ignore */
-        balanceCheckFlag: PropTypes.bool.isRequired,
     };
 
     static renderProgressChildren(activeStepIndex, sizeOfActiveSteps, t) {
@@ -79,9 +75,9 @@ class Tools extends PureComponent {
         const { wallet, ui } = this.props;
 
         if (
-            prevProps.isTransitioning === ui.isTransitioning &&
-            prevProps.isAttachingToTangle === ui.isAttachingToTangle &&
-            prevProps.balanceCheckFlag === wallet.balanceCheckFlag &&
+            prevProps.ui.isTransitioning === ui.isTransitioning &&
+            prevProps.ui.isAttachingToTangle === ui.isAttachingToTangle &&
+            prevProps.wallet.balanceCheckFlag === wallet.balanceCheckFlag &&
             prevProps.ui.isSyncing === ui.isSyncing
         ) {
             return;
@@ -89,7 +85,9 @@ class Tools extends PureComponent {
 
         if (ui.isSyncing || ui.isTransitioning || ui.isAttachingToTangle || wallet.balanceCheckFlag) {
             Electron.updateMenu('enabled', false);
+            this.props.setWalletBusy(true);
         } else {
+            this.props.setWalletBusy(false);
             Electron.updateMenu('enabled', true);
             Electron.garbageCollect();
         }
@@ -258,7 +256,4 @@ const mapDispatchToProps = {
     setBalanceCheckFlag,
 };
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(withI18n()(Tools));
+export default connect(mapStateToProps, mapDispatchToProps)(withI18n()(Tools));

--- a/src/desktop/src/ui/views/settings/index.scss
+++ b/src/desktop/src/ui/views/settings/index.scss
@@ -226,6 +226,14 @@
         margin: 32px 0;
         border-top: 1px solid var(--body-alt);
     }
+
+    &.busy {
+        a,
+        button {
+            opacity: 0.5;
+            pointer-events: none;
+        }
+    }
 }
 
 .scroll {


### PR DESCRIPTION
# Description

-  Add busy state to Settings page (disable menu and close links) while doing Manual sync or Snapshot transition
- Add disabled state to Advanced settings menu item
- Set Login as default route if adding first account is complete

Fixes #1440
Fixes #1442 
Fixes #1439 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on macOS 10.14

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code