### PR TITLE
Desktop 0.5.0 Release

### DIFF
--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trinity-desktop",
   "productName": "Trinity",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "private": true,
   "url": "https://trinity.iota.org",
   "homepage": "https://trinity.iota.org",

--- a/src/desktop/src/ui/global/About.js
+++ b/src/desktop/src/ui/global/About.js
@@ -59,6 +59,37 @@ class About extends React.PureComponent {
 
                     <article>
                         <Scrollbar>
+                            <h5>0.5.0</h5>
+                            <ul>
+                                <li>- Add: Node quorum - Trinity will query multiple nodes on particular API calls and only accept a result with 67% consensus, otherwise fallback to a safe result</li>
+                                <li>- Add: Replace local storage with encrypted Realm database </li>
+                                <li>- Add: Deep link support</li>
+                                <li>- Update: Remove 2FA</li>
+                                <li>- Fix: Use local time for SeedVault export file</li>
+                                <li>- Update: Add polling service for automatically retrying failed transactions</li>
+                                <li>- Update: Update dependencies</li>
+                                <li>- Fix: Bugs related to local PoW</li>
+                                <li>- Fix: Minor bugs in Realm and polling</li>
+                                <li>- Fix: Snapshot transition showing 0 balance</li>
+                                <li>- Fix: Add missing domains to external link whitelist</li>
+                                <li>- Fix: Increase timeout for getTransactionsToApprove requests</li>
+                                <li>- Fix: Improve performance by not reconstructing bundles unnecessarily</li>
+                                <li>- Update: Show modal for Ledger errors related to udev</li>
+                                <li>- Fix: Linux app icon</li>
+                                <li>- Fix: Only trigger notifications for new transactions</li>
+                                <li>- Update: Validate SeedVault before attempting to import</li>
+                                <li>- Update: Add seed export unavailable explanation</li>
+                                <li>- Update: Transaction history search feature</li>
+                                <li>- Fix: Use less strict threshold for out-of-sync checks</li>
+                                <li>- Fix: Align Entangled trunk/branch assignment with IRI</li>
+                                <li>- Update: Add iota.org node cluster</li>
+                                <li>- Update: Additional SeedVault export validation check</li>
+                                <li>- Fix: Onboarding unique seed check raises error</li>
+                                <li>- Fix: Additional account onboarding freezes after first unsuccessful try</li>
+                                <li>- Fix: Unable to cancel history refresh without Ledger device</li>
+                                <li>- Fix: Receive closes automatically on Ledger account</li>
+                                <li>- Fix: Various other bug fixes, changes and improvements</li>
+                            </ul>
                             <h5>0.4.6</h5>
                             <ul>
                                 <li>- Fix: Unexpected wallet behaviour with account names starting with a number</li>


### PR DESCRIPTION
# Changelog

* Node quorum - Trinity will query multiple nodes on particular API calls and only accept a result with 67% consensus, otherwise fallback to a safe result (#631)
* Replace local storage with Realm database (#375, #1041, #1146, #1260)
* Encrypt account history within Realm database (#1018)
* Deep link support: useful feature for iota-centric e-commerce, where clicking a deep link prefills transaction data in Trinity (e.g. iota://XNGPUCURQLLJFGXNDCMROGYNWAZP9AFWSVEUAIWIESOSPYDUPWSPSREEBWJPD9ZWZPAJKBHPLG99DJWJCZUHWTQTDD/?amount=1000000&message=happybirthdayrajiv) (#1143)
* Remove 2FA from all versions #(1292)
* Node out of sync errors (#1392, #1405, #1436)
* Use local time for SeedVault export file (#1178)
* Add polling service for automatically retrying failed transactions (#1142)
* Add missing domains to external link whitelist (#1237)
* Large history performance improvements (#1293, #1276)
* Fix bug where the full bundle is not stored on failed broadcast (#1018)
* Fix bug where unspent addresses are reported as spent when reattaching (#1046)
* Increase timeout for attachToTangle network requests (#989)
* Autoretry with increased timeouts for getTransactionsToApprove and attachToTangle endpoints (#1285)
* Don’t store invalid bundles constructed with local PoW nor mark associated addresses as spent (#1122)
* Fix account duplication on account rename (#1077)
* Add more default nodes (#1106)
* Remove dead nodes from config (#1087, #1401)
* Reduce quorum size (#1149)
* Disable quorum on login (#1157)
* Disable quorum on first account load and manual sync (#1258)
* Disable quorum on migration (#1404)
* Block untraversable bundles from being broadcasted (#1191, #1214)
* Incorrect Realm type casting in state (#1394)
* Ensure all RealmObject nested properties are converted to plain objects (#1431)
* Refine snapshot transition function to find funds more easily (#1395)
* Rewrite flexible Realm version to version migration setup (#1168)
* Make sure we remove unnecessary realm storage files on deprecated storage path (#1358)
* Show modal for Ledger errors related to udev (#1192)
* Fix linux app icon (#1322)
* Only trigger notifications for new transactions (#1323)
* Validate SeedVault before attempting to import (#1432)
* Add seed export unavailable explanation (#1383)
* Transaction history search feature (#1340)
* Align Entangled trunk/branch assignment with IRI (#1302)
* Add iota.org node cluster (#1405)
* Additional SeedVault export validation check (#1432)
* Fix inability to cancel history refresh without Ledger device (#1101)
* Fix receive pane closing automatically on Ledger account (#1101)
* Various other bug fixes, changes and improvements