### PR TITLE
Desktop: Hide Retry button in macOS tray application

### DIFF
--- a/src/desktop/src/ui/components/list.scss
+++ b/src/desktop/src/ui/components/list.scss
@@ -518,5 +518,9 @@
             margin-bottom: 10px;
             min-width: 120px;
         }
+
+        @media (max-width: 320px) {
+            display: none;
+        }
     }
 }


### PR DESCRIPTION
# Description

Tray application is read-only currently and does not provide any functionality, including Retrying transactions, so the `Retry` button should be hidden. 

Fixes #1856 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
