### PR TITLE
Shared: Fix old storage data schema update

### DIFF
--- a/src/shared/schemas/index.js
+++ b/src/shared/schemas/index.js
@@ -78,12 +78,15 @@ export const updateSchema = (input) => {
         }
     });
 
-    const convertToNodeObject = (url) => ({
-        url,
-        pow: false,
-        token: '',
-        password: '',
-    });
+    const convertToNodeObject = (url) =>
+        typeof url === 'object'
+            ? url
+            : {
+                  url,
+                  pow: false,
+                  token: '',
+                  password: '',
+              };
 
     // Types of state.settings.node, state.settings.nodes and state.settings.customNodes are changed in the latest redux schema
     // Previously, they were stored as strings e.g., state.settings.node: <string>, state.settings.node: <string>[]


### PR DESCRIPTION
# Description

At `updateSchema` – in case of old storage data don't include `settings.nodes` key, default nodes with new structure are added first and then each `settings.nodes[]` item is converted again. In result, `settings.nodes[].url` contains the node object itself and not a string.

Fixes #1876

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Windows 7

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
