### PR TITLE
Desktop/Windows: Fix issues with special characters in Realm path

### DIFF
--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "start": "concurrently --kill-others \"npm run devserver\" \"cross-env NODE_ENV=development electron -r @babel/register native/Index.js\"",
-    "postinstall": "patch-package && electron-builder install-app-deps",
+    "postinstall": "node scripts/win-realm-patch.js && patch-package && electron-builder install-app-deps",
     "devserver": "node scripts/webpackServer.js",
     "build": "rimraf dist && npm run build-main && npm run build-app",
     "build-main": "./node_modules/.bin/cross-env NODE_ENV=production webpack --env=production --config webpack.config/config.main.js",

--- a/src/desktop/realm-patch/realm+2.23.0.patch
+++ b/src/desktop/realm-patch/realm+2.23.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/realm/scripts/download-realm.js b/node_modules/realm/scripts/download-realm.js
+index 1208e73..1b11fdb 100644
+--- a/node_modules/realm/scripts/download-realm.js
++++ b/node_modules/realm/scripts/download-realm.js
+@@ -89,7 +89,7 @@ function printProgress(input, totalBytes, archive) {
+ }
+ 
+ function download(serverFolder, archive, destination) {
+-    const url = `https://static.realm.io/downloads/${serverFolder}/${archive}`;
++    const url = `https://trinity-realm-win-degif.iota-dev1.now.sh/realm-core-Release-v5.13.0-6-g34e041ac1-win64-devel.tar.gz`;
+     console.log(`Download url: ${url}`);
+     const proxyUrl = process.env.HTTP_PROXY || process.env.http_proxy || process.env.HTTPS_PROXY || process.env.https_proxy;
+     let agent;

--- a/src/desktop/scripts/win-realm-patch.js
+++ b/src/desktop/scripts/win-realm-patch.js
@@ -1,0 +1,17 @@
+const os = require('os');
+const { execSync } = require('child_process');
+const { resolve } = require('path');
+
+const applyRealmPatch = () => {
+    if (os.platform() === 'win32') {
+        execSync('npx patch-package --patch-dir realm-patch', {
+            cwd: resolve(__dirname, '..'),
+            stdio: 'inherit',
+        });
+    } else {
+        console.log('Windows env not detected'); // eslint-disable-line no-console
+        process.exit(0);
+    }
+};
+
+applyRealmPatch();


### PR DESCRIPTION
# Description

Patches `node_modules/realm/scripts/download-realm.js` on Windows so that a patched version (based on https://github.com/realm/realm-core/pull/3293) of `realm-core` is downloaded instead of the original one

Fixes #1594

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested locally on Windows 10 VM
- [x] Tested on CI

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes