### PR TITLE
Bump realm to 2.29.1

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -86,7 +86,7 @@
     "react-native-view-shot": "git+https://github.com/cvarley100/react-native-view-shot#master",
     "react-redux": "^5.0.6",
     "readable-stream": "^1.0.33",
-    "realm": "2.29.0",
+    "realm": "2.29.1",
     "redux": "^3.7.2",
     "rn-fetch-blob": "https://github.com/rajivshah3/rn-fetch-blob#10.13-226",
     "shared-modules": "../shared/",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -8118,10 +8118,10 @@ readable-stream@~2.0.6:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-realm@2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/realm/-/realm-2.29.0.tgz#bc734be98be46faa6388067f09f0ed1d8f9d8579"
-  integrity sha512-xjv3UJlnxmoMcWDbkikPfGPbUyScO1o9ho0GjqiLoLlRbgnAQBHexxiRbA5XAjo7dfT86uYbU9/oBEpkwPQO6w==
+realm@2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/realm/-/realm-2.29.1.tgz#24b3d1b6b66c08f51969932ee1e3268df0446d93"
+  integrity sha512-8oHCRrzz9vXNbr6PLnEDnNLCt+WKFO+JsJLCmY3raoPlamzPHBJndTAl3+x0Z1S0xR8Z0g86a53ptgCVOnfuQA==
   dependencies:
     command-line-args "^4.0.6"
     decompress "^4.2.0"

--- a/src/shared/package.json
+++ b/src/shared/package.json
@@ -57,7 +57,7 @@
     "mocha": "^6.1.4",
     "nock": "^10.0.6",
     "nyc": "^14.1.1",
-    "realm": "2.29.0",
+    "realm": "2.29.1",
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.5.3",
     "rimraf": "^2.6.3",

--- a/src/shared/yarn.lock
+++ b/src/shared/yarn.lock
@@ -4101,10 +4101,10 @@ readable-stream@^2.0.6, readable-stream@^2.2.2, readable-stream@^2.3.0, readable
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-realm@2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/realm/-/realm-2.29.0.tgz#bc734be98be46faa6388067f09f0ed1d8f9d8579"
-  integrity sha512-xjv3UJlnxmoMcWDbkikPfGPbUyScO1o9ho0GjqiLoLlRbgnAQBHexxiRbA5XAjo7dfT86uYbU9/oBEpkwPQO6w==
+realm@2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/realm/-/realm-2.29.1.tgz#24b3d1b6b66c08f51969932ee1e3268df0446d93"
+  integrity sha512-8oHCRrzz9vXNbr6PLnEDnNLCt+WKFO+JsJLCmY3raoPlamzPHBJndTAl3+x0Z1S0xR8Z0g86a53ptgCVOnfuQA==
   dependencies:
     command-line-args "^4.0.6"
     decompress "^4.2.0"


### PR DESCRIPTION
# Description
Bumps realm to 2.29.1 (see [release notes](https://github.com/realm/realm-js/blob/master/CHANGELOG.md#2291-release-notes-2019-7-11)). Desktop will be updated in #2044.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration_

- Test A
- Test B


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes