### PR TITLE
Mobile: Fix long account name styling on transfer confirmation modal

### DIFF
--- a/src/mobile/src/ui/components/TransferConfirmationModal.js
+++ b/src/mobile/src/ui/components/TransferConfirmationModal.js
@@ -152,7 +152,7 @@ class TransferConfirmationModal extends Component {
                             ? message.length > 0
                                 ? t('sendingAMessage').toUpperCase()
                                 : t('sendingAnEmptyMessage').toUpperCase()
-                            : t('fromAccount', { selectedAccountName }).toUpperCase()}
+                            : t('fromAccount', { selectedAccountName: `${selectedAccountName.substring(0, 18)}...` }).toUpperCase()}
                     </Text>
                     {isMessage &&
                         message.length > 0 && (

--- a/src/mobile/src/ui/components/TransferConfirmationModal.js
+++ b/src/mobile/src/ui/components/TransferConfirmationModal.js
@@ -152,7 +152,11 @@ class TransferConfirmationModal extends Component {
                             ? message.length > 0
                                 ? t('sendingAMessage').toUpperCase()
                                 : t('sendingAnEmptyMessage').toUpperCase()
-                            : t('fromAccount', { selectedAccountName: `${selectedAccountName.substring(0, 18)}...` }).toUpperCase()}
+                            : selectedAccountName.length >= 18
+                            ? t('fromAccount', {
+                                  selectedAccountName: `${selectedAccountName.substring(0, 18)}...`,
+                              }).toUpperCase()
+                            : t('fromAccount', { selectedAccountName }).toUpperCase()}
                     </Text>
                     {isMessage &&
                         message.length > 0 && (


### PR DESCRIPTION
# Description

Fix ugly styling with long account names on transfer confirmation modal

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
