### PR TITLE
Desktop/Windows: Use DigiCert timestamp server

### DIFF
--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -123,7 +123,8 @@
     },
     "win": {
       "publisherName": "IOTA Stiftung",
-      "target": "nsis"
+      "target": "nsis",
+      "timeStampServer": "http://timestamp.digicert.com"
     },
     "linux": {
       "target": [


### PR DESCRIPTION
# Description

Switches timestamp server from `http://timestamp.verisign.com/scripts/timstamp.dll` (default) to `http://timestamp.digicert.com`. The VeriSign timestamp server is currently down and DigiCert support told me in a chat that the server will be deprecated soon.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on CI (see [build log](https://buildkite.com/iota-foundation/trinity-desktop-internal-build/builds/12#6bb2812a-d182-4e37-a2a4-5d9514bc575e))


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code