### PR TITLE
fix: do not perform quorum when it's explicitly turned off

### DIFF
--- a/src/shared/selectors/global.js
+++ b/src/shared/selectors/global.js
@@ -1,5 +1,5 @@
 import assign from 'lodash/assign';
-import get from 'lodash/get';
+import has from 'lodash/has';
 import filter from 'lodash/filter';
 import { createSelector } from 'reselect';
 import Themes from '../themes/themes';
@@ -197,14 +197,19 @@ export const nodesConfigurationFactory = (overrides) =>
                 autoNodeList: state.autoNodeList,
             };
 
-            const quorumOverride = get(overrides, 'quorum');
-            const remoteNodesOverride = get(overrides, 'useOnlyPowNodes');
+            const shouldOverrideQuorumConfig = has(overrides, 'quorum');
+            const shouldUseOnlyPowNodes = has(overrides, 'useOnlyPowNodes');
 
-            if (quorumOverride) {
-                config.quorum = assign({}, config.quorum, { enabled: quorumOverride });
+            if (
+                shouldOverrideQuorumConfig &&
+                // Only allow quorum override if user has explicitly turned on quorum (or if it is turned off as default)
+                // If a user has disabled quorum, then no quorum should be executed at any place in the application
+                config.quorum.enabled === true
+            ) {
+                config.quorum = assign({}, config.quorum, { enabled: overrides.quorum });
             }
 
-            if (remoteNodesOverride) {
+            if (shouldUseOnlyPowNodes) {
                 config.nodes = filter(config.nodes, (node) => node.pow === true);
             }
 


### PR DESCRIPTION
# Description

We do not perform quorum in all areas of the application and therefore have used param variables for determining when and when not to perform quorum. With the node settings update (where we have allowed users to disable quorum completely), there existed an issue where the quorum was still happening despite deactivation.

This commit fixes the issue and ensures that on deactivation, quorum will not be performed in any area of the application.

Related issue: https://github.com/iotaledger/trinity-wallet/issues/1739

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Unit test coverage
- Manually tested iOS simulator (dev) mode

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
