### PR TITLE
Add seed validation

### DIFF
--- a/src/mobile/android/app/src/main/java/org/iota/mobile/EntangledAndroid.java
+++ b/src/mobile/android/app/src/main/java/org/iota/mobile/EntangledAndroid.java
@@ -30,35 +30,43 @@ public class EntangledAndroid extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void generateAddress(ReadableArray seed, int index, int security, Promise promise) {
-        byte[] seedByteArr = readableArrayToByteArray(seed);
-        byte[] addressByteArr = Interface.iota_sign_address_gen_trits(seedByteArr, index, security);
-        WritableArray addressWritableArr = byteArrayToWritableArray(addressByteArr);
-        promise.resolve(addressWritableArr);
+        if (seed.size() == 243) {
+            byte[] seedByteArr = readableArrayToByteArray(seed);
+            byte[] addressByteArr = Interface.iota_sign_address_gen_trits(seedByteArr, index, security);
+            WritableArray addressWritableArr = byteArrayToWritableArray(addressByteArr);
+            promise.resolve(addressWritableArr);
+        } else {
+            promise.reject("Error: Address generation failed.");
+        }
     }
 
     @ReactMethod
     public void generateAddresses(final ReadableArray seed, final int index, final int security, final int total, final Promise promise) {
-        byte[] seedByteArr = readableArrayToByteArray(seed);
-        new GuardedResultAsyncTask<ReadableNativeArray>(mContext) {
-            @Override
-            protected ReadableNativeArray doInBackgroundGuarded() {
-                WritableNativeArray addresses = new WritableNativeArray();
-                int i = 0;
-                int addressIndex = index;
-                do {
-                    byte[] address = Interface.iota_sign_address_gen_trits(seedByteArr, addressIndex, security);
-                    addresses.pushArray(byteArrayToWritableArray(address));
-                    i++;
-                    addressIndex++;
-                } while (i < total);
-                return addresses;
-            }
+        if (seed.size() == 243) {
+            byte[] seedByteArr = readableArrayToByteArray(seed);
+            new GuardedResultAsyncTask<ReadableNativeArray>(mContext) {
+                @Override
+                protected ReadableNativeArray doInBackgroundGuarded() {
+                    WritableNativeArray addresses = new WritableNativeArray();
+                    int i = 0;
+                    int addressIndex = index;
+                    do {
+                        byte[] address = Interface.iota_sign_address_gen_trits(seedByteArr, addressIndex, security);
+                        addresses.pushArray(byteArrayToWritableArray(address));
+                        i++;
+                        addressIndex++;
+                    } while (i < total);
+                    return addresses;
+                }
 
-            @Override
-            protected void onPostExecuteGuarded(ReadableNativeArray result) {
-                promise.resolve(result);
-            }
-        }.execute();
+                @Override
+                protected void onPostExecuteGuarded(ReadableNativeArray result) {
+                    promise.resolve(result);
+                }
+            }.execute();
+        } else {
+            promise.reject("Error: Address generation failed.");
+        }
     }
 
     @ReactMethod

--- a/src/shared/libs/errors.js
+++ b/src/shared/libs/errors.js
@@ -59,4 +59,5 @@ export default {
     LEDGER_DENIED: 'Ledger transaction denied by user',
     LEDGER_INVALID_INDEX: 'Incorrect Ledger device or changed mnemonic',
     REQUEST_TIMED_OUT: 'Request timed out',
+    FOUND_INVALID_SEED_IN_KEYCHAIN: 'Found invalid seed in keychain',
 };


### PR DESCRIPTION
# Description

- Validate seed before address generation in SeedStore (mobile)
- Validate seed length before address generation in (iOS & android) Native Modules methods

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Manually tested iOS simulator iPhone 7 Plus

**Note: Not tested on android.**

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
