### PR TITLE
Bump desktop release to `0.6.1`

### DIFF
--- a/src/shared/libs/versions.json
+++ b/src/shared/libs/versions.json
@@ -2,5 +2,5 @@
     "desktopBlacklist": ["0.3.4", "0.3.5", "0.3.6", "0.4.0", "0.4.1"],
     "mobileBlacklist": ["20", "21", "22", "25", "26", "27"],
     "latestMobile": "61",
-    "latestDesktop": "0.6.0"
+    "latestDesktop": "0.6.1"
 }


### PR DESCRIPTION
# Description

Bump desktop release to `0.6.1`

Related to #1797