### PR TITLE
Shared: Fix `getSelectedAccountMeta` selector

### DIFF
--- a/src/shared/__tests__/selectors/accounts.spec.js
+++ b/src/shared/__tests__/selectors/accounts.spec.js
@@ -11,6 +11,7 @@ import {
     getAddressesForSelectedAccount,
     getBalanceForSelectedAccount,
     getSelectedAccountName,
+    getSelectedAccountMeta,
     getSetupInfoFromAccounts,
     getTasksFromAccounts,
     getSetupInfoForSelectedAccount,
@@ -85,6 +86,30 @@ describe('selectors: accounts', () => {
 
         it('should return account name for seed index', () => {
             expect(getSelectedAccountName(state)).to.equal('TEST');
+        });
+    });
+
+    describe('#getSelectedAccountMeta', () => {
+        it('should return account meta for seed index', () => {
+            const state = {
+                accounts,
+                wallet: {
+                    seedIndex: 0,
+                },
+            };
+            expect(getSelectedAccountMeta(state)).to.eql({ type: 'ledger' });
+        });
+
+        it('should return undefined if no accounts present', () => {
+            const state = {
+                accounts: {
+                    accountInfo: {},
+                },
+                wallet: {
+                    seedIndex: 0,
+                },
+            };
+            expect(getSelectedAccountMeta(state)).to.be.undefined;
         });
     });
 

--- a/src/shared/__tests__/selectors/accounts.spec.js
+++ b/src/shared/__tests__/selectors/accounts.spec.js
@@ -109,7 +109,7 @@ describe('selectors: accounts', () => {
                     seedIndex: 0,
                 },
             };
-            expect(getSelectedAccountMeta(state)).to.be.undefined;
+            expect(getSelectedAccountMeta(state)).to.equal(undefined);
         });
     });
 

--- a/src/shared/selectors/accounts.js
+++ b/src/shared/selectors/accounts.js
@@ -99,7 +99,7 @@ export const selectLatestAddressFromAccountFactory = (withChecksum = true) =>
  **/
 export const getSelectedAccountMeta = createSelector(
     selectAccountInfo,
-    (account) => account.meta || { type: 'keychain' },
+    (account) => get(account, 'meta') || { type: 'keychain' },
 );
 
 /**

--- a/src/shared/selectors/accounts.js
+++ b/src/shared/selectors/accounts.js
@@ -99,7 +99,7 @@ export const selectLatestAddressFromAccountFactory = (withChecksum = true) =>
  **/
 export const getSelectedAccountMeta = createSelector(
     selectAccountInfo,
-    (account) => get(account, 'meta') || { type: 'keychain' },
+    (account) => get(account, 'meta'),
 );
 
 /**


### PR DESCRIPTION
# Description

Fix `getSelectedAccountMeta` to not raise fatal error if `typeof account === "undefined"`

Happens when first onboarding is finished and initial load raises an error. The desktop wallet returns to Login screen, where this selector is used in props, but no account is added yet.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
