### PR TITLE
Shared: Add localisation of balance and comma separators

### DIFF
--- a/src/desktop/src/ui/components/Balance.js
+++ b/src/desktop/src/ui/components/Balance.js
@@ -96,7 +96,7 @@ export class BalanceComponent extends React.PureComponent {
                     {formatIotas(accountBalance, balanceIsShort)}
                     <small>{`${formatUnit(accountBalance)}`}</small>
                 </h1>
-                <h2>{new Intl.NumberFormat(settings.locale, { style: 'currency', currency: settings.currency }).format(fiatBalance)}{' '}</h2>
+                <h2>{new Intl.NumberFormat(settings.locale, { style: 'currency', currency: settings.currency }).format(fiatBalance)}</h2>
             </div>
         );
     }

--- a/src/desktop/src/ui/components/Balance.js
+++ b/src/desktop/src/ui/components/Balance.js
@@ -7,7 +7,7 @@ import { getAccountNamesFromState } from 'selectors/accounts';
 
 import { accumulateBalance } from 'libs/iota/addresses';
 import { formatUnit, formatIotas } from 'libs/iota/utils';
-import { formatMonetaryValue } from 'libs/currency';
+import { getFiatBalance } from 'libs/currency';
 
 import Icon from 'ui/components/Icon';
 
@@ -77,12 +77,7 @@ export class BalanceComponent extends React.PureComponent {
 
         const accountBalance = accumulateBalance(balances);
 
-        const fiatBalance = formatMonetaryValue(
-            accountBalance,
-            marketData.usdPrice * settings.conversionRate,
-            settings.currency,
-        );
-
+        const fiatBalance = getFiatBalance(accountBalance, marketData.usdPrice, settings.conversionRate);
         return (
             <div className={css.balance}>
                 <h3>{accountName}</h3>
@@ -101,7 +96,7 @@ export class BalanceComponent extends React.PureComponent {
                     {formatIotas(accountBalance, balanceIsShort)}
                     <small>{`${formatUnit(accountBalance)}`}</small>
                 </h1>
-                <h2>{fiatBalance}</h2>
+                <h2>{new Intl.NumberFormat(settings.locale, { style: 'currency', currency: settings.currency }).format(fiatBalance)}{' '}</h2>
             </div>
         );
     }

--- a/src/mobile/src/ui/views/wallet/Balance.js
+++ b/src/mobile/src/ui/views/wallet/Balance.js
@@ -18,12 +18,13 @@ import { round, roundDown } from 'shared-modules/libs/utils';
 import { computeStatusText, formatRelevantRecentTransactions } from 'shared-modules/libs/iota/transfers';
 import { setAnimateChartOnMount } from 'shared-modules/actions/ui';
 import { formatValue, formatUnit } from 'shared-modules/libs/iota/utils';
+import { getFiatBalance } from 'shared-modules/libs/currency';
 import {
     getTransactionsForSelectedAccount,
     getBalanceForSelectedAccount,
     getAddressesForSelectedAccount,
 } from 'shared-modules/selectors/accounts';
-import { getCurrencySymbol } from 'shared-modules/libs/currency';
+import { getLocaleFromLabel } from 'shared-modules/libs/i18n';
 import { getThemeFromState } from 'shared-modules/selectors/global';
 import WithManualRefresh from 'ui/components/ManualRefresh';
 import SimpleTransactionRow from 'ui/components/SimpleTransactionRow';
@@ -126,6 +127,8 @@ export class Balance extends Component {
         setAnimateChartOnMount: PropTypes.func.isRequired,
         /** @ignore */
         animateChartOnMount: PropTypes.bool.isRequired,
+        /** @ignore */
+        language: PropTypes.string.isRequired,
     };
 
     /**
@@ -236,14 +239,13 @@ export class Balance extends Component {
     }
 
     render() {
-        const { balance, conversionRate, currency, usdPrice, theme, isRefreshing, animateChartOnMount } = this.props;
+        const { balance, conversionRate, currency, usdPrice, theme, isRefreshing, animateChartOnMount, language } = this.props;
         const { body, primary } = theme;
 
         const shortenedBalance =
             roundDown(formatValue(balance), 1) +
             (balance < 1000 || Balance.getDecimalPlaces(formatValue(balance)) <= 1 ? '' : '+');
-        const currencySymbol = getCurrencySymbol(currency);
-        const fiatBalance = balance * usdPrice / 1000000 * conversionRate;
+        const fiatBalance = getFiatBalance(balance, usdPrice, conversionRate);
         const textColor = { color: body.color };
         const recentTransactions = this.renderTransactions();
         const iotaBalance = this.state.balanceIsShort ? shortenedBalance : formatValue(balance);
@@ -275,7 +277,7 @@ export class Balance extends Component {
                                     <Text style={[styles.iotaUnit, textColor]}>{iotaUnit}</Text>
                                 </View>
                                 <Text style={[styles.fiatBalance, textColor]}>
-                                    {currencySymbol} {round(fiatBalance, 2).toFixed(2)}{' '}
+                                    {new Intl.NumberFormat(getLocaleFromLabel(language), { style: 'currency', currency }).format(fiatBalance)}{' '}
                                 </Text>
                             </View>
                         </TouchableWithoutFeedback>
@@ -304,6 +306,7 @@ const mapStateToProps = (state) => ({
     conversionRate: state.settings.conversionRate,
     theme: getThemeFromState(state),
     animateChartOnMount: state.ui.animateChartOnMount,
+    language: state.settings.language,
 });
 
 const mapDispatchToProps = {

--- a/src/mobile/src/ui/views/wallet/Balance.js
+++ b/src/mobile/src/ui/views/wallet/Balance.js
@@ -277,7 +277,7 @@ export class Balance extends Component {
                                     <Text style={[styles.iotaUnit, textColor]}>{iotaUnit}</Text>
                                 </View>
                                 <Text style={[styles.fiatBalance, textColor]}>
-                                    {new Intl.NumberFormat(getLocaleFromLabel(language), { style: 'currency', currency }).format(fiatBalance)}{' '}
+                                    {new Intl.NumberFormat(getLocaleFromLabel(language), { style: 'currency', currency }).format(fiatBalance)}
                                 </Text>
                             </View>
                         </TouchableWithoutFeedback>

--- a/src/shared/libs/currency.js
+++ b/src/shared/libs/currency.js
@@ -115,6 +115,16 @@ export const formatMonetaryValue = (iotas, unitPrice, currency) => {
     return `${currency ? getCurrencySymbol(currency) + ' ' : ''}${value}`;
 };
 
+/**
+ * Returns fiat balance
+ * @param {*} balance
+ * @param {*} usdPrice
+ * @param {string} conversionRate
+ */
+export const getFiatBalance = (balance, usdPrice, conversionRate) => {
+    return balance * usdPrice / 1000000 * conversionRate;
+}
+
 export const availableCurrencies = [
     'USD',
     'GBP',

--- a/src/shared/libs/currency.js
+++ b/src/shared/libs/currency.js
@@ -119,7 +119,7 @@ export const formatMonetaryValue = (iotas, unitPrice, currency) => {
  * Returns fiat balance
  * @param {*} balance
  * @param {*} usdPrice
- * @param {string} conversionRate
+ * @param {number} conversionRate
  */
 export const getFiatBalance = (balance, usdPrice, conversionRate) => {
     return balance * usdPrice / 1000000 * conversionRate;

--- a/src/shared/libs/currency.js
+++ b/src/shared/libs/currency.js
@@ -117,7 +117,7 @@ export const formatMonetaryValue = (iotas, unitPrice, currency) => {
 
 /**
  * Returns fiat balance
- * @param {*} balance
+ * @param {number} balance
  * @param {*} usdPrice
  * @param {number} conversionRate
  */

--- a/src/shared/libs/currency.js
+++ b/src/shared/libs/currency.js
@@ -118,7 +118,7 @@ export const formatMonetaryValue = (iotas, unitPrice, currency) => {
 /**
  * Returns fiat balance
  * @param {number} balance
- * @param {*} usdPrice
+ * @param {number} usdPrice
  * @param {number} conversionRate
  */
 export const getFiatBalance = (balance, usdPrice, conversionRate) => {


### PR DESCRIPTION
## Description

- Localise balance depending on language
- Add comma separators (i.e. 1,000,000)

Fixes #272

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on iOS and Mac

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
