### PR TITLE
Desktop: Do not allow tab when password fields are disabled

### DIFF
--- a/src/desktop/src/ui/components/input/Password.js
+++ b/src/desktop/src/ui/components/input/Password.js
@@ -97,6 +97,7 @@ export class PasswordComponent extends React.PureComponent {
                         <Icon icon="eye" size={16} />
                     </a>
                     <input
+                        {...disabled && { tabIndex: '-1' }}
                         type={hidden ? 'password' : 'text'}
                         ref={(input) => {
                             this.input = input;


### PR DESCRIPTION
# Description

Fixes https://github.com/iotaledger/trinity-wallet/issues/1847

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manually tested macOS desktop (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
