### PR TITLE
Desktop: Fix Tray application Fiat value

### DIFF
--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -43,11 +43,15 @@ class Polling extends React.PureComponent {
         /** @ignore */
         allPollingServices: PropTypes.array.isRequired,
         /** @ignore */
+        isPollingMarketData: PropTypes.bool.isRequired,
+        /** @ignore */
         unconfirmedBundleTails: PropTypes.object.isRequired,
         /** @ignore */
         autoPromotion: PropTypes.bool.isRequired,
         /** @ignore */
         setPollFor: PropTypes.func.isRequired,
+        /** @ignore */
+        marketData: PropTypes.object.isRequired,
         /** @ignore */
         fetchMarketData: PropTypes.func.isRequired,
         /** @ignore */
@@ -73,20 +77,20 @@ class Polling extends React.PureComponent {
         autoPromoteSkips: 0,
     };
 
+    componentDidMount() {
+        this.onPollTick = this.fetch.bind(this);
+        this.interval = setInterval(this.onPollTick, 8000);
+    }
+
     componentDidUpdate(prevProps) {
-        const { marketData } = this.props;
+        const { marketData, isPollingMarketData } = this.props;
 
         /**
          * Send updated marketData to Tray application
          */
-        if (prevProps.isPollingMarketData && !this.props.isPollingMarketData) {
+        if (prevProps.isPollingMarketData && !isPollingMarketData) {
             Electron.storeUpdate(JSON.stringify({ marketData }));
         }
-    }
-
-    componentDidMount() {
-        this.onPollTick = this.fetch.bind(this);
-        this.interval = setInterval(this.onPollTick, 8000);
     }
 
     componentWillUnmount() {

--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -73,6 +73,17 @@ class Polling extends React.PureComponent {
         autoPromoteSkips: 0,
     };
 
+    componentDidUpdate(prevProps) {
+        const { marketData } = this.props;
+
+        /**
+         * Send updated marketData to Tray application
+         */
+        if (prevProps.isPollingMarketData && !this.props.isPollingMarketData) {
+            Electron.storeUpdate(JSON.stringify({ marketData }));
+        }
+    }
+
     componentDidMount() {
         this.onPollTick = this.fetch.bind(this);
         this.interval = setInterval(this.onPollTick, 8000);
@@ -213,6 +224,7 @@ const mapStateToProps = (state) => ({
     isRetryingFailedTransaction: state.ui.isRetryingFailedTransaction,
     failedBundleHashes: getFailedBundleHashes(state),
     password: state.wallet.password,
+    marketData: state.marketData,
 });
 
 const mapDispatchToProps = {

--- a/src/desktop/src/ui/views/wallet/Dashboard.js
+++ b/src/desktop/src/ui/views/wallet/Dashboard.js
@@ -41,6 +41,8 @@ class Dashboard extends React.PureComponent {
         /** @ignore */
         location: PropTypes.object,
         /** @ignore */
+        marketData: PropTypes.object.isRequired,
+        /** @ignore */
         history: PropTypes.shape({
             push: PropTypes.func.isRequired,
         }).isRequired,

--- a/src/desktop/src/ui/views/wallet/Dashboard.js
+++ b/src/desktop/src/ui/views/wallet/Dashboard.js
@@ -54,6 +54,15 @@ class Dashboard extends React.PureComponent {
         }
     }
 
+    componentDidMount() {
+        const { marketData } = this.props;
+
+        /**
+         * Send updated marketData to Tray application
+         */
+        Electron.storeUpdate(JSON.stringify({ marketData }));
+    }
+
     updateAccount = async () => {
         const { password, accountName, accountMeta } = this.props;
 
@@ -133,6 +142,7 @@ const mapStateToProps = (state) => ({
     accountMeta: getSelectedAccountMeta(state),
     password: state.wallet.password,
     isDeepLinkActive: state.wallet.deepLinkRequestActive,
+    marketData: state.marketData,
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
# Description

Send `marketData` after update to Tray application as the market data are excluded from Realm sync 

Fixes #1501 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS 10.14

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
