### PR TITLE
Desktop: Fix Ledger onboarding error handling

### DIFF
--- a/src/desktop/src/ui/views/onboarding/seedStore/Ledger.js
+++ b/src/desktop/src/ui/views/onboarding/seedStore/Ledger.js
@@ -118,10 +118,12 @@ class Ledger extends React.PureComponent {
 
             // Handle udev errors
             // See https://github.com/LedgerHQ/ledger-live-desktop/issues/1057 and https://github.com/iotaledger/trinity-wallet/issues/589
-            if (error.message.includes('cannot open device with path')) {
+            if (typeof error.message === 'string' && error.message.includes('cannot open device with path')) {
                 this.setState({
                     udevError: true,
                 });
+            } else {
+                generateAlert('error', t('ledger:connectionError'), t('ledger:connectionErrorExplanation'));
             }
 
             this.setState({


### PR DESCRIPTION
# Description

Desktop Ledger onboarding `setIndex` would keep the wallet on loading state forever if itself raises an error which does not include a `message`. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS and Linux Ubuntu

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code