### PR TITLE
Allow state export from desktop

### DIFF
--- a/src/desktop/native/preload/Electron.js
+++ b/src/desktop/native/preload/Electron.js
@@ -10,6 +10,7 @@ import machineUuid from 'machine-uuid-sync';
 import { byteToTrit, byteToChar } from 'libs/iota/converter';
 import { removeNonAlphaNumeric } from 'libs/utils';
 import { moment } from 'libs/exports';
+import Errors from 'libs/errors';
 
 import kdbx from '../libs/kdbx';
 import Entangled from '../libs/Entangled';
@@ -462,6 +463,30 @@ const Electron = {
         } catch (error) {
             return error.message;
         }
+    },
+
+    /**
+     * Exports wallet's state
+     *
+     * @param {string} - Serialized wallet state
+     *
+     * @returns {Promise}
+     */
+    exportState: (content) => {
+        const prefix = 'Trinity';
+
+        const path = remote.dialog.showSaveDialog(remote.getCurrentWindow(), {
+            title: 'Export state',
+            defaultPath: `${prefix}-${moment().format('YYYYMMDD-HHmm')}.txt`,
+            buttonLabel: 'Export',
+            filters: [{ name: 'State Export File', extensions: ['txt'] }],
+        });
+
+        if (!path) {
+            return Promise.reject(new Error(Errors.EXPORT_CANCELLED));
+        }
+
+        return new Promise((resolve, reject) => fs.writeFile(path, content, (err) => (err ? reject(err) : resolve())));
     },
 
     /**

--- a/src/desktop/src/ui/views/settings/Advanced.js
+++ b/src/desktop/src/ui/views/settings/Advanced.js
@@ -1,4 +1,5 @@
 /* global Electron */
+import pick from 'lodash/pick';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation, Trans } from 'react-i18next';
@@ -6,6 +7,9 @@ import { connect } from 'react-redux';
 
 import { clearVault } from 'libs/crypto';
 import { getEncryptionKey, ALIAS_REALM } from 'libs/realm';
+import { serialise } from 'libs/utils';
+import { iota, quorum } from 'libs/iota';
+import Errors from 'libs/errors';
 
 import {
     changePowSettings,
@@ -40,6 +44,10 @@ class Advanced extends PureComponent {
         settings: PropTypes.object.isRequired,
         /** @ignore */
         wallet: PropTypes.object,
+        /** @ignore */
+        accounts: PropTypes.object.isRequired,
+        /** @ignore */
+        notificationLog: PropTypes.array.isRequired,
         /** @ignore */
         setTray: PropTypes.func.isRequired,
         /** @ignore */
@@ -144,6 +152,52 @@ class Advanced extends PureComponent {
                 });
             }, 1000);
         }
+    };
+
+    /**
+     * Exports wallet's state
+     *
+     * @method exportState
+     *
+     * @returns {void}
+     */
+    exportState = () => {
+        const { accounts, settings, notificationLog, t } = this.props;
+
+        const content = serialise(
+            {
+                notificationLog,
+                settings,
+                accounts: pick(accounts, ['onboardingComplete', 'accountInfo']),
+                __globals__: {
+                    quorumNodes: quorum.nodes,
+                    quorumSize: quorum.size,
+                    iotaNode: iota.provider,
+                },
+            },
+            null,
+            4,
+        );
+
+        Electron.exportState(content)
+            .then(() => {
+                this.props.generateAlert(
+                    'success',
+                    t('stateExport:exportSuccess'),
+                    t('stateExport:exportSuccessExplanation'),
+                );
+            })
+            .catch((error) => {
+                if (error.message !== Errors.EXPORT_CANCELLED) {
+                    this.props.generateAlert(
+                        'error',
+                        t('global:somethingWentWrong'),
+                        t('global:somethingWentWrongTryAgain'),
+                        10000,
+                        error,
+                    );
+                }
+            });
     };
 
     render() {
@@ -262,6 +316,17 @@ class Advanced extends PureComponent {
                             <hr />
                         </React.Fragment>
 
+                        <React.Fragment>
+                            <h3>{t('advancedSettings:stateExport')}</h3>
+                            <p>
+                                <React.Fragment>{t('stateExport:stateExportExplanation')}</React.Fragment>
+                            </p>
+                            <Button className="small" onClick={this.exportState} variant="positive">
+                                {t('global:export')}
+                            </Button>
+                            <hr />
+                        </React.Fragment>
+
                         <h3>{t('settings:reset')}</h3>
                         <Trans i18nKey="walletResetConfirmation:warning">
                             <p>
@@ -330,6 +395,8 @@ class Advanced extends PureComponent {
 }
 
 const mapStateToProps = (state) => ({
+    accounts: state.accounts,
+    notificationLog: state.alerts.notificationLog,
     settings: state.settings,
     wallet: state.wallet,
     lockScreenTimeout: state.settings.lockScreenTimeout,
@@ -346,4 +413,7 @@ const mapDispatchToProps = {
     setProxy,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(Advanced));
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(withTranslation()(Advanced));

--- a/src/shared/libs/errors.js
+++ b/src/shared/libs/errors.js
@@ -65,4 +65,5 @@ export default {
     REQUEST_TIMED_OUT: 'The node took too long to respond.',
     FOUND_INVALID_SEED_IN_KEYCHAIN: 'Found an invalid seed in the keychain.',
     MISSING_FROM_KEYCHAIN: (alias) => `Missing ${alias} from keychain.`,
+    EXPORT_CANCELLED: 'Export cancelled',
 };


### PR DESCRIPTION
# Description

This PR allows users to export state from desktop wallet. 

Related https://github.com/iotaledger/trinity-wallet/pull/1341

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

- Manually tested Desktop macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
