### PR TITLE
Fix "Duplicate module name" issue

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -137,6 +137,11 @@
     },
     "transformIgnorePatterns": [
       "node_modules/?!(react-native|shared-modules)/"
+    ],
+    "modulePathIgnorePatterns": [
+      "<rootDir>/ios/build/",
+      "<rootDir>/android/build/",
+      "<rootDir>/nodejs-assets/"
     ]
   },
   "react-native": {


### PR DESCRIPTION
# Description

`yarn test` or `npm run test` throws following exceptions:

```
jest-haste-map: Haste module naming collision:
  Duplicate module name: nodejs-project
  Paths: /Users/umair/workspace/trinity-wallet/src/mobile/ios/build/Build/Products/Debug-iphonesimulator/iotaWallet.app/nodejs-project/package.json collides with /Users/umair/workspace/trinity-wallet/src/mobile/nodejs-assets/nodejs-project/package.json

This warning is caused by `hasteImpl` returning the same name for different files.
jest-haste-map: Haste module naming collision:
  Duplicate module name: rn-bridge
  Paths: /Users/umair/workspace/trinity-wallet/src/mobile/android/app/build/intermediates/merged_assets/debug/mergeDebugAssets/out/builtin_modules/rn-bridge/package.json collides with /Users/umair/workspace/trinity-wallet/src/mobile/ios/build/Build/Products/Debug-iphonesimulator/iotaWallet.app/builtin_modules/rn-bridge/package.json

This warning is caused by `hasteImpl` returning the same name for different files.
```

This PR fixes the issue. 

## Type of change

- Bug fix

# How Has This Been Tested?

- By running `yarn test` in `mobile/` directory macOS mojave 10.14.5

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
