### PR TITLE
Desktop: Update min/max functionality on type `Number` inputs

### DIFF
--- a/src/desktop/__tests__/ui/components/input/number.test.jsx
+++ b/src/desktop/__tests__/ui/components/input/number.test.jsx
@@ -25,8 +25,22 @@ describe('TeNumberxt component', () => {
     test('Input change callback', () => {
         const wrapper = shallow(<Number {...props} />);
 
-        wrapper.find('input').simulate('change', { target: { value: '30' } });
-        expect(props.onChange).toHaveBeenLastCalledWith(30);
+        wrapper.find('input').simulate('change', { target: { value: '999999' } });
+        expect(props.onChange).toHaveBeenLastCalledWith(999999);
+    });
+
+    test('Input min value callback', () => {
+        const wrapper = shallow(<Number min={10} {...props} />);
+
+        wrapper.find('input').simulate('change', { target: { value: '5' } });
+        expect(props.onChange).toHaveBeenLastCalledWith(10);
+    });
+
+    test('Input max value callback', () => {
+        const wrapper = shallow(<Number max={10} {...props} />);
+
+        wrapper.find('input').simulate('change', { target: { value: '15' } });
+        expect(props.onChange).toHaveBeenLastCalledWith(10);
     });
 
     test('Input label', () => {

--- a/src/desktop/src/ui/components/input/Number.js
+++ b/src/desktop/src/ui/components/input/Number.js
@@ -43,6 +43,20 @@ export default class Number extends React.PureComponent {
         }
     }
 
+    onInput(value) {
+        const { min, max, onChange } = this.props;
+
+        if (typeof min === 'number') {
+            value = Math.max(value, min);
+        }
+
+        if (typeof max === 'number') {
+            value = Math.min(value, max);
+        }
+
+        onChange(value);
+    }
+
     render() {
         const { disabled, label, inline, value, onChange, max, min } = this.props;
 
@@ -51,7 +65,7 @@ export default class Number extends React.PureComponent {
                 <fieldset>
                     <div>
                         <small>{label}</small>
-                        <span onClick={() => onChange(Math.max(min || 0, value - 1))}>
+                        <span onClick={() => this.onInput(value - 1)}>
                             <Icon icon="chevronLeft" size={inline ? 9 : 12} />
                         </span>
                         <input
@@ -61,11 +75,9 @@ export default class Number extends React.PureComponent {
                             type="number"
                             value={value}
                             min="0"
-                            onChange={(e) =>
-                                onChange(Math.max(min || 0, Math.min(parseInt(e.target.value), max || 999)))
-                            }
+                            onChange={(e) => this.onInput(parseInt(e.target.value))}
                         />
-                        <span onClick={() => onChange(Math.min(value + 1, max || 999))}>
+                        <span onClick={() => this.onInput(value + 1)}>
                             <Icon icon="chevronRight" size={inline ? 9 : 12} />
                         </span>
                     </div>

--- a/src/desktop/src/ui/components/input/Number.js
+++ b/src/desktop/src/ui/components/input/Number.js
@@ -43,22 +43,26 @@ export default class Number extends React.PureComponent {
         }
     }
 
-    onInput(value) {
-        const { min, max, onChange } = this.props;
+    onInput(input) {
+        const { min, max, onChange, value } = this.props;
+
+        if (isNaN(input)) {
+            input = value;
+        }
 
         if (typeof min === 'number') {
-            value = Math.max(value, min);
+            input = Math.max(input, min);
         }
 
         if (typeof max === 'number') {
-            value = Math.min(value, max);
+            input = Math.min(input, max);
         }
 
-        onChange(value);
+        onChange(input);
     }
 
     render() {
-        const { disabled, label, inline, value, onChange, max, min } = this.props;
+        const { disabled, label, inline, value } = this.props;
 
         return (
             <div className={classNames(css.input, css.number, inline && css.inline, disabled && css.disabled)}>

--- a/src/desktop/src/ui/views/onboarding/seedStore/Ledger.js
+++ b/src/desktop/src/ui/views/onboarding/seedStore/Ledger.js
@@ -183,6 +183,7 @@ class Ledger extends React.PureComponent {
                         <Number
                             value={index}
                             focus
+                            min={0}
                             label={advancedMode ? t('ledger:accountIndex') : null}
                             onChange={(value) => this.updateIndex(value)}
                         />
@@ -190,6 +191,7 @@ class Ledger extends React.PureComponent {
                             <Number
                                 value={page}
                                 focus
+                                min={0}
                                 label={t('ledger:accountPage')}
                                 onChange={(value) => this.setState({ page: value })}
                             />


### PR DESCRIPTION
# Description

Type `Number` input was limited to `999` even if `max` prop is not defined.

Fixes #1875

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested manually on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes