### PR TITLE
Shared: Fixes autopromotion settings

### DIFF
--- a/src/shared/actions/settings.js
+++ b/src/shared/actions/settings.js
@@ -524,7 +524,6 @@ export function setFullNode(node, addingCustomNode = false) {
                 } else {
                     // Automatically default to local PoW if this node has no attach to tangle available
                     dispatch(setRemotePoW(false));
-                    dispatch(setAutoPromotion(false));
 
                     dispatch(
                         generateAlert(

--- a/src/shared/actions/settings.js
+++ b/src/shared/actions/settings.js
@@ -596,37 +596,17 @@ export function changePowSettings() {
 export function changeAutoPromotionSettings() {
     return (dispatch, getState) => {
         const settings = getState().settings;
-        if (!settings.autoPromotion) {
-            allowsRemotePow(settings.node).then((hasRemotePow) => {
-                if (!hasRemotePow) {
-                    return dispatch(
-                        generateAlert(
-                            'error',
-                            i18next.t('global:attachToTangleUnavailable'),
-                            i18next.t('global:attachToTangleUnavailableExplanationShort'),
-                            10000,
-                        ),
-                    );
-                }
-                dispatch(setAutoPromotion(!settings.autoPromotion));
-                dispatch(
-                    generateAlert(
-                        'success',
-                        i18next.t('autoPromotion:autoPromotionUpdated'),
-                        i18next.t('autoPromotion:autoPromotionUpdatedExplanation'),
-                    ),
-                );
-            });
-        } else {
-            dispatch(setAutoPromotion(!settings.autoPromotion));
-            dispatch(
-                generateAlert(
-                    'success',
-                    i18next.t('autoPromotion:autoPromotionUpdated'),
-                    i18next.t('autoPromotion:autoPromotionUpdatedExplanation'),
-                ),
-            );
+        if (!settings.powNode) {
+            dispatch(setPowNode(getRandomPowNodeFromState(getState())));
         }
+        dispatch(setAutoPromotion(!settings.autoPromotion));
+        dispatch(
+            generateAlert(
+                'success',
+                i18next.t('autoPromotion:autoPromotionUpdated'),
+                i18next.t('autoPromotion:autoPromotionUpdatedExplanation'),
+            ),
+        );
     };
 }
 

--- a/src/shared/actions/settings.js
+++ b/src/shared/actions/settings.js
@@ -595,7 +595,7 @@ export function changePowSettings() {
 export function changeAutoPromotionSettings() {
     return (dispatch, getState) => {
         const settings = getState().settings;
-        if (!settings.powNode) {
+        if (!settings.autoPromotion && !settings.powNode) {
             dispatch(setPowNode(getRandomPowNodeFromState(getState())));
         }
         dispatch(setAutoPromotion(!settings.autoPromotion));


### PR DESCRIPTION
#  Description

- Makes changes to autopromotion settings to accommodate for remote pow node changes  

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS simulator

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
