### PR TITLE
Mobile: Allow exporting complete settings from state

### DIFF
--- a/src/mobile/src/ui/views/wallet/StateExport.js
+++ b/src/mobile/src/ui/views/wallet/StateExport.js
@@ -19,6 +19,7 @@ import RNFetchBlob from 'rn-fetch-blob';
 import { isAndroid, getAndroidFileSystemPermissions } from 'libs/device';
 import { moment } from 'shared-modules/libs/exports';
 import { serialise } from 'shared-modules/libs/utils';
+import { iota, quorum } from 'shared-modules/libs/iota';
 
 const styles = StyleSheet.create({
     container: {
@@ -98,10 +99,15 @@ export class StateExport extends Component {
                 path,
                 serialise(
                     {
-                        accounts: pick(accounts, ['onboardingComplete', 'accountInfo']),
-                        settings: pick(settings, ['versions']),
                         notificationLog,
+                        settings,
+                        accounts: pick(accounts, ['onboardingComplete', 'accountInfo']),
                         storageFiles: filter(flatMap(files), (name) => includes(name, 'realm')),
+                        __globals__: {
+                            quorumNodes: quorum.nodes,
+                            quorumSize: quorum.size,
+                            iotaNode: iota.provider,
+                        },
                     },
                     null,
                     4,

--- a/src/shared/libs/iota/quorum.js
+++ b/src/shared/libs/iota/quorum.js
@@ -347,6 +347,18 @@ export default function Quorum(config) {
 
     return {
         /**
+         * Returns (selected) quorum nodes
+         */
+        get nodes() {
+            return selectedNodes;
+        },
+        /**
+         * Returns (active) quorum size
+         */
+        get size() {
+            return quorumSize;
+        },
+        /**
          * Set quorum nodes.
          *
          * @method setNodes


### PR DESCRIPTION
# Description

This PR allows users to export:
1. Complete `state.settings` object
2. `iota.provider`
3. `quorum.nodes` (Selected nodes for quorum)
4. `quorum.size` (Active quorum size)

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Manually tested iOS simulator iPhone 7 Plus (Debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
