### PR TITLE
Mobile/iOS: Remove keychain sharing and fix Debug scheme

### DIFF
--- a/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
+++ b/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
@@ -1663,7 +1663,7 @@
 								enabled = 1;
 							};
 							com.apple.Keychain = {
-								enabled = 1;
+								enabled = 0;
 							};
 							com.apple.iCloud = {
 								enabled = 1;

--- a/src/mobile/ios/iotaWallet.xcodeproj/xcshareddata/xcschemes/iotaWallet-Debug.xcscheme
+++ b/src/mobile/ios/iotaWallet.xcodeproj/xcshareddata/xcschemes/iotaWallet-Debug.xcscheme
@@ -1,11 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
       <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "83CBBA2D1A601D0E00E9B192"
+               BuildableName = "libReact.a"
+               BlueprintName = "React"
+               ReferencedContainer = "container:../node_modules/react-native/React/React.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
@@ -20,6 +34,34 @@
                ReferencedContainer = "container:iotaWallet.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "30A16F44D53CE8CFD5085B3A66B82141"
+               BuildableName = "iotaWalletTests.xctest"
+               BlueprintName = "iotaWalletTests"
+               ReferencedContainer = "container:iotaWallet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B337D5A007B26D2B5F9D16F7E2662744"
+               BuildableName = "iotaWalletUITests.xctest"
+               BlueprintName = "iotaWalletUITests"
+               ReferencedContainer = "container:iotaWallet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,6 +70,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "30A16F44D53CE8CFD5085B3A66B82141"
+               BuildableName = "iotaWalletTests.xctest"
+               BlueprintName = "iotaWalletTests"
+               ReferencedContainer = "container:iotaWallet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B337D5A007B26D2B5F9D16F7E2662744"
+               BuildableName = "iotaWalletUITests.xctest"
+               BlueprintName = "iotaWalletUITests"
+               ReferencedContainer = "container:iotaWallet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -61,11 +123,18 @@
             ReferencedContainer = "container:iotaWallet.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "disable"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -85,7 +154,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/src/mobile/ios/iotaWallet/iotaWallet.entitlements
+++ b/src/mobile/ios/iotaWallet/iotaWallet.entitlements
@@ -8,9 +8,5 @@
 	<array/>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
-	<key>keychain-access-groups</key>
-	<array>
-		<string>$(AppIdentifierPrefix)org.reactjs.native.example.iotaWallet</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
# Description

- Remove keychain sharing to prevent same keychain items from being used in both beta and App Store versions
- Duplicate iotaWallet-Beta scheme to create iotaWallet-Debug scheme

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
