### PR TITLE
Desktop: Add Snapshot Transition reminder

### DIFF
--- a/src/desktop/src/ui/views/onboarding/SeedIntro.js
+++ b/src/desktop/src/ui/views/onboarding/SeedIntro.js
@@ -46,9 +46,10 @@ class SeedIntro extends React.PureComponent {
         });
     }
 
-    stepForward(route) {
+    stepForward(route, existingSeed) {
         this.props.setAccountInfoDuringSetup({
             meta: { type: 'keychain' },
+            usedExistingSeed: existingSeed,
         });
 
         this.props.history.push(`/onboarding/${route}`);
@@ -90,18 +91,32 @@ class SeedIntro extends React.PureComponent {
                 </section>
                 <footer className={!ledger ? css.choiceDefault : css.choiceLedger}>
                     <div>
-                        <Button onClick={() => this.stepForward('seed-verify')} className="square" variant="dark">
+                        <Button onClick={() => this.stepForward('seed-verify', true)} className="square" variant="dark">
                             {t('walletSetup:noIHaveOne')}
                         </Button>
-                        <Button onClick={() => this.stepForward('seed-generate')} className="square" variant="primary">
+                        <Button
+                            onClick={() => this.stepForward('seed-generate', false)}
+                            className="square"
+                            variant="primary"
+                        >
                             {t('walletSetup:yesINeedASeed')}
                         </Button>
                     </div>
                     <div>
-                        <Button to="/onboarding/seed-ledger" onClick={() => setAccountInfoDuringSetup({usedExistingSeed: true})} className="square" variant="dark">
+                        <Button
+                            to="/onboarding/seed-ledger"
+                            onClick={() => setAccountInfoDuringSetup({ usedExistingSeed: true })}
+                            className="square"
+                            variant="dark"
+                        >
                             {t('ledger:restoreLedgerAccount')}
                         </Button>
-                        <Button to="/onboarding/seed-ledger" onClick={() => setAccountInfoDuringSetup({usedExistingSeed: false})} className="square" variant="primary">
+                        <Button
+                            to="/onboarding/seed-ledger"
+                            onClick={() => setAccountInfoDuringSetup({ usedExistingSeed: false })}
+                            className="square"
+                            variant="primary"
+                        >
                             {t('ledger:createNewLedgerAccount')}
                         </Button>
                     </div>

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -144,6 +144,8 @@
         "isYourBalanceCorrect": "Is your balance correct?",
         "ifYourBalanceIsNotCorrect": "If your balance is not correct, it is likely that you are using a pre-snapshot seed.",
         "headToAdvancedSettingsForTransition": "Head to Advanced Settings and perform a Snapshot Transition.",
+        "headToAccountTools": "Head to Account Tools and perform a Snapshot Transition.",
+        "openAccountTools": "Open Account Tools",
         "usingTrinityWalletWithKeePass": "Using Trinity Wallet with Keepass2Android",
         "signedTrytesBroadcastErrorExplanation": "There was a network error while broadcasting your transaction.",
         "broadcastError": "Could not broadcast transfer",


### PR DESCRIPTION
# Description

Add Snapshot Transition reminder warning for new accounts that use existing seed.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on macOS by adding new account with existing and newly generated seeds.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
