### PR TITLE
Shared: Fix bugs associated with quorum

### DIFF
--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -506,7 +506,7 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
                     // Progressbar step => (Syncing account)
                     dispatch(setNextStepAsActive());
 
-                    return syncAccount(settings, quorum)(accountState, seedStore);
+                    return syncAccount(settings, withQuorum)(accountState, seedStore);
                 });
             })
             .then((newState) => {

--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -41,7 +41,7 @@ import {
     syncAccountAfterReattachment,
     syncAccount,
     syncAccountAfterSpending,
-    syncAccountOnValueTransactionFailure,
+    syncAccountOnErrorAfterSigning,
     syncAccountOnSuccessfulRetryAttempt,
     syncAccountOnUnsuccessfulAutoRetryAttempt,
 } from '../libs/iota/accounts';
@@ -63,6 +63,7 @@ import {
     generateNodeOutOfSyncErrorAlert,
     generateUnsupportedNodeErrorAlert,
     generateTransactionSuccessAlert,
+    prepareLogUpdate,
 } from './alerts';
 import i18next from '../libs/i18next.js';
 import Errors from '../libs/errors';
@@ -472,6 +473,9 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
     // Keep track if the inputs are signed
     let hasSignedInputs = false;
 
+    // Keep track if the bundle was successfully broadcasted
+    let hasBroadcast = false;
+
     // Keep track if the created bundle is valid after inputs are signed
     let isValidBundle = false;
 
@@ -743,13 +747,24 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
                         ),
                 )(storeAndBroadcastAsync)(cached.trytes);
             })
-            .then(() =>
-                new NodesManager(
+            .then(() => {
+                hasBroadcast = true;
+                return new NodesManager(
                     nodesConfigurationFactory({
                         quorum,
                     })(getState()),
-                ).withRetries()(syncAccountAfterSpending)(seedStore, cached.transactionObjects, accountState),
-            )
+                )
+                    .withRetries()(syncAccountAfterSpending)(seedStore, cached.transactionObjects, accountState)
+                    .catch((error) => {
+                        dispatch(prepareLogUpdate(error));
+                        return syncAccountOnErrorAfterSigning(
+                            // Sort in ascending order
+                            orderBy(cached.transactionObjects, ['currentIndex']),
+                            accountState,
+                            hasBroadcast,
+                        );
+                    });
+            })
             .then((newState) => {
                 // Update account in (Realm) storage
                 Account.update(accountName, newState);
@@ -777,10 +792,11 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
                 // Only keep the failed trytes locally if the bundle was valid
                 // In case the bundle is invalid, discard the signing as it was never broadcast
                 if (hasSignedInputs && isValidBundle) {
-                    const newState = syncAccountOnValueTransactionFailure(
+                    const newState = syncAccountOnErrorAfterSigning(
                         // Sort in ascending order
                         orderBy(cached.transactionObjects, ['currentIndex']),
                         accountState,
+                        hasBroadcast,
                     );
 
                     // Update account in (Realm) storage

--- a/src/shared/libs/iota/accounts.js
+++ b/src/shared/libs/iota/accounts.js
@@ -210,7 +210,7 @@ export const syncAccountAfterSpending = (settings, withQuorum) => (seedStore, ne
     return (
         syncAddresses(settings, withQuorum)(seedStore, updatedAddressData, updatedTransactions)
             // Map latest address data (spend statuses & balances) to addresses
-            .then((latestAddressData) => mapLatestAddressData(settings)(latestAddressData, updatedTransactions))
+            .then((latestAddressData) => mapLatestAddressData(settings, withQuorum)(latestAddressData, updatedTransactions))
             .then((latestAddressData) => ({ addressData: latestAddressData, transactions: updatedTransactions }))
     );
 };

--- a/src/shared/libs/iota/accounts.js
+++ b/src/shared/libs/iota/accounts.js
@@ -253,7 +253,7 @@ export const syncAccountAfterReattachment = (reattachment, accountState) => ({
  *
  *   @returns {object}
  **/
-export const syncAccountOnErrorAfterSigning = (newTransactionObjects, accountState, hasBroadcast) => {
+export const syncAccountOnErrorAfterSigning = (newTransactionObjects, accountState, hasBroadcast = false) => {
     const failedTransactions = map(newTransactionObjects, (transaction) => ({
         ...transaction,
         persistence: false,

--- a/src/shared/libs/iota/accounts.js
+++ b/src/shared/libs/iota/accounts.js
@@ -210,7 +210,9 @@ export const syncAccountAfterSpending = (settings, withQuorum) => (seedStore, ne
     return (
         syncAddresses(settings, withQuorum)(seedStore, updatedAddressData, updatedTransactions)
             // Map latest address data (spend statuses & balances) to addresses
-            .then((latestAddressData) => mapLatestAddressData(settings, withQuorum)(latestAddressData, updatedTransactions))
+            .then((latestAddressData) =>
+                mapLatestAddressData(settings, withQuorum)(latestAddressData, updatedTransactions),
+            )
             .then((latestAddressData) => ({ addressData: latestAddressData, transactions: updatedTransactions }))
     );
 };
@@ -242,19 +244,20 @@ export const syncAccountAfterReattachment = (reattachment, accountState) => ({
 });
 
 /**
- *  Sync local account in case signed inputs were exposed to the network (and the network call failed)
+ *  Sync local account in case signed inputs were exposed to the network (and a network call failed)
  *
- *   @method syncAccountOnValueTransactionFailure
+ *   @method syncAccountOnErrorAfterSigning
  *   @param {array} newTransactionObjects
  *   @param {object} accountState
+ *   @param {boolean} hasBroadcast
  *
  *   @returns {object}
  **/
-export const syncAccountOnValueTransactionFailure = (newTransactionObjects, accountState) => {
+export const syncAccountOnErrorAfterSigning = (newTransactionObjects, accountState, hasBroadcast) => {
     const failedTransactions = map(newTransactionObjects, (transaction) => ({
         ...transaction,
         persistence: false,
-        broadcasted: false,
+        broadcasted: hasBroadcast,
         fatalErrorOnRetry: false,
     }));
     const addressData = markAddressesAsSpentSync([failedTransactions], accountState.addressData);


### PR DESCRIPTION
# Description

- Ensures quorum is not performed when explicitly turned off during send
- Correctly sync account if there is an error after broadcast
- Fixes associated incorrect `alreadySpentFrom` error message

Fixes #1538
Fixes #1386

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
