### PR TITLE
Desktop: Revert to node-usb 1.5.0

### DIFF
--- a/src/desktop/npm-shrinkwrap.json
+++ b/src/desktop/npm-shrinkwrap.json
@@ -15462,20 +15462,12 @@
       }
     },
     "usb": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-1.6.0.tgz",
-      "integrity": "sha512-52DyWlCk9K+iw3LnvY95WXSnpHjxJoI++aGkV8HiMNPc4zmvDQlYvWAzrkbJ2JH3oUcx26XfU5sZcG4RAcVkMg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-1.5.0.tgz",
+      "integrity": "sha512-/0stiQEmweuO2BKv2avzQQ8ypDUjo4Osz5sSEi+d0F4Rc+ddX1xED3uf4Tkelc1eADlfn0JQZYHP0bI7CNDA0Q==",
       "requires": {
-        "bindings": "^1.4.0",
-        "nan": "2.13.2",
-        "prebuild-install": "^5.2.4"
-      },
-      "dependencies": {
-        "nan": {
-          "version": "2.13.2",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-          "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
-        }
+        "nan": "^2.8.0",
+        "node-pre-gyp": "^0.11.0"
       }
     },
     "use": {

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -170,6 +170,7 @@
     "react-transition-group": "4.0.1",
     "realm": "2.23.0",
     "recharts": "1.6.0",
-    "redux": "4.0.1"
+    "redux": "4.0.1",
+    "usb": "1.5.0"
   }
 }


### PR DESCRIPTION
# Description

[node-usb 1.6.0 introduced](https://github.com/tessel/node-usb/releases/tag/v1.6.0) prebuilt releases, which fail on macOS (linux, windows untested). Revert and fixate to `1.5.0` till resolved.


Fixes # (issue)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
