### PR TITLE
fix: update local state quorum size to match default quorum size

### DIFF
--- a/src/mobile/src/ui/views/wallet/NodeSettings.js
+++ b/src/mobile/src/ui/views/wallet/NodeSettings.js
@@ -28,7 +28,7 @@ const defaultState = {
     autoNodeList: true,
     nodeAutoSwitch: true,
     quorumEnabled: true,
-    quorumSize: '4',
+    quorumSize: QUORUM_SIZE.toString(),
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
# Description

Default quorum size was [reduced](https://github.com/iotaledger/trinity-wallet/pull/1303/commits/5d7b7a87d00fa87368fce413ed13a0dd54559f1c) but the local state was still using `4` as the default quorum size. 

This PR fixes the issue by matching local state quorum size with the default one.

Fixes # (issue)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
