### PR TITLE
Shared: Fix extra parameter in fn call when reattaching and promoting

### DIFF
--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -400,7 +400,7 @@ export const forceTransactionPromotion = (
             }
 
             const existingAccountState = selectedAccountStateFactory(accountName)(getState());
-            const newState = syncAccountAfterReattachment(accountName, reattachment, existingAccountState);
+            const newState = syncAccountAfterReattachment(reattachment, existingAccountState);
 
             // Update storage (realm)
             Account.update(accountName, newState);


### PR DESCRIPTION
# Description

`syncAccountAfterReattachment` was called with an extra parameter when reattaching and promoting a transaction. This resulted in an error that said `accountState.transactions is not iterable` or `Cannot read property 'Symbol(Symbol.iterator)' of undefined`.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on macOS (debug)


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
