### PR TITLE
Desktop: Avoid writing to stdout when replacing Bugsnag API key

### DIFF
--- a/src/desktop/bugsnag.sh
+++ b/src/desktop/bugsnag.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Add Bugsnag API key to src/index.js
-cat src/index.js | sed -e "s/fakeAPIkey/$BUGSNAG_KEY/" | tee src/index.js
+sed -i".orig" -e "s/fakeAPIkey/$BUGSNAG_KEY/" ./src/index.js && rm ./src/index.js.orig
 
 # Add Bugsnag API key to bugsnag.js
-cat bugsnag.js | sed -e "s/fakeAPIkey/$BUGSNAG_KEY/" | tee bugsnag.js
+sed -i".orig" -e "s/fakeAPIkey/$BUGSNAG_KEY/" ./bugsnag.js && rm ./bugsnag.js.orig


### PR DESCRIPTION
# Description
Edits files in place with `sed` instead of displaying them in build logs (side effect of using `tee`) as it can bloat the build logs

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested locally

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code