### PR TITLE
Desktop: Fix Windows 7 does not save quorum state

### DIFF
--- a/src/desktop/native/libs/Realm.js
+++ b/src/desktop/native/libs/Realm.js
@@ -1,9 +1,15 @@
 /**
  * Realm database mock for Windows 7 compatibility
  */
+const handler = {
+    get: function(_target, name) {
+        return name;
+    },
+};
+
 class Realm {
     constructor() {}
-    objectForPrimaryKey = () => {};
+    objectForPrimaryKey = () => new Proxy({}, handler);
     schemaVersion = () => -1;
     objects = () => {};
     create = () => {};

--- a/src/desktop/webpack.config/config.main.js
+++ b/src/desktop/webpack.config/config.main.js
@@ -18,9 +18,6 @@ module.exports = {
     node: {
         __dirname: false,
     },
-    optimization: {
-        minimize: false,
-    },
     module: {
         rules: [
             {


### PR DESCRIPTION
# Description

Realm `updateQuorumConfig` was failing so the Quorum setting would never be saved. Realm `objectForPrimaryKey` is now mocked with a Proxy to always resolve when requested for an object.

Fixes #1678 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Windows 7

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
