### PR TITLE
Shared: Block autoretry if a tx has a fatal error on retry

### DIFF
--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -177,8 +177,6 @@ class Polling extends React.PureComponent {
                   name,
                   bundleForRetry,
                   seedStore,
-                  // isAutoRetrying --> true
-                  true
             );
         } else {
             this.moveToNextPollService();

--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -173,7 +173,13 @@ class Polling extends React.PureComponent {
 
             const seedStore = await new SeedStore[type](password, name);
 
-            this.props.retryFailedTransaction(name, bundleForRetry, seedStore);
+            this.props.retryFailedTransaction(
+                  name,
+                  bundleForRetry,
+                  seedStore,
+                  // isAutoRetrying --> true
+                  true
+            );
         } else {
             this.moveToNextPollService();
         }

--- a/src/mobile/src/ui/components/Poll.js
+++ b/src/mobile/src/ui/components/Poll.js
@@ -174,7 +174,13 @@ export class Poll extends Component {
 
             const seedStore = await new SeedStore[type](password, name);
 
-            this.props.retryFailedTransaction(name, bundleForRetry, seedStore);
+            this.props.retryFailedTransaction(
+                name,
+                bundleForRetry,
+                seedStore,
+                // isAutoRetrying --> true
+                true,
+            );
         } else {
             this.moveToNextPollService();
         }
@@ -265,4 +271,7 @@ const mapDispatchToProps = {
     retryFailedTransaction,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(Poll);
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(Poll);

--- a/src/mobile/src/ui/components/Poll.js
+++ b/src/mobile/src/ui/components/Poll.js
@@ -178,8 +178,6 @@ export class Poll extends Component {
                 name,
                 bundleForRetry,
                 seedStore,
-                // isAutoRetrying --> true
-                true,
             );
         } else {
             this.moveToNextPollService();

--- a/src/shared/__tests__/__samples__/transactions.js
+++ b/src/shared/__tests__/__samples__/transactions.js
@@ -22,6 +22,7 @@ const confirmedZeroValueTransactions = [
         nonce: 'OIDFG9999999999999999999999',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
 ];
 
@@ -46,6 +47,7 @@ const confirmedValueTransactions = [
         nonce: 'GIJIDMPJFIDJKHBCPOLVNWMAOGI',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'OAAMETLECXOVQNTTAKCNWPZSQALUYEGTO9QGEQL9ST9RFJ9JPNBHTOABJQTCIHKMNUMHEKZJSFYT99999',
@@ -67,6 +69,7 @@ const confirmedValueTransactions = [
         nonce: 'KGFTPYLNJCEUZAFHXNWKVWRYKJL',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'GL9TUTOTURKGADPQUJAGOCMFGVBJ9M9EHMQABNFS9OSWEGJEOSJRHCJUWPRRJOPMQSDZEJZVXBSIA9999',
@@ -88,6 +91,7 @@ const confirmedValueTransactions = [
         nonce: 'XAGXZKARSLXSMXUSIBAJJIPLHGJ',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'MKELFERILDLTMIFD9FG9GZDJPOB9YHUWENQNTADWDKWLPOYD9R9JJUKJQLFTHZRYVDYNJWWDSP9O99999',
@@ -109,6 +113,7 @@ const confirmedValueTransactions = [
         nonce: 'GCFKXOAZCXG9BSJQAKAY9QGMYFH',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'FQVZNSOUKKSQPCFWCBJCSMAZNAGGVFROELHOOZGFXUVZUWL9TXIQGSUZORIUXJSBKKSUCWNPPWFGA9999',
@@ -130,6 +135,7 @@ const confirmedValueTransactions = [
         nonce: 'XMEIM9999999999999999999999',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'ZBQPKYDP9UXYGMTGDMSVUHKVJLLPTXVQDEAKPJCDBLAVPSMZEGTBPMWLOESS9UPGGBL9ASBFGLSX99999',
@@ -151,6 +157,7 @@ const confirmedValueTransactions = [
         nonce: 'TCXS9A999999999999999999999',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'ACY9SX9YYF9YZEYDPXNLWXZVGEYEAMBZMHV9LJDNCXJNERWJHB9CWXNBRWERCDKDFRBLCIZODZBWA9999',
@@ -172,6 +179,7 @@ const confirmedValueTransactions = [
         nonce: 'ARPIG9999999999999999999999',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'FYTFJUVSACOSQBSPLCBCBFGWYJTGZOYEPLCBK9QMZTYMZOFNNQRMTMQVUR9NMEYAGWYPNHBXKINW99999',
@@ -193,6 +201,7 @@ const confirmedValueTransactions = [
         nonce: 'Z9EBD9999999999999999999999',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'GERAGOPQB9ULOVZJWJWQQ9ONFRNAIECCAHCMIGDOWSLJOKKDFGBFYZYGMU9UVEW9DOMKDE9VPSLJZ9999',
@@ -214,6 +223,7 @@ const confirmedValueTransactions = [
         nonce: 'YSAHPA999999999999999999999',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'RRSOMOBUMCCAVMBRLCHACRKNMSHWIIP9TNXHJQNLANULTWRCIFTQT9BGNZIDGWWO9BZTNGC9MKZHA9999',
@@ -235,6 +245,7 @@ const confirmedValueTransactions = [
         nonce: 'WPPQB9999999999999999999999',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'EYKEEUQVDCSBXIB9FTLIOWEELKLQHVPWEXBGTWLQMMTVFRVLHBPZZEH9FLCXCJFOEUDUSJNSZWGA99999',
@@ -256,6 +267,7 @@ const confirmedValueTransactions = [
         nonce: 'PDPINA999999999999999999999',
         persistence: true,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
 ];
 
@@ -280,6 +292,7 @@ const unconfirmedValueTransactions = [
         nonce: 'TRRNG9999999999999999999999',
         persistence: false,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'IYXZVXTAIKDZQLPIKOBALADCLKIISONLMZYVZAUKHCMJR9BGHTVRWZZTTP9BUQLLUINLPXCWSZ9HZ9999',
@@ -301,6 +314,7 @@ const unconfirmedValueTransactions = [
         nonce: 'EVHIC9999999999999999999999',
         persistence: false,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'AD9JXNOMIQNGCEPQJELKOOOBOVXXQKWOROGZHMYMEFEPXEAXHZMJHFPRPTJETFGQNGYTIORJ9NGFZ9999',
@@ -322,6 +336,7 @@ const unconfirmedValueTransactions = [
         nonce: 'APCAK9999999999999999999999',
         persistence: false,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'WWCQCQ9RCYIBGLDXTCFN9OTOIWNFKSVTJQEDHKYQRSPZHPFOYWMZKMPOWUVKBRQNSZVMCSDGNVSDA9999',
@@ -343,6 +358,7 @@ const unconfirmedValueTransactions = [
         nonce: 'GABYI9999999999999999999999',
         persistence: false,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'IXZUUKVWLWPWWTJWGSAO9GUVVDCEYOUNJRTPPDQVAJQKGTLSZHDHUPGBNJJPZHZADJENZQ9MGQVR99999',
@@ -364,6 +380,7 @@ const unconfirmedValueTransactions = [
         nonce: '9HFRB9999999999999999999999',
         persistence: false,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'PWNCXLVGCRURP9HMSDRHZAYPUJTWPTVSIHORMROEBHATFR9LVEPGDBWGIAHUQMYMZWALZG9XGVBKA9999',
@@ -385,6 +402,7 @@ const unconfirmedValueTransactions = [
         nonce: 'FFWOE9999999999999999999999',
         persistence: false,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'MOJVWYLRIETUURNWIWOZLFKTLYBRRXNSOBXRZIIYQWCYUIHFOGGDGUJVMIK9TFVHSUARVJSN9MOQA9999',
@@ -406,6 +424,7 @@ const unconfirmedValueTransactions = [
         nonce: 'NRFFD9999999999999999999999',
         persistence: false,
         broadcasted: true,
+        fatalErrorOnRetry: false,
     },
 ];
 
@@ -430,6 +449,7 @@ const failedTransactionsWithCorrectTransactionHashes = [
         nonce: 'DPLDK9999999999999999999999',
         persistence: false,
         broadcasted: false,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'DEAFXJMCUPKWPBIYTZGHYDBKWYBNLHZSEACJGNWGEDNDRDQSGVOEXZAYRUIHNYPGRXBOFILFYJTPA9999',
@@ -451,6 +471,7 @@ const failedTransactionsWithCorrectTransactionHashes = [
         nonce: 'N9LWB9999999999999999999999',
         persistence: false,
         broadcasted: false,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'NNVRU9KMIWAZJ9JHSCNDEKJFACRXICFOESLWFDWVZJPSINHEYLRUKQDRAESZMHRKOAFSKPHVOGBY99999',
@@ -472,6 +493,7 @@ const failedTransactionsWithCorrectTransactionHashes = [
         nonce: 'YSLDI9999999999999999999999',
         persistence: false,
         broadcasted: false,
+        fatalErrorOnRetry: false,
     },
 ];
 
@@ -496,6 +518,7 @@ const failedTransactionsWithIncorrectTransactionHashes = [
         nonce: '999999999999999999999999999',
         persistence: false,
         broadcasted: false,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'OA9XIZCOTXWORJWFUVPFAWPCHZUMWQHUI9OEJXABFGOCXHETWXUU9YUHQ9QBJKPOCPXSWOJWYXUMNLFKO',
@@ -517,6 +540,7 @@ const failedTransactionsWithIncorrectTransactionHashes = [
         nonce: '999999999999999999999999999',
         persistence: false,
         broadcasted: false,
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'EEQUTO9HOJB9NBEYUFMSENPKZJZRJRU9BIMX9UPFFRNUJNGSPYNCRNWYWE9YHUMIZCDDJGRIKUV9VSHJW',
@@ -538,6 +562,7 @@ const failedTransactionsWithIncorrectTransactionHashes = [
         nonce: '999999999999999999999999999',
         persistence: false,
         broadcasted: false,
+        fatalErrorOnRetry: false,
     },
 ];
 
@@ -884,6 +909,7 @@ const newZeroValueTransaction = [
         attachmentTimestampLowerBound: 0,
         attachmentTimestampUpperBound: 0,
         nonce: '999999999999999999999999999',
+        fatalErrorOnRetry: false,
     },
 ];
 
@@ -910,6 +936,7 @@ const newZeroValueAttachedTransaction = [
         attachmentTimestampLowerBound: 0,
         attachmentTimestampUpperBound: 3812798742493,
         nonce: 'VCDRNVOSEBJRBWUICWHVJLZKRER',
+        fatalErrorOnRetry: false,
     },
 ];
 
@@ -932,6 +959,7 @@ const newValueTransaction = [
         attachmentTimestampLowerBound: 0,
         attachmentTimestampUpperBound: 0,
         nonce: '999999999999999999999999999',
+        fatalErrorOnRetry: false,
     },
     {
         hash: '9IZLAYLKLHAABKLLCCMRGHXPVTRFEGBBADADVTNYEMHOQ9BJGK9CMPQTCLDLOEDYUOCXPBXENQD9BNPKX',
@@ -951,6 +979,7 @@ const newValueTransaction = [
         attachmentTimestampLowerBound: 0,
         attachmentTimestampUpperBound: 0,
         nonce: '999999999999999999999999999',
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'SDMDX9VWXNQNVXKLKQJFCTPILYNOLIGDLOWLNIMNDICFGMDMOZCYVT9ASDPBGHPWJBIKNAOEXA9N9MMNR',
@@ -970,6 +999,7 @@ const newValueTransaction = [
         attachmentTimestampLowerBound: 0,
         attachmentTimestampUpperBound: 0,
         nonce: '999999999999999999999999999',
+        fatalErrorOnRetry: false,
     },
 ];
 
@@ -997,6 +1027,7 @@ const newValueAttachedTransaction = [
         attachmentTimestampLowerBound: 0,
         attachmentTimestampUpperBound: 3812798742493,
         nonce: 'WRCKILEZJDXQOWXJ99LHBTAILOI',
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'AACJTULPORZYLSJV9YUYXFBSJGUAHIIHDLYCUBISNSINMGAMNHHWCYCCQJIBASEIWYUUQRVXTRJPA9999',
@@ -1016,6 +1047,7 @@ const newValueAttachedTransaction = [
         attachmentTimestampLowerBound: 0,
         attachmentTimestampUpperBound: 3812798742493,
         nonce: '9JFAIRPUGIAIYPFGGYEBGPCINQP',
+        fatalErrorOnRetry: false,
     },
     {
         hash: 'FVA9VKHYQ9VNKIUMCGVUYQIGZGBXSATPUZU9KRTTQQPEGFZIAU9FOGBQFBBJVLGVMWBVLIEOHOTVA9999',
@@ -1035,6 +1067,7 @@ const newValueAttachedTransaction = [
         attachmentTimestampLowerBound: 0,
         attachmentTimestampUpperBound: 3812798742493,
         nonce: '9EEPIJPWUPBTIMYCWREJECGJCPM',
+        fatalErrorOnRetry: false,
     },
 ];
 

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -76,6 +76,3 @@ export const MAXIMUM_QUORUM_SIZE = 7;
 
 /** Maximum milestone fallbehind threshold for node sync checks */
 export const MAX_MILESTONE_FALLBEHIND = 2;
-
-/** Maximum auto-retry limit for failed transactions */
-export const MAX_AUTO_RETRY_ATTEMPTS = 5;

--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -76,3 +76,6 @@ export const MAXIMUM_QUORUM_SIZE = 7;
 
 /** Maximum milestone fallbehind threshold for node sync checks */
 export const MAX_MILESTONE_FALLBEHIND = 2;
+
+/** Maximum auto-retry limit for failed transactions */
+export const MAX_AUTO_RETRY_ATTEMPTS = 5;

--- a/src/shared/libs/iota/accounts.js
+++ b/src/shared/libs/iota/accounts.js
@@ -290,6 +290,33 @@ export const syncAccountOnSuccessfulRetryAttempt = (newTransactionObjects, accou
 };
 
 /**
+ *  Syncs account when auto-retry attempt (to broadcast) a failed transaction was unsuccessful
+ *
+ * @method syncAccountOnUnSuccessfulAutoRetryAttempt
+ *
+ * @param {object} accountState
+ * @param {string} bundleHash
+ *
+ * @returns {object} accountState
+ **/
+export const syncAccountOnUnSuccessfulAutoRetryAttempt = (accountState, bundleHash) => {
+    const updatedTransactions = map(accountState.transactions, (transaction) => {
+        if (transaction.bundle === bundleHash) {
+            return assign({}, transaction, {
+                autoRetryAttempts: transaction.autoRetryAttempts + 1,
+            });
+        }
+
+        return transaction;
+    });
+
+    return {
+        ...accountState,
+        transactions: updatedTransactions,
+    };
+};
+
+/**
  *  Sync local account in case signed inputs were exposed to the network (and the network call failed)
  *
  *   @method syncAccountOnValueTransactionFailure

--- a/src/shared/libs/iota/accounts.js
+++ b/src/shared/libs/iota/accounts.js
@@ -303,7 +303,7 @@ export const syncAccountOnUnsuccessfulAutoRetryAttempt = (accountState, bundleHa
     const updatedTransactions = map(accountState.transactions, (transaction) => {
         if (transaction.bundle === bundleHash) {
             return assign({}, transaction, {
-                autoRetryAttempts: transaction.autoRetryAttempts + 1,
+                fatalErrorOnRetry: true,
             });
         }
 

--- a/src/shared/libs/iota/accounts.js
+++ b/src/shared/libs/iota/accounts.js
@@ -292,14 +292,14 @@ export const syncAccountOnSuccessfulRetryAttempt = (newTransactionObjects, accou
 /**
  *  Syncs account when auto-retry attempt (to broadcast) a failed transaction was unsuccessful
  *
- * @method syncAccountOnUnSuccessfulAutoRetryAttempt
+ * @method syncAccountOnUnsuccessfulAutoRetryAttempt
  *
  * @param {object} accountState
  * @param {string} bundleHash
  *
  * @returns {object} accountState
  **/
-export const syncAccountOnUnSuccessfulAutoRetryAttempt = (accountState, bundleHash) => {
+export const syncAccountOnUnsuccessfulAutoRetryAttempt = (accountState, bundleHash) => {
     const updatedTransactions = map(accountState.transactions, (transaction) => {
         if (transaction.bundle === bundleHash) {
             return assign({}, transaction, {

--- a/src/shared/libs/iota/accounts.js
+++ b/src/shared/libs/iota/accounts.js
@@ -201,6 +201,7 @@ export const syncAccountAfterSpending = (settings, withQuorum) => (seedStore, ne
             persistence: false,
             // Since these transactions were successfully broadcasted, assign broadcast status as true
             broadcasted: true,
+            fatalErrorOnRetry: false,
         })),
     ];
     // Update address data
@@ -231,7 +232,12 @@ export const syncAccountAfterReattachment = (reattachment, accountState) => ({
     ...accountState,
     transactions: [
         ...accountState.transactions,
-        ...map(reattachment, (transaction) => ({ ...transaction, persistence: false, broadcasted: true })),
+        ...map(reattachment, (transaction) => ({
+            ...transaction,
+            persistence: false,
+            broadcasted: true,
+            fatalErrorOnRetry: false,
+        })),
     ],
 });
 
@@ -249,6 +255,7 @@ export const syncAccountOnValueTransactionFailure = (newTransactionObjects, acco
         ...transaction,
         persistence: false,
         broadcasted: false,
+        fatalErrorOnRetry: false,
     }));
     const addressData = markAddressesAsSpentSync([failedTransactions], accountState.addressData);
 
@@ -349,6 +356,7 @@ export const syncAccountDuringSnapshotTransition = (attachedTransactions, attach
                 ...transaction,
                 persistence: false,
                 broadcasted: true,
+                fatalErrorOnRetry: false,
             })),
         ],
     };

--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -1071,3 +1071,27 @@ export const isBundleTraversable = (bundle, trunkTransaction, branchTransaction)
  * @returns {boolean}
  */
 export const isBundle = (bundle) => iota.utils.isBundle(orderBy(bundle, ['currentIndex'], ['asc']));
+
+/**
+ * Determines if a transaction error should be considere fatal
+ *
+ * @method isFatalTransactionError
+ *
+ * @param {object} err
+ *
+ * @returns {boolean}
+ */
+export const isFatalTransactionError = (err) => {
+    const fatalTransferErrors = [
+        Errors.BUNDLE_NO_LONGER_FUNDED,
+        Errors.DETECTED_INPUT_WITH_ZERO_BALANCE,
+        Errors.INVALID_TRANSFER,
+        Errors.TRANSACTION_IS_INCONSISTENT,
+        Errors.ALREADY_SPENT_FROM_ADDRESSES,
+        Errors.INVALID_BUNDLE,
+        Errors.BUNDLE_NO_LONGER_VALID,
+        Errors.FUNDS_AT_SPENT_ADDRESSES,
+        Errors.KEY_REUSE,
+    ];
+    return some(fatalTransferErrors, (error) => err.message && err.message.includes(error));
+};

--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -463,6 +463,7 @@ export const syncTransactions = (settings) => (diff, existingTransactions) => {
                         // Temporarily assign persistence false
                         // In the next step, communicate with the ledger to get correct inclusion state (persistence) and assign those
                         persistence: false,
+                        fatalErrorOnRetry: false,
                     })),
                 );
 

--- a/src/shared/reducers/accounts.js
+++ b/src/shared/reducers/accounts.js
@@ -226,6 +226,13 @@ const account = (
                 ...state,
                 ...updateAccountInfo(state, action.payload),
             };
+        case TransfersActionTypes.RETRY_FAILED_TRANSACTION_ERROR:
+            return action.payload
+                ? {
+                      ...state,
+                      ...updateAccountInfo(state, action.payload),
+                  }
+                : state;
         case AccountsActionTypes.FULL_ACCOUNT_INFO_FETCH_SUCCESS:
             return {
                 ...state,

--- a/src/shared/schemas/index.js
+++ b/src/shared/schemas/index.js
@@ -3,6 +3,7 @@ import v0Schema from './v0';
 import v1Schema, { migration as v1Migration } from './v1';
 import v2Schema, { migration as v2Migration } from './v2';
 import v3Schema, { migration as v3Migration } from './v3';
+import v4Schema, { migration as v4Migration } from './v4';
 import { __MOBILE__, __TEST__, __DEV__ } from '../config';
 
 const STORAGE_PATH =
@@ -47,6 +48,12 @@ export default [
         schemaVersion: 3,
         path: STORAGE_PATH,
         migration: v3Migration,
+    },
+    {
+        schema: v4Schema,
+        schemaVersion: 4,
+        path: STORAGE_PATH,
+        migration: v4Migration,
     },
 ];
 

--- a/src/shared/schemas/v4/index.js
+++ b/src/shared/schemas/v4/index.js
@@ -14,11 +14,11 @@ export default map(v3Schema, (schema) => {
         return merge({}, schema, {
             properties: {
                 /**
-                 * Total transaction autoretry attempts
+                 * Determines if tx had fatal error on retry
                  */
-                autoRetryAttempts: {
-                    type: 'int',
-                    default: 0,
+                fatalErrorOnRetry: {
+                    type: 'bool',
+                    default: false,
                 },
             },
         });

--- a/src/shared/schemas/v4/index.js
+++ b/src/shared/schemas/v4/index.js
@@ -1,0 +1,30 @@
+import merge from 'lodash/merge';
+import map from 'lodash/map';
+import v3Schema from '../v3';
+
+const migration = (_, newRealm) => {
+    const walletData = newRealm.objectForPrimaryKey('Wallet', 3);
+
+    // Bump wallet version.
+    walletData.version = 4;
+};
+
+export default map(v3Schema, (schema) => {
+    if (schema.name === 'Transaction') {
+        return merge({}, schema, {
+            properties: {
+                /**
+                 * (Optional) authentication token (username) for node
+                 */
+                autoRetryAttempts: {
+                    type: 'int',
+                    default: 0,
+                },
+            },
+        });
+    }
+
+    return schema;
+});
+
+export { migration };

--- a/src/shared/schemas/v4/index.js
+++ b/src/shared/schemas/v4/index.js
@@ -14,7 +14,7 @@ export default map(v3Schema, (schema) => {
         return merge({}, schema, {
             properties: {
                 /**
-                 * (Optional) authentication token (username) for node
+                 * Total transaction autoretry attempts
                  */
                 autoRetryAttempts: {
                     type: 'int',

--- a/src/shared/selectors/accounts.js
+++ b/src/shared/selectors/accounts.js
@@ -12,6 +12,7 @@ import { createSelector } from 'reselect';
 import { getSeedIndexFromState } from './global';
 import { accumulateBalance, getLatestAddress } from '../libs/iota/addresses';
 import { categoriseInclusionStatesByBundleHash, mapNormalisedTransactions } from '../libs/iota/transfers';
+import { MAX_AUTO_RETRY_ATTEMPTS } from '../config';
 
 /**
  *   Selects accounts prop from state.
@@ -397,7 +398,8 @@ export const getFailedBundleHashes = createSelector(
             (acc, info, accountName) => {
                 const failedTransactions = filter(
                     info.transactions,
-                    (transaction) => transaction.broadcasted === false,
+                    (transaction) =>
+                        transaction.broadcasted === false && transaction.autoRetryAttempts < MAX_AUTO_RETRY_ATTEMPTS,
                 );
 
                 each(failedTransactions, (transaction) => {

--- a/src/shared/selectors/accounts.js
+++ b/src/shared/selectors/accounts.js
@@ -12,7 +12,6 @@ import { createSelector } from 'reselect';
 import { getSeedIndexFromState } from './global';
 import { accumulateBalance, getLatestAddress } from '../libs/iota/addresses';
 import { categoriseInclusionStatesByBundleHash, mapNormalisedTransactions } from '../libs/iota/transfers';
-import { MAX_AUTO_RETRY_ATTEMPTS } from '../config';
 
 /**
  *   Selects accounts prop from state.
@@ -399,7 +398,7 @@ export const getFailedBundleHashes = createSelector(
                 const failedTransactions = filter(
                     info.transactions,
                     (transaction) =>
-                        transaction.broadcasted === false && transaction.autoRetryAttempts < MAX_AUTO_RETRY_ATTEMPTS,
+                        transaction.broadcasted === false && !transaction.fatalErrorOnRetry,
                 );
 
                 each(failedTransactions, (transaction) => {


### PR DESCRIPTION
# Description

- Marks transaction that face a fatal error on retry and blocks their future autoretry

Fixes #1640, #1538, #1386

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on iOS

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
