### PR TITLE
Fix promotion & reattachment alert issue

### DIFF
--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -373,7 +373,7 @@ export const forceTransactionPromotion = (
                 promotionAttempt < maxPromotionAttempts
             ) {
                 // Retry promotion on same reference (hash)
-                return promote(tailTransaction);
+                return promote(settings)(tailTransaction);
             } else if (
                 isTransactionInconsistent &&
                 promotionAttempt === maxPromotionAttempts &&
@@ -384,7 +384,7 @@ export const forceTransactionPromotion = (
                 promotionAttempt = 0;
 
                 // Reattach and try to promote with a newly reattached reference (hash)
-                return reattachAndPromote();
+                return reattachAndPromote(settings)();
             }
 
             throw error;
@@ -421,7 +421,7 @@ export const forceTransactionPromotion = (
             dispatch(updateAccountAfterReattachment(newState));
             const tailTransaction = find(reattachment, { currentIndex: 0 });
 
-            return promote(tailTransaction);
+            return promote(settings)(tailTransaction);
         });
     };
 


### PR DESCRIPTION
# Description

Fixes issue where function is displayed instead of tx hash while opening modals when promoting

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

-

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
