### PR TITLE
Desktop: Fix location reload on wallet reset

### DIFF
--- a/src/desktop/native/preload/Electron.js
+++ b/src/desktop/native/preload/Electron.js
@@ -309,6 +309,14 @@ const Electron = {
     },
 
     /**
+     * Reload Wallet window to initial location
+     * @returns {undefined}
+     */
+    reload: () => {
+        remote.getCurrentWindow().webContents.goToIndex(0);
+    },
+
+    /**
      * Focus main wallet window
      * @param {string} view - optional view to navigate to
      */

--- a/src/desktop/src/ui/Index.js
+++ b/src/desktop/src/ui/Index.js
@@ -321,7 +321,7 @@ class App extends React.Component {
                                 />
                                 <Route path="/wallet" component={Wallet} />
                                 <Route path="/onboarding" component={Onboarding} />
-                                <Route exact path="/index.html" loop={false} component={this.Init} />
+                                <Route loop={false} component={this.Init} />
                             </Switch>
                         </div>
                     </CSSTransition>

--- a/src/desktop/src/ui/views/settings/Advanced.js
+++ b/src/desktop/src/ui/views/settings/Advanced.js
@@ -45,10 +45,6 @@ class Advanced extends PureComponent {
         /** @ignore */
         setProxy: PropTypes.func.isRequired,
         /** @ignore */
-        history: PropTypes.shape({
-            push: PropTypes.func.isRequired,
-        }).isRequired,
-        /** @ignore */
         setNotifications: PropTypes.func.isRequired,
         /** @ignore */
         changePowSettings: PropTypes.func.isRequired,
@@ -102,17 +98,16 @@ class Advanced extends PureComponent {
      * @returns {undefined}
      */
     resetWallet = async () => {
-        const { t, generateAlert, history } = this.props;
+        const { t, generateAlert } = this.props;
 
         try {
-            history.push('/');
-
             await clearVault(ALIAS_REALM);
             localStorage.clear();
             Electron.clearStorage();
 
             await reinitialiseStorage(getEncryptionKey);
-            location.reload();
+
+            Electron.reload();
         } catch (_err) {
             generateAlert(
                 'error',


### PR DESCRIPTION
# Description

Wallet location was reloaded before data reset, thus resulting in an Authorisation error.

Fixes #1681 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes