### PR TITLE
Shared: If enabled only sample remote pow nodes for autoswitching

### DIFF
--- a/src/shared/libs/iota/NodesManager.js
+++ b/src/shared/libs/iota/NodesManager.js
@@ -2,6 +2,7 @@ import includes from 'lodash/includes';
 import isArray from 'lodash/isArray';
 import isFunction from 'lodash/isFunction';
 import isUndefined from 'lodash/isUndefined';
+import unionBy from 'lodash/unionBy';
 import Errors from '../errors';
 import { getRandomNodes } from './utils';
 import { DEFAULT_RETRIES } from '../../config';
@@ -33,14 +34,11 @@ export default class NodesManager {
      */
     withRetries(failureCallbacks, retryAttempts = DEFAULT_RETRIES) {
         const { priorityNode, primaryNode, nodeAutoSwitch, nodes, quorum } = this.config;
-
         let attempt = 0;
         let executedCallback = false;
-
-        const randomNodes = getRandomNodes(nodes, retryAttempts, [primaryNode]);
-
-        const retryNodes = [priorityNode, ...randomNodes];
-
+        const remotePoW = store.getState().settings.remotePoW;
+        const randomNodes = getRandomNodes(nodes, retryAttempts, [primaryNode], remotePoW);
+        const retryNodes = unionBy(remotePoW === priorityNode.pow && [priorityNode], randomNodes, 'url');
         // Abort retries on these errors
         const cancellationErrors = [Errors.LEDGER_CANCELLED, Errors.CANNOT_TRANSITION_ADDRESSES_WITH_ZERO_BALANCE];
 

--- a/src/shared/libs/iota/utils.js
+++ b/src/shared/libs/iota/utils.js
@@ -8,6 +8,7 @@ import includes from 'lodash/includes';
 import isNull from 'lodash/isNull';
 import sampleSize from 'lodash/sampleSize';
 import size from 'lodash/size';
+import cloneDeep from 'lodash/cloneDeep';
 import URL from 'url-parse';
 import { BigNumber } from 'bignumber.js';
 import { iota } from './index';
@@ -459,7 +460,7 @@ export const fetchRemoteNodes = (
  * @returns {Array}
  */
 export const getRandomNodes = (nodes, size = 5, blacklistedNodes = [], PoW = false) => {
-    let nodesToSample = nodes;
+    let nodesToSample = cloneDeep(nodes);
     if (PoW) {
         nodesToSample = filter(nodes, (node) => node.pow === true);
     }

--- a/src/shared/libs/iota/utils.js
+++ b/src/shared/libs/iota/utils.js
@@ -454,11 +454,16 @@ export const fetchRemoteNodes = (
  * @param {array} nodes
  * @param {number} [size]
  * @param {array} [blacklistedNodes]
+ * @param {bool} Remote PoW
  *
  * @returns {Array}
  */
-export const getRandomNodes = (nodes, size = 5, blacklistedNodes = []) => {
-    return sampleSize(filter(nodes, (node) => !find(blacklistedNodes, { url: node.url })), size);
+export const getRandomNodes = (nodes, size = 5, blacklistedNodes = [], PoW = false) => {
+    let nodesToSample = nodes;
+    if (PoW) {
+        nodesToSample = filter(nodes, (node) => node.pow === true);
+    }
+    return sampleSize(filter(nodesToSample, (node) => !find(blacklistedNodes, { url: node.url })), size);
 };
 
 /**


### PR DESCRIPTION
# Description

- Only use nodes for autoswitching if remote PoW is enabled

# Type of Change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
