### PR TITLE
Desktop: Check for correct Realm encryption key length

### DIFF
--- a/src/desktop/src/libs/realm.js
+++ b/src/desktop/src/libs/realm.js
@@ -13,7 +13,7 @@ export const ALIAS_REALM = 'realm_enc_key';
  */
 export const getEncryptionKey = () => {
     return Electron.readKeychain(ALIAS_REALM).then((encryptionKey) => {
-        if (encryptionKey === null) {
+        if (encryptionKey === null || encryptionKey.split(',').length !== 64) {
             const key = Uint8Array.from(randomBytes(64));
 
             return Electron.setKeychain(ALIAS_REALM, key.toString()).then(() => key);


### PR DESCRIPTION
# Description

Windows 10 users who have been trying Windows 7 release first, have the wrong length Realm encryption key added to keychain. This check ensures that the correct length key is generated and stored.

Possibly related #1542

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Windows 10

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
