### PR TITLE
Update redux schema before migration

### DIFF
--- a/src/desktop/src/index.js
+++ b/src/desktop/src/index.js
@@ -16,6 +16,7 @@ import { getEncryptionKey } from 'libs/realm';
 import { changeIotaNode, quorum } from 'libs/iota';
 import { bugsnagClient, ErrorBoundary } from 'libs/bugsnag';
 import { initialise as initialiseStorage, realm } from 'storage';
+import { updateSchema } from 'schemas';
 
 import Index from 'ui/Index';
 import Tray from 'ui/Tray';
@@ -69,7 +70,7 @@ const init = () => {
                 }
 
                 // Get persisted data from Realm storage if no old persisted data present
-                const data = hasDataToMigrate ? oldPersistedData : mapStorageToState();
+                const data = hasDataToMigrate ? updateSchema(oldPersistedData) : mapStorageToState();
 
                 // Change provider on global iota instance
                 const node = get(data, 'settings.node');

--- a/src/mobile/src/ui/routes/entry.js
+++ b/src/mobile/src/ui/routes/entry.js
@@ -30,6 +30,7 @@ import { getEncryptionKey } from 'libs/realm';
 import registerScreens from 'ui/routes/navigation';
 import { initialise as initialiseStorage } from 'shared-modules/storage';
 import { mapStorageToState } from 'shared-modules/libs/storageToStateMappers';
+import { updateSchema } from 'shared-modules/schemas';
 
 // Assign Realm to global RN variable
 global.Realm = Realm;
@@ -233,14 +234,16 @@ onAppStart()
                 // If a user has stored data in AsyncStorage then map that data to redux store.
                 return reduxStore.dispatch(
                     mapStorageToStateAction(
-                        merge({}, storedData, {
-                            settings: {
-                                versions: latestVersions,
-                                // completedMigration prop was added to keep track of AsyncStorage -> Realm migration
-                                // That is why it won't be present in storedData (Data directly fetched from AsyncStorage)
-                                completedMigration,
-                            },
-                        }),
+                        updateSchema(
+                            merge({}, storedData, {
+                                settings: {
+                                    versions: latestVersions,
+                                    // completedMigration prop was added to keep track of AsyncStorage -> Realm migration
+                                    // That is why it won't be present in storedData (Data directly fetched from AsyncStorage)
+                                    completedMigration,
+                                },
+                            }),
+                        ),
                     ),
                 );
             }

--- a/src/shared/schemas/index.js
+++ b/src/shared/schemas/index.js
@@ -6,6 +6,7 @@ import v3Schema, { migration as v3Migration } from './v3';
 import v4Schema, { migration as v4Migration } from './v4';
 import v5Schema, { migration as v5Migration } from './v5';
 import { __MOBILE__, __TEST__, __DEV__ } from '../config';
+import { initialState as reduxSettingsState } from '../reducers/settings';
 
 const STORAGE_PATH =
     __MOBILE__ || __TEST__
@@ -25,6 +26,30 @@ const getDeprecatedStoragePath = (schemaVersion) =>
     __MOBILE__ || __TEST__
         ? `trinity-${schemaVersion}.realm`
         : `${Electron.getUserDataPath()}/trinity${__DEV__ ? '-dev' : ''}-${schemaVersion}.realm`;
+
+/**
+ * Updates (redux) state object schema to current wallet version
+ *
+ * @method updateSchema
+ *
+ * @param {object} input - target state object
+ *
+ * @returns {object} - updated state object
+ */
+export const updateSchema = (input) => {
+    const state = Object.assign({}, input);
+
+    /**
+     * 0.6.0
+     */
+    if (typeof state.settings.quorum !== 'object') {
+        state.settings.quorum = Object.assign({}, reduxSettingsState.quorum);
+        state.settings.autoNodeList = reduxSettingsState.autoNodeList;
+        state.settings.nodeAutoSwitch = reduxSettingsState.nodeAutoSwitch;
+    }
+
+    return state;
+};
 
 export default [
     {


### PR DESCRIPTION
# Description

New properties added to redux should be manually assigned to old persisted data before migration.
 
Possibly fixes https://github.com/iotaledger/trinity-wallet/issues/1753 & https://github.com/iotaledger/trinity-wallet/issues/1752

Note that this change was already [done](https://github.com/iotaledger/trinity-wallet/blob/window-7/src/desktop/src/libs/updateSchema.js) in the [window-7](https://github.com/iotaledger/trinity-wallet/tree/window-7) branch. 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Tested by building iOS (debug)
- Tested by building desktop macOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
