### PR TITLE
Desktop: Skip retry failed transactions when password is not available

### DIFF
--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -166,7 +166,7 @@ class Polling extends React.PureComponent {
     retryFailedTransaction = async () => {
         const { failedBundleHashes, password } = this.props;
 
-        if (!isEmpty(failedBundleHashes)) {
+        if (!isEmpty(failedBundleHashes) && !isEmpty(password)) {
             const bundleHashes = keys(failedBundleHashes);
             const bundleForRetry = head(bundleHashes);
             const { name, type } = failedBundleHashes[bundleForRetry];


### PR DESCRIPTION
# Description

Skip polling `retryFailedTransaction` when the password is not available (when wallet lock screen is active).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code