### PR TITLE
Desktop: Prepare 0.6.2 release

### DIFF
--- a/src/desktop/npm-shrinkwrap.json
+++ b/src/desktop/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "trinity-desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trinity-desktop",
   "productName": "Trinity",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "url": "https://trinity.iota.org",
   "homepage": "https://trinity.iota.org",
   "description": "Desktop wallet for IOTA",

--- a/src/desktop/src/ui/global/About.js
+++ b/src/desktop/src/ui/global/About.js
@@ -59,6 +59,17 @@ export class AboutComponent extends React.PureComponent {
 
                     <article>
                         <Scrollbar>
+                            <h5>0.6.2</h5>
+                            <ul>
+                                <li>Fix: Migration not successful when migrating from 0.4x and below to latest</li>
+                                <li>Fix: Incorrect already spent from address errors on transaction retry</li>
+                                <li>Fix: Incorrect transaction failure alert when successfully broadcast</li>
+                                <li>Fix: Quorum being conducted on transaction account syncs when explicitly turned off</li>
+                                <li>Fix: Error-related crashes</li>
+                                <li>Fix: Handle exception if password salt is missing from keychain</li>
+                                <li>Update: Add remote node list endpoint back-ups</li>
+                                <li>Update: New translations</li>
+                            </ul>
                             <h5>0.6.1</h5>
                             <ul>
                                 <li>Fix: Autopromotion not working as intended</li>

--- a/src/desktop/src/ui/global/About.js
+++ b/src/desktop/src/ui/global/About.js
@@ -61,7 +61,7 @@ export class AboutComponent extends React.PureComponent {
                         <Scrollbar>
                             <h5>0.6.2</h5>
                             <ul>
-                                <li>Fix: Migration not successful when migrating from 0.4x and below to latest</li>
+                                <li>Fix: Migration not successful when migrating from 0.4.x and below to latest</li>
                                 <li>Fix: Incorrect already spent from address errors on transaction retry</li>
                                 <li>Fix: Incorrect transaction failure alert when successfully broadcast</li>
                                 <li>Fix: Quorum being conducted on transaction account syncs when explicitly turned off</li>

--- a/src/desktop/src/ui/global/About.js
+++ b/src/desktop/src/ui/global/About.js
@@ -66,7 +66,6 @@ export class AboutComponent extends React.PureComponent {
                                 <li>Fix: Incorrect transaction failure alert when successfully broadcast</li>
                                 <li>Fix: Quorum being conducted on transaction account syncs when explicitly turned off</li>
                                 <li>Fix: Error-related crashes</li>
-                                <li>Fix: Handle exception if password salt is missing from keychain</li>
                                 <li>Update: Add remote node list endpoint back-ups</li>
                                 <li>Update: Add more verbose error log messages</li>
                                 <li>Update: New translations</li>

--- a/src/desktop/src/ui/global/About.js
+++ b/src/desktop/src/ui/global/About.js
@@ -68,6 +68,7 @@ export class AboutComponent extends React.PureComponent {
                                 <li>Fix: Error-related crashes</li>
                                 <li>Fix: Handle exception if password salt is missing from keychain</li>
                                 <li>Update: Add remote node list endpoint back-ups</li>
+                                <li>Update: Add more verbose error log messages</li>
                                 <li>Update: New translations</li>
                             </ul>
                             <h5>0.6.1</h5>


### PR DESCRIPTION
Fix: Migration not successful when migrating from 0.4.x and below to latest (#1832)
Fix: Incorrect already spent from address errors on transaction retry (#1835)
Fix: Incorrect transaction failure alert when successfully broadcast (#1835)
Fix: Quorum being conducted on transaction account syncs when explicitly turned off (#1835)
Fix: Error-related crashes (#1833)
Update: Add remote node list endpoint back-ups (#1811)
Update: Add more verbose error log messages (#1834)
Update: New translations (#1826)

Closes #1538, #1386, #1815, #1422