### PR TITLE
Desktop: Fix password change with Ledger accounts only

### DIFF
--- a/src/desktop/src/ui/views/settings/Password.js
+++ b/src/desktop/src/ui/views/settings/Password.js
@@ -72,6 +72,10 @@ class PasswordSettings extends PureComponent {
                 .map((accountName) => (accounts[accountName].meta ? accounts[accountName].meta.type : 'keychain'))
                 .filter((accountType, index, accountTypes) => accountTypes.indexOf(accountType) === index);
 
+            if (accountTypes.indexOf('keychain') < 0) {
+                accountTypes.push('keychain');
+            }
+
             for (let i = 0; i < accountTypes.length; i++) {
                 await SeedStore[accountTypes[i]].updatePassword(passwordCurrentHash, passwordNewHash);
             }


### PR DESCRIPTION
# Description

Password change loops through all account types present on the wallet, but type `keychain` could be missing (e.g. only Ledger accounts are added), thus main keychain password is not changed.

Fixes #685 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes