### PR TITLE
Desktop: Fix zero fiat balance on Mac tray app

### DIFF
--- a/src/desktop/src/index.js
+++ b/src/desktop/src/index.js
@@ -17,7 +17,7 @@ import mapStorageToState from 'libs/storageToStateMappers';
 import getEncryptionKey from 'libs/realm';
 import { changeIotaNode, quorum } from 'libs/iota';
 import { bugsnagClient, ErrorBoundary } from 'libs/bugsnag';
-import { initialise as initialiseStorage, realm } from 'storage';
+import { initialise as initialiseStorage } from 'storage';
 import { updateSchema } from 'schemas';
 
 import Index from 'ui/Index';
@@ -87,10 +87,10 @@ const init = () => {
                 // Assign accountIndex to every account in accountInfo if it is not assigned already
                 store.dispatch(assignAccountIndexIfNecessary(get(data, 'accounts.accountInfo')));
 
-                // Proxy realm changes to Tray application
-                realm.addListener('change', () => {
-                    const data = mapStorageToState();
-                    Electron.storeUpdate(JSON.stringify(data));
+                // Proxy state changes to Tray application
+                store.subscribe(() => {
+                    const { settings, accounts, marketData } = store.getState();
+                    Electron.storeUpdate(JSON.stringify({ settings, accounts, marketData }));
                 });
 
                 // Set theme to default if current theme does not exist

--- a/src/desktop/src/ui/global/Polling.js
+++ b/src/desktop/src/ui/global/Polling.js
@@ -54,8 +54,6 @@ class Polling extends React.PureComponent {
         /** @ignore */
         setPollFor: PropTypes.func.isRequired,
         /** @ignore */
-        marketData: PropTypes.object.isRequired,
-        /** @ignore */
         fetchMarketData: PropTypes.func.isRequired,
         /** @ignore */
         fetchPrice: PropTypes.func.isRequired,
@@ -109,17 +107,6 @@ class Polling extends React.PureComponent {
 
         this.onPollTick = this.fetch.bind(this);
         this.interval = setInterval(this.onPollTick, 8000);
-    }
-
-    componentDidUpdate(prevProps) {
-        const { marketData, isPollingMarketData } = this.props;
-
-        /**
-         * Send updated marketData to Tray application
-         */
-        if (prevProps.isPollingMarketData && !isPollingMarketData) {
-            Electron.storeUpdate(JSON.stringify({ marketData }));
-        }
     }
 
     componentWillUnmount() {
@@ -212,23 +199,21 @@ class Polling extends React.PureComponent {
     };
 
     shouldSkipCycle() {
-        const props = this.props;
-
         const isAlreadyDoingSomeHeavyLifting =
-            props.isSyncing ||
-            props.isSendingTransfer ||
-            props.isGeneratingReceiveAddress ||
-            props.isFetchingAccountInfo || // In case the app is already fetching latest account info, stop polling because the market related data is already fetched on login
-            props.addingAdditionalAccount ||
-            props.isTransitioning ||
-            props.isRetryingFailedTransaction;
+            this.props.isSyncing ||
+            this.props.isSendingTransfer ||
+            this.props.isGeneratingReceiveAddress ||
+            this.props.isFetchingAccountInfo || // In case the app is already fetching latest account info, stop polling because the market related data is already fetched on login
+            this.props.addingAdditionalAccount ||
+            this.props.isTransitioning ||
+            this.props.isRetryingFailedTransaction;
 
         const isAlreadyPollingSomething =
-            props.isPollingPrice ||
-            props.isPollingChartData ||
-            props.isPollingMarketData ||
-            props.isPollingAccountInfo ||
-            props.isAutoPromoting;
+            this.props.isPollingPrice ||
+            this.props.isPollingChartData ||
+            this.props.isPollingMarketData ||
+            this.props.isPollingAccountInfo ||
+            this.props.isAutoPromoting;
 
         return isAlreadyDoingSomeHeavyLifting || isAlreadyPollingSomething;
     }
@@ -260,7 +245,6 @@ const mapStateToProps = (state) => ({
     isRetryingFailedTransaction: state.ui.isRetryingFailedTransaction,
     failedBundleHashes: getFailedBundleHashes(state),
     password: state.wallet.password,
-    marketData: state.marketData,
 });
 
 const mapDispatchToProps = {

--- a/src/desktop/src/ui/views/wallet/Dashboard.js
+++ b/src/desktop/src/ui/views/wallet/Dashboard.js
@@ -41,8 +41,6 @@ class Dashboard extends React.PureComponent {
         /** @ignore */
         location: PropTypes.object,
         /** @ignore */
-        marketData: PropTypes.object.isRequired,
-        /** @ignore */
         history: PropTypes.shape({
             push: PropTypes.func.isRequired,
         }).isRequired,
@@ -54,15 +52,6 @@ class Dashboard extends React.PureComponent {
         if (this.props.isDeepLinkActive) {
             this.props.history.push('/wallet/send');
         }
-    }
-
-    componentDidMount() {
-        const { marketData } = this.props;
-
-        /**
-         * Send updated marketData to Tray application
-         */
-        Electron.storeUpdate(JSON.stringify({ marketData }));
     }
 
     updateAccount = async () => {
@@ -144,7 +133,6 @@ const mapStateToProps = (state) => ({
     accountMeta: getSelectedAccountMeta(state),
     password: state.wallet.password,
     isDeepLinkActive: state.wallet.deepLinkRequestActive,
-    marketData: state.marketData,
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
# Description

There was no `settings.conversionRate` change listener as Realm does not store this change. Switched from Realm change listener to State change listener to catch them all.

Fixes #1967 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS 10.14

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes