### PR TITLE
Mobile/iOS: Patch react-native run-ios

### DIFF
--- a/src/mobile/patches/react-native+0.57.5.patch
+++ b/src/mobile/patches/react-native+0.57.5.patch
@@ -54,4 +54,17 @@ index 5534eb6..dba31c9 100644
 +      clientBuilder.connectTimeout(timeout, TimeUnit.MILLISECONDS);
      }
      OkHttpClient client = clientBuilder.build();
- 
+
+diff --git a/node_modules/react-native/local-cli/runIOS/findMatchingSimulator.js b/node_modules/react-native/local-cli/runIOS/findMatchingSimulator.js
+index 1928d6f..82a862d 100644
+--- a/node_modules/react-native/local-cli/runIOS/findMatchingSimulator.js
++++ b/node_modules/react-native/local-cli/runIOS/findMatchingSimulator.js
+@@ -39,7 +39,7 @@ function findMatchingSimulator(simulators, simulatorString) {
+   var match;
+   for (let version in devices) {
+     // Making sure the version of the simulator is an iOS or tvOS (Removes Apple Watch, etc)
+-    if (!version.startsWith('iOS') && !version.startsWith('tvOS')) {
++    if (!version.includes('iOS') && !version.includes('tvOS')) {
+       continue;
+     }
+     if (simulatorVersion && !version.endsWith(simulatorVersion)) {


### PR DESCRIPTION
# Description

react-native run-ios returns error "Could not find iPhone simulator". This only happens on xcode version 10.2.

This commit fixes the issue by patching react-native.

Fixes https://github.com/iotaledger/trinity-wallet/issues/1508

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested by building iOS (debug) using `./node_modules/.bin/react-native run-ios`

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
