### PR TITLE
Update Menu.js | Fixes Help > Trinity Help leads to 404

### DIFF
--- a/src/desktop/native/libs/Menu.js
+++ b/src/desktop/native/libs/Menu.js
@@ -360,7 +360,7 @@ export const initMenu = (app, getWindowFunc) => {
                 {
                     label: `${app.getName()} ${language.help}`,
                     click: function() {
-                        shell.openExternal('https://docs.iota.org/docs/trinity/0.1/introduction/overview');
+                        shell.openExternal('https://docs.iota.org/docs/wallets/0.1/trinity/introduction/overview');
                     },
                 },
             ],


### PR DESCRIPTION
Update Trinity Help Link to new location on docs.iota.org