### PR TITLE
Desktop: FatalError component Linux fix

### DIFF
--- a/src/desktop/src/ui/global/FatalError.js
+++ b/src/desktop/src/ui/global/FatalError.js
@@ -1,11 +1,10 @@
-/* global Electron */
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import css from 'ui/views/onboarding/index.scss';
 
 /**
- * Linux missing dependencies tutorial
+ * Desktop fatal error display component
  */
 const FatalError = ({ error }) => {
     const [errors, setErrors] = useState(typeof window.fatalErrors === 'object' ? window.fatalErrors : []);
@@ -20,10 +19,10 @@ const FatalError = ({ error }) => {
         };
     }, []);
 
-    const linuxContent = () => {
+    const getContent = () => {
         if (typeof error === 'string' && error.indexOf('Unknown or unsupported transport') > -1) {
             return (
-                <form className={css.tutorial}>
+                <form>
                     <h1>Cannot connect to Secret Service API</h1>
                     <p>
                         Please check that you are not running Trinity as <strong>root</strong> user
@@ -33,39 +32,46 @@ const FatalError = ({ error }) => {
             );
         }
 
-        return (
-            <form className={css.tutorial}>
-                <h1>Missing security dependencies</h1>
-                <p>
-                    Your Linux distribution is missing libsecret library that is required for Trinity to securely store
-                    and retrieve sensitive information.
-                </p>
-                <p>Depending on your distribution, you will need to run the following command:</p>
-                <ul>
-                    <li>
-                        Debian/Ubuntu: <pre>sudo apt-get install libsecret-1-dev</pre>
-                    </li>
-                    <li>
-                        Red Hat-based: <pre>sudo yum install libsecret-devel</pre>
-                    </li>
-                    <li>
-                        Arch Linux: <pre>sudo pacman -S libsecret</pre>
-                    </li>
-                </ul>
-                <p>
-                    For some desktop environments (e.g. Kubuntu or KDE), you may need to install an additional library
-                    for the communication with libsecret:
-                </p>
-                <ul>
-                    <li>
-                        <pre>sudo apt-get install gnome-keyring</pre>
-                    </li>
-                </ul>
-            </form>
-        );
-    };
+        if (
+            typeof error === 'string' &&
+            [
+                'The name org.freedesktop.secrets was not provided by any .service files',
+                'Cannot create an item in a locked collection',
+                "Unknown or unsupported transport 'disabled' for address 'disabled:'",
+            ].indexOf(error) > -1
+        ) {
+            return (
+                <form className={css.tutorial}>
+                    <h1>Missing security dependencies</h1>
+                    <p>
+                        Your Linux distribution is missing libsecret library that is required for Trinity to securely
+                        store and retrieve sensitive information.
+                    </p>
+                    <p>Depending on your distribution, you will need to run the following command:</p>
+                    <ul>
+                        <li>
+                            Debian/Ubuntu: <pre>sudo apt-get install libsecret-1-dev</pre>
+                        </li>
+                        <li>
+                            Red Hat-based: <pre>sudo yum install libsecret-devel</pre>
+                        </li>
+                        <li>
+                            Arch Linux: <pre>sudo pacman -S libsecret</pre>
+                        </li>
+                    </ul>
+                    <p>
+                        For some desktop environments (e.g. Kubuntu or KDE), you may need to install an additional
+                        library for the communication with libsecret:
+                    </p>
+                    <ul>
+                        <li>
+                            <pre>sudo apt-get install gnome-keyring</pre>
+                        </li>
+                    </ul>
+                </form>
+            );
+        }
 
-    const generalContent = () => {
         return (
             <form>
                 <h1>Error launching wallet</h1>
@@ -82,9 +88,7 @@ const FatalError = ({ error }) => {
         <main className={css.onboarding}>
             <header />
             <div>
-                <div>
-                    {typeof Electron === 'object' && Electron.getOS() === 'linux' ? linuxContent() : generalContent()}
-                </div>
+                <div>{getContent()}</div>
             </div>
         </main>
     );

--- a/src/desktop/src/ui/global/FatalError.js
+++ b/src/desktop/src/ui/global/FatalError.js
@@ -34,11 +34,11 @@ const FatalError = ({ error }) => {
 
         if (
             typeof error === 'string' &&
-            [
+            ([
                 'The name org.freedesktop.secrets was not provided by any .service files',
                 'Cannot create an item in a locked collection',
-                'Unknown or unsupported transport \'disabled\' for address \'disabled:\'',
-            ].indexOf(error) > -1
+            ].indexOf(error) > -1 ||
+                /disabled(.*)disabled:/g.test(error))
         ) {
             return (
                 <form className={css.tutorial}>

--- a/src/desktop/src/ui/global/FatalError.js
+++ b/src/desktop/src/ui/global/FatalError.js
@@ -37,7 +37,7 @@ const FatalError = ({ error }) => {
             [
                 'The name org.freedesktop.secrets was not provided by any .service files',
                 'Cannot create an item in a locked collection',
-                "Unknown or unsupported transport 'disabled' for address 'disabled:'",
+                'Unknown or unsupported transport \'disabled\' for address \'disabled:\'',
             ].indexOf(error) > -1
         ) {
             return (


### PR DESCRIPTION
# Description

Desktop's `FatalError` component would yield `Missing security dependencies` error on Linux also for application initialisation (e.g. Realm) errors.

Fixes #1630 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS, Ubuntu Linux

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
