### PR TITLE
Shared: Mitigate potential crashes when formatting fiat balance

### DIFF
--- a/src/desktop/src/ui/components/Balance.js
+++ b/src/desktop/src/ui/components/Balance.js
@@ -7,7 +7,7 @@ import { getAccountNamesFromState } from 'selectors/accounts';
 
 import { accumulateBalance } from 'libs/iota/addresses';
 import { formatUnit, formatIotas } from 'libs/iota/utils';
-import { getFiatBalance } from 'libs/currency';
+import { getFiatBalance, formatFiatBalance } from 'libs/currency';
 
 import Icon from 'ui/components/Icon';
 
@@ -96,7 +96,7 @@ export class BalanceComponent extends React.PureComponent {
                     {formatIotas(accountBalance, balanceIsShort)}
                     <small>{`${formatUnit(accountBalance)}`}</small>
                 </h1>
-                <h2>{new Intl.NumberFormat(settings.locale, { style: 'currency', currency: settings.currency }).format(fiatBalance)}</h2>
+                <h2>{formatFiatBalance(settings.locale, settings.currency, fiatBalance)}</h2>
             </div>
         );
     }

--- a/src/mobile/__tests__/ui/views/wallet/Balance.spec.js
+++ b/src/mobile/__tests__/ui/views/wallet/Balance.spec.js
@@ -46,6 +46,7 @@ const getProps = (overrides) =>
             onRefresh: noop,
             animateChartOnMount: true,
             setAnimateChartOnMount: noop,
+            language: 'English (International)',
         },
         overrides,
     );
@@ -90,6 +91,10 @@ describe('Testing Balance component', () => {
 
         it('should require an animateChartOnMount bool as a prop', () => {
             expect(Balance.propTypes.animateChartOnMount).toEqual(PropTypes.bool.isRequired);
+        });
+
+        it('should require a language string as a prop', () => {
+            expect(Balance.propTypes.language).toEqual(PropTypes.string.isRequired);
         });
     });
 

--- a/src/mobile/src/ui/views/wallet/Balance.js
+++ b/src/mobile/src/ui/views/wallet/Balance.js
@@ -18,7 +18,7 @@ import { round, roundDown } from 'shared-modules/libs/utils';
 import { computeStatusText, formatRelevantRecentTransactions } from 'shared-modules/libs/iota/transfers';
 import { setAnimateChartOnMount } from 'shared-modules/actions/ui';
 import { formatValue, formatUnit } from 'shared-modules/libs/iota/utils';
-import { getFiatBalance } from 'shared-modules/libs/currency';
+import { getFiatBalance, formatFiatBalance } from 'shared-modules/libs/currency';
 import {
     getTransactionsForSelectedAccount,
     getBalanceForSelectedAccount,
@@ -239,7 +239,16 @@ export class Balance extends Component {
     }
 
     render() {
-        const { balance, conversionRate, currency, usdPrice, theme, isRefreshing, animateChartOnMount, language } = this.props;
+        const {
+            balance,
+            conversionRate,
+            currency,
+            usdPrice,
+            theme,
+            isRefreshing,
+            animateChartOnMount,
+            language,
+        } = this.props;
         const { body, primary } = theme;
 
         const shortenedBalance =
@@ -277,7 +286,7 @@ export class Balance extends Component {
                                     <Text style={[styles.iotaUnit, textColor]}>{iotaUnit}</Text>
                                 </View>
                                 <Text style={[styles.fiatBalance, textColor]}>
-                                    {new Intl.NumberFormat(getLocaleFromLabel(language), { style: 'currency', currency }).format(fiatBalance)}
+                                    {formatFiatBalance(getLocaleFromLabel(language), currency, fiatBalance)}
                                 </Text>
                             </View>
                         </TouchableWithoutFeedback>
@@ -313,4 +322,11 @@ const mapDispatchToProps = {
     setAnimateChartOnMount,
 };
 
-export default WithManualRefresh()(withNamespaces(['global'])(connect(mapStateToProps, mapDispatchToProps)(Balance)));
+export default WithManualRefresh()(
+    withNamespaces(['global'])(
+        connect(
+            mapStateToProps,
+            mapDispatchToProps,
+        )(Balance),
+    ),
+);

--- a/src/shared/libs/currency.js
+++ b/src/shared/libs/currency.js
@@ -122,8 +122,31 @@ export const formatMonetaryValue = (iotas, unitPrice, currency) => {
  * @param {number} conversionRate
  */
 export const getFiatBalance = (balance, usdPrice, conversionRate) => {
-    return balance * usdPrice / 1000000 * conversionRate;
-}
+    return ((balance * usdPrice) / 1000000) * conversionRate;
+};
+
+/**
+ * Format fiat balance
+ * @param  {string} locale
+ * @param  {string} currency
+ * @param  {number} fiatBalance
+ * @return {string}
+ */
+export const formatFiatBalance = (locale, currency, fiatBalance) => {
+    // FIXME(rajivshah3): Temporarily mitigate crashes
+    // Will be fixed when language codes are standardized
+    // See https://github.com/iotaledger/trinity-wallet/issues/2039
+    let intl = null;
+
+    // Replace underscore with hyphen
+    locale = locale.replace(/_/g, '-');
+    try {
+        intl = new Intl.NumberFormat(locale, { style: 'currency', currency, localeMatcher: 'best fit' });
+    } catch {
+        intl = new Intl.NumberFormat('en', { style: 'currency', currency, localeMatcher: 'best fit' });
+    }
+    return intl.format(fiatBalance);
+};
 
 export const availableCurrencies = [
     'USD',


### PR DESCRIPTION
# Description

- Use `en` as a fallback locale when the currently selected locale is not supported
- Abstract away formatting to `shared` instead of implementing in both `mobile` and `desktop`

This hotfix is temporary and can be removed once language codes are standardized (see #2039).

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on iOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
