### PR TITLE
Desktop: Fix cannot login when node auto-switching disabled

### DIFF
--- a/src/shared/schemas/index.js
+++ b/src/shared/schemas/index.js
@@ -78,15 +78,24 @@ export const updateSchema = (input) => {
         }
     });
 
-    const convertToNodeObject = (url) =>
-        typeof url === 'object'
-            ? url
-            : {
-                  url,
-                  pow: false,
-                  token: '',
-                  password: '',
-              };
+    const convertToNodeObject = (node) => {
+        /**
+         * Windows 7 release <= 1.0.0 was converting nodes  that are already converted which resulted in node.url containing the node object itself, this hotfix check reverses that
+         */
+        if (typeof node === 'object') {
+            if (typeof node.url === 'object') {
+                return node.url;
+            }
+            return node;
+        }
+
+        return {
+            url: node,
+            pow: false,
+            token: '',
+            password: '',
+        };
+    };
 
     // Types of state.settings.node, state.settings.nodes and state.settings.customNodes are changed in the latest redux schema
     // Previously, they were stored as strings e.g., state.settings.node: <string>, state.settings.node: <string>[]


### PR DESCRIPTION
# Description

 Windows 7 release <= 1.0.0 on state initial load  was converting state `settings.nodes` object  that was already converted which resulted in `node.url` containing the node object itself.  This fix reverts that change.


Fixes #1914 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Windows 7

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
