### PR TITLE
Revert "Bump appcompat-v7 from 27.1.0 to 28.0.0 in /src/mobile/android"

### DIFF
--- a/src/mobile/android/app/build.gradle
+++ b/src/mobile/android/app/build.gradle
@@ -168,7 +168,7 @@ dependencies {
     implementation project(':react-native-svg')
     implementation project(':react-native-navigation')
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:appcompat-v7:27.1.0'
     implementation ('com.facebook.react:react-native:+')
     implementation project(':react-native-svg')
     implementation project(':react-native-keychain')


### PR DESCRIPTION
Reverts iotaledger/trinity-wallet#961

Resolves a warning about using support library version 28 when `compileSdkVersion` is 27