### PR TITLE
fix: pass seedStore instance during auto promotion

### DIFF
--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -14,6 +14,7 @@ import {
     isSettingUpNewAccount,
     getPromotableBundlesFromState,
     getSelectedAccountName,
+    getSelectedAccountType,
     getFailedBundleHashes,
 } from 'selectors/accounts';
 import {
@@ -36,6 +37,8 @@ class Polling extends React.PureComponent {
         accountNames: PropTypes.array.isRequired,
         /** Name for selected account */
         selectedAccountName: PropTypes.string,
+        /** Type for selected account */
+        selectedAccountType: PropTypes.string.isRequired,
         /** @ignore */
         pollFor: PropTypes.string.isRequired,
         /** @ignore */
@@ -177,18 +180,14 @@ class Polling extends React.PureComponent {
 
             const seedStore = await new SeedStore[type](password, name);
 
-            this.props.retryFailedTransaction(
-                  name,
-                  bundleForRetry,
-                  seedStore,
-            );
+            this.props.retryFailedTransaction(name, bundleForRetry, seedStore);
         } else {
             this.moveToNextPollService();
         }
     };
 
-    promote = () => {
-        const { unconfirmedBundleTails, autoPromotion } = this.props;
+    promote = async () => {
+        const { unconfirmedBundleTails, autoPromotion, selectedAccountType, password } = this.props;
 
         const { autoPromoteSkips } = this.state;
 
@@ -203,7 +202,9 @@ class Polling extends React.PureComponent {
 
                 const { accountName } = unconfirmedBundleTails[bundleHashToPromote];
 
-                return this.props.promoteTransfer(bundleHashToPromote, accountName);
+                const seedStore = await new SeedStore[selectedAccountType](password, name);
+
+                return this.props.promoteTransfer(bundleHashToPromote, accountName, seedStore);
             }
         }
 
@@ -232,6 +233,7 @@ const mapStateToProps = (state) => ({
     accountNames: getAccountNamesFromState(state),
     unconfirmedBundleTails: getPromotableBundlesFromState(state),
     selectedAccountName: getSelectedAccountName(state),
+    selectedAccountType: getSelectedAccountType(state),
     isTransitioning: state.ui.isTransitioning,
     isRetryingFailedTransaction: state.ui.isRetryingFailedTransaction,
     failedBundleHashes: getFailedBundleHashes(state),

--- a/src/shared/actions/polling.js
+++ b/src/shared/actions/polling.js
@@ -458,6 +458,7 @@ export const getAccountInfoForAllAccounts = (accountNames, notificationFn, quoru
  *
  * @param {string} bundleHash
  * @param {string} accountName
+ * @param {object} seedStore
  * @param {boolean} [withQuorum]
  *
  * @returns {function} - dispatch


### PR DESCRIPTION
# Description

[SeedStore](https://github.com/iotaledger/trinity-wallet/blob/develop/src/mobile/src/libs/SeedStore/index.js) instance need to be passed to [attachToTangle](https://github.com/iotaledger/trinity-wallet/blob/develop/src/shared/libs/iota/extendedApi.js) method. However, it was missing for auto-promotion action. This PR fixes the issue by passing [SeedStore](https://github.com/iotaledger/trinity-wallet/blob/develop/src/mobile/src/libs/SeedStore/index.js) correctly.

(Possibly) Related https://github.com/iotaledger/trinity-wallet/issues/1788

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manually tested iOS simulator (debug)
- Manually tested desktop macOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
