### PR TITLE
Desktop: Auto update functionality updates

### DIFF
--- a/src/desktop/__tests__/ui/global/alerts.test.jsx
+++ b/src/desktop/__tests__/ui/global/alerts.test.jsx
@@ -18,6 +18,11 @@ const props = {
 
 global.Electron = {
     getOS: () => {},
+    onEvent: function(_event, e) {
+        this.updateEvent = e;
+    },
+    removeEvent: () => {},
+    updateEvent: null,
 };
 
 describe('Alerts component', () => {
@@ -60,5 +65,14 @@ describe('Alerts component', () => {
 
         expect(wrapper.find('.update')).toHaveLength(1);
         expect(wrapper.find('strong').text()).toEqual('global:shouldUpdate');
+    });
+
+    test('Hide update banner if update in progress', () => {
+        const mockProps = Object.assign({}, props, { forceUpdate: true, shouldUpdate: true });
+        const wrapper = shallow(<Alerts {...mockProps} />);
+
+        Electron.updateEvent({ percent: 99 });
+
+        expect(wrapper.find('.update')).toHaveLength(0);
     });
 });

--- a/src/desktop/native/libs/Menu.js
+++ b/src/desktop/native/libs/Menu.js
@@ -46,6 +46,7 @@ let language = {
     no: 'No',
     updates: {
         errorRetrievingUpdateData: 'Error retrieving update data',
+        errorRetrievingUpdateDataExplanation: 'Could not retrieve update. Please check your internet connection and try again.',
         noUpdatesAvailable: 'No updates available',
         noUpdatesAvailableExplanation: 'You have the latest version of Trinity!',
         newVersionAvailable: 'New version available',
@@ -70,7 +71,7 @@ autoUpdater.on('error', (error) => {
     }
     dialog.showErrorBox(
         language.updates.errorRetrievingUpdateData,
-        error === null ? 'unknown' : (error.stack || error).toString(),
+        language.updates.errorRetrievingUpdateDataExplanation,
     );
 });
 

--- a/src/desktop/native/libs/Menu.js
+++ b/src/desktop/native/libs/Menu.js
@@ -46,7 +46,8 @@ let language = {
     no: 'No',
     updates: {
         errorRetrievingUpdateData: 'Error retrieving update data',
-        errorRetrievingUpdateDataExplanation: 'Could not retrieve update. Please check your internet connection and try again.',
+        errorRetrievingUpdateDataExplanation:
+            'Could not retrieve update. Please check your internet connection and try again.',
         noUpdatesAvailable: 'No updates available',
         noUpdatesAvailableExplanation: 'You have the latest version of Trinity!',
         newVersionAvailable: 'New version available',
@@ -64,7 +65,7 @@ autoUpdater.autoDownload = false;
 /**
  * On update error event callback
  */
-autoUpdater.on('error', (error) => {
+autoUpdater.on('error', () => {
     const mainWindow = getWindow('main');
     if (mainWindow) {
         mainWindow.webContents.send('update.progress', false);

--- a/src/desktop/native/libs/Menu.js
+++ b/src/desktop/native/libs/Menu.js
@@ -120,12 +120,12 @@ autoUpdater.on('update-downloaded', () => {
             message: language.updates.installUpdateExplanation,
         },
         () => {
-            setImmediate(() => {
+            setTimeout(() => {
                 const mainWindow = getWindow('main');
                 mainWindow.removeAllListeners('close');
                 app.removeAllListeners('window-all-closed');
                 autoUpdater.quitAndInstall();
-            });
+            }, 0);
         },
     );
 });

--- a/src/desktop/native/preload/Electron.js
+++ b/src/desktop/native/preload/Electron.js
@@ -564,6 +564,7 @@ const Electron = {
             no: t('no'),
             updates: {
                 errorRetrievingUpdateData: t('updates:errorRetrievingUpdateData'),
+                errorRetrievingUpdateDataExplanation: t('updates:errorRetrievingUpdateDataExplanation'),
                 noUpdatesAvailable: t('updates:noUpdatesAvailable'),
                 noUpdatesAvailableExplanation: t('updates:noUpdatesAvailableExplanation'),
                 newVersionAvailable: t('updates:newVersionAvailable'),

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trinity-desktop",
   "productName": "Trinity",
-  "version": "0.5.2",
+  "version": "0.5.0",
   "url": "https://trinity.iota.org",
   "homepage": "https://trinity.iota.org",
   "description": "Desktop wallet for IOTA",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trinity-desktop",
   "productName": "Trinity",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "url": "https://trinity.iota.org",
   "homepage": "https://trinity.iota.org",
   "description": "Desktop wallet for IOTA",

--- a/src/desktop/src/ui/global/Alerts.js
+++ b/src/desktop/src/ui/global/Alerts.js
@@ -24,8 +24,6 @@ export class AlertsComponent extends React.PureComponent {
         /** @ignore */
         shouldUpdate: PropTypes.bool.isRequired,
         /** @ignore */
-        isUpdating: PropTypes.bool.isRequired,
-        /** @ignore */
         displayTestWarning: PropTypes.bool.isRequired,
         /** @ignore */
         t: PropTypes.func.isRequired,
@@ -33,15 +31,12 @@ export class AlertsComponent extends React.PureComponent {
 
     state = {
         dismissUpdate: false,
+        isUpdating: false,
     };
 
     componentDidMount() {
         this.onStatusChange = this.statusChange.bind(this);
         Electron.onEvent('update.progress', this.onStatusChange);
-    }
-
-    componentWillUnmount() {
-        Electron.removeEvent('update.progress', this.onStatusChange);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -55,11 +50,25 @@ export class AlertsComponent extends React.PureComponent {
         }
     }
 
+    componentWillUnmount() {
+        Electron.removeEvent('update.progress', this.onStatusChange);
+    }
+
     closeAlert() {
         if (this.timeout) {
             clearTimeout(this.timeout);
         }
         this.props.dismissAlert();
+    }
+
+    /**
+     * Update update in progress state
+     * @param {object} progress - Current update progress percent
+     */
+    statusChange(progress) {
+        this.setState({
+            isUpdating: typeof progress === 'object',
+        });
     }
 
     renderFullWidthAlert(title, explanation, dismissable, onClick) {
@@ -75,16 +84,6 @@ export class AlertsComponent extends React.PureComponent {
                 )}
             </section>
         );
-    }
-
-    /**
-     * Update update in progress state
-     * @param {object} progress - Current update progress percent
-     */
-    statusChange(progress) {
-        this.setState({
-            isUpdating: typeof progress === 'object',
-        });
     }
 
     render() {
@@ -104,12 +103,14 @@ export class AlertsComponent extends React.PureComponent {
                 {!dismissUpdate &&
                     displayTestWarning &&
                     this.renderFullWidthAlert(`${t('rootDetection:warning')}:`, t('global:testVersionWarning'), true)}
-                {!isUpdating && !dismissUpdate &&
+                {!isUpdating &&
+                    !dismissUpdate &&
                     shouldUpdate &&
                     this.renderFullWidthAlert(t('global:shouldUpdate'), t('global:shouldUpdateExplanation'), true, () =>
                         Electron.autoUpdate(),
                     )}
-                {!isUpdating && forceUpdate &&
+                {!isUpdating &&
+                    forceUpdate &&
                     this.renderFullWidthAlert(t('global:forceUpdate'), t('global:forceUpdateExplanation'), false, () =>
                         Electron.autoUpdate(),
                     )}

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -767,6 +767,7 @@
     },
     "updates": {
         "errorRetrievingUpdateData": "Error retrieving update data",
+        "errorRetrievingUpdateDataExplanation": "Could not retrieve update. Please check your internet connection and try again.",
         "noUpdatesAvailable": "No updates available",
         "noUpdatesAvailableExplanation": "You have the latest version of Trinity!",
         "newVersionAvailable": "New version available",


### PR DESCRIPTION
# Description

- Show a localised error message for failing updates
- Disable update header while update in progress
- Replace `setImmediate` to `setTimeout`

Fixes #1625, #1626, #1639 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
