### PR TITLE
Shared: Prevent `Cannot read property message of undefined` in error catches

### DIFF
--- a/src/desktop/src/libs/SeedStore/Ledger.js
+++ b/src/desktop/src/libs/SeedStore/Ledger.js
@@ -149,7 +149,7 @@ class Ledger extends SeedStoreCore {
         } catch (err) {
             Electron.send('ledger', { awaitTransaction: false });
 
-            const error = err.message;
+            const error = typeof err.message === 'string' ? err.message : err;
 
             if (options === null) {
                 throw new Error(Errors.LEDGER_ZERO_VALUE);

--- a/src/desktop/src/ui/components/input/Seed.js
+++ b/src/desktop/src/ui/components/input/Seed.js
@@ -229,9 +229,9 @@ export class SeedComponent extends React.PureComponent {
 
             Electron.garbageCollect();
         } catch (error) {
-            if (error.code === 'InvalidKey') {
+            if (typeof error.code === 'string' && error.code === 'InvalidKey') {
                 generateAlert('error', t('seedVault:unrecognisedKey'), t('seedVault:unrecognisedKeyExplanation'));
-            } else if (error.message === 'SeedNotFound') {
+            } else if (typeof error.message === 'string' && error.message === 'SeedNotFound') {
                 generateAlert('error', t('seedVault:noSeedFound'), t('seedVault:noSeedFoundExplanation'));
             } else {
                 generateAlert(

--- a/src/desktop/src/ui/views/wallet/Receive.js
+++ b/src/desktop/src/ui/views/wallet/Receive.js
@@ -137,7 +137,7 @@ class Receive extends React.PureComponent {
         } catch (err) {
             this.props.addressValidationSuccess();
             history.push('/wallet/');
-            if (err.message === Errors.LEDGER_INVALID_INDEX) {
+            if (typeof err.message === 'string' && err.message === Errors.LEDGER_INVALID_INDEX) {
                 generateAlert(
                     'error',
                     t('ledger:ledgerIncorrectIndex'),
@@ -285,4 +285,7 @@ const mapDispatchToProps = {
     addressValidationSuccess,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(Receive));
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withTranslation()(Receive));

--- a/src/mobile/src/ui/components/SeedVaultImportComponent.js
+++ b/src/mobile/src/ui/components/SeedVaultImportComponent.js
@@ -197,7 +197,7 @@ export class SeedVaultImportComponent extends Component {
                 timer.setTimeout('delayDocumentPicker', () => this.showDocumentPicker(), 200);
             })
             .catch((err) => {
-                if (err.message === 'Read permissions not granted.') {
+                if (typeof err.message === 'string' && err.message === 'Read permissions not granted.') {
                     return this.props.generateAlert(
                         'error',
                         t('receive:missingPermission'),

--- a/src/mobile/src/ui/views/wallet/ForceChangePassword.js
+++ b/src/mobile/src/ui/views/wallet/ForceChangePassword.js
@@ -125,7 +125,7 @@ class ForceChangePassword extends Component {
 
         if (this.isNewPasswordValid()) {
             const throwError = (err) => {
-                if (err.message === 'Incorrect password') {
+                if (typeof err.message === 'string' && err.message === 'Incorrect password') {
                     this.props.generateAlert(
                         'error',
                         t('global:unrecognisedPassword'),
@@ -225,7 +225,10 @@ class ForceChangePassword extends Component {
     }
 
     render() {
-        const { t, theme: { body } } = this.props;
+        const {
+            t,
+            theme: { body },
+        } = this.props;
         const { currentPassword, newPassword, newPasswordReentry } = this.state;
         const textColor = { color: body.color };
         const score = zxcvbn(newPassword);
@@ -291,24 +294,22 @@ class ForceChangePassword extends Component {
                             <View style={{ flex: 0.2 }} />
                         </View>
                         <View style={styles.bottomContainer}>
-                            {currentPassword !== '' &&
-                                newPassword !== '' &&
-                                newPasswordReentry !== '' && (
-                                    <TouchableOpacity
-                                        onPress={() => this.onSavePress()}
-                                        hitSlop={{
-                                            top: height / 55,
-                                            bottom: height / 55,
-                                            left: width / 55,
-                                            right: width / 55,
-                                        }}
-                                    >
-                                        <View style={styles.itemRight}>
-                                            <Text style={[styles.titleTextRight, textColor]}>{t('global:save')}</Text>
-                                            <Icon name="tick" size={width / 28} color={body.color} />
-                                        </View>
-                                    </TouchableOpacity>
-                                )}
+                            {currentPassword !== '' && newPassword !== '' && newPasswordReentry !== '' && (
+                                <TouchableOpacity
+                                    onPress={() => this.onSavePress()}
+                                    hitSlop={{
+                                        top: height / 55,
+                                        bottom: height / 55,
+                                        left: width / 55,
+                                        right: width / 55,
+                                    }}
+                                >
+                                    <View style={styles.itemRight}>
+                                        <Text style={[styles.titleTextRight, textColor]}>{t('global:save')}</Text>
+                                        <Icon name="tick" size={width / 28} color={body.color} />
+                                    </View>
+                                </TouchableOpacity>
+                            )}
                         </View>
                         <View style={{ flex: 0.5 }} />
                     </View>
@@ -329,5 +330,8 @@ const mapDispatchToProps = {
 };
 
 export default withNamespaces(['changePassword', 'global'])(
-    connect(mapStateToProps, mapDispatchToProps)(ForceChangePassword),
+    connect(
+        mapStateToProps,
+        mapDispatchToProps,
+    )(ForceChangePassword),
 );

--- a/src/shared/actions/alerts.js
+++ b/src/shared/actions/alerts.js
@@ -169,7 +169,7 @@ export const generateNotEnoughSyncedNodes = (err) => (dispatch) => {
  * @returns {function} dispatch
  */
 export const generateTransitionErrorAlert = (err) => (dispatch) => {
-    if (err.message.includes(Errors.ATTACH_TO_TANGLE_UNAVAILABLE)) {
+    if (typeof err.message === 'string' && err.message.includes(Errors.ATTACH_TO_TANGLE_UNAVAILABLE)) {
         dispatch(
             generateAlert(
                 'error',
@@ -179,7 +179,10 @@ export const generateTransitionErrorAlert = (err) => (dispatch) => {
                 err,
             ),
         );
-    } else if (err.message.includes(Errors.CANNOT_TRANSITION_ADDRESSES_WITH_ZERO_BALANCE)) {
+    } else if (
+        typeof err.message === 'string' &&
+        err.message.includes(Errors.CANNOT_TRANSITION_ADDRESSES_WITH_ZERO_BALANCE)
+    ) {
         dispatch(
             generateAlert(
                 'error',

--- a/src/shared/actions/polling.js
+++ b/src/shared/actions/polling.js
@@ -544,7 +544,7 @@ export const promoteTransfer = (bundleHash, accountName, seedStore, quorum = tru
         })
         .then(() => dispatch(promoteTransactionSuccess()))
         .catch((err) => {
-            if (err.message.includes(Errors.ATTACH_TO_TANGLE_UNAVAILABLE)) {
+            if (typeof err.message === 'string' && err.message.includes(Errors.ATTACH_TO_TANGLE_UNAVAILABLE)) {
                 // FIXME: Temporary solution until local/remote PoW is reworked on auto-promotion
                 dispatch(
                     generateAlert(

--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -309,7 +309,7 @@ export const promoteTransaction = (bundleHash, accountName, seedStore, quorum = 
                         err,
                     ),
                 );
-            } else if (err.message.includes(Errors.ATTACH_TO_TANGLE_UNAVAILABLE)) {
+            } else if (get(err, 'message') === Errors.ATTACH_TO_TANGLE_UNAVAILABLE) {
                 dispatch(
                     generateAlert(
                         'error',

--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -1095,5 +1095,8 @@ export const isFatalTransactionError = (err) => {
         Errors.FUNDS_AT_SPENT_ADDRESSES,
         Errors.KEY_REUSE,
     ];
-    return some(fatalTransferErrors, (error) => err.message && err.message.includes(error));
+    return some(
+        fatalTransferErrors,
+        (error) => error === err || (typeof err.message === 'string' && err.message.includes(error)),
+    );
 };


### PR DESCRIPTION
# Description

Errors in error catches should be checked to be instance of `Error` or if it actually has a `message` key, otherwise the catch can fail with an error itself.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
