### PR TITLE
Desktop: Lock node-usb to 1.5.0

### DIFF
--- a/src/desktop/npm-shrinkwrap.json
+++ b/src/desktop/npm-shrinkwrap.json
@@ -1415,13 +1415,12 @@
           "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
         },
         "usb": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/usb/-/usb-1.6.0.tgz",
-          "integrity": "sha512-52DyWlCk9K+iw3LnvY95WXSnpHjxJoI++aGkV8HiMNPc4zmvDQlYvWAzrkbJ2JH3oUcx26XfU5sZcG4RAcVkMg==",
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/usb/-/usb-1.5.0.tgz",
+          "integrity": "sha512-/0stiQEmweuO2BKv2avzQQ8ypDUjo4Osz5sSEi+d0F4Rc+ddX1xED3uf4Tkelc1eADlfn0JQZYHP0bI7CNDA0Q==",
           "requires": {
-            "bindings": "^1.4.0",
-            "nan": "2.13.2",
-            "prebuild-install": "^5.2.4"
+            "nan": "^2.8.0",
+            "node-pre-gyp": "^0.11.0"
           }
         }
       }


### PR DESCRIPTION
# Description
`@ledger-hq/hw-transport-node-hid@4.58.0` introduced prebuilt binaries which are currently not working. See #1558 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on macOS (debug)


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code