### PR TITLE
Mobile/iOS: Patch react-native-document-picker

### DIFF
--- a/src/mobile/patches/react-native-document-picker+3.2.2.patch
+++ b/src/mobile/patches/react-native-document-picker+3.2.2.patch
@@ -11,3 +11,27 @@ index c87eb62..95ab12c 100644
    // Use a timeout to ensure the warning is displayed in the YellowBox
    setTimeout(() => {
      console.warn(
+diff --git a/node_modules/react-native-document-picker/ios/RNDocumentPicker/RNDocumentPicker.m b/node_modules/react-native-document-picker/ios/RNDocumentPicker/RNDocumentPicker.m
+index 1cb8b4b..eead541 100644
+--- a/node_modules/react-native-document-picker/ios/RNDocumentPicker/RNDocumentPicker.m
++++ b/node_modules/react-native-document-picker/ios/RNDocumentPicker/RNDocumentPicker.m
+@@ -5,6 +5,7 @@
+ #if __has_include(<React/RCTConvert.h>)
+ #import <React/RCTConvert.h>
+ #import <React/RCTBridge.h>
++#import <React/RCTUtils.h>
+ #else // back compatibility for RN version < 0.40
+ #import "RCTConvert.h"
+ #import "RCTBridge.h"
+@@ -72,10 +73,7 @@ - (dispatch_queue_t)methodQueue
+     }
+ #endif
+     
+-    UIViewController *rootViewController = [[[[UIApplication sharedApplication]delegate] window] rootViewController];
+-    while (rootViewController.presentedViewController) {
+-        rootViewController = rootViewController.presentedViewController;
+-    }
++    UIViewController *rootViewController = RCTPresentedViewController();
+     
+     [rootViewController presentViewController:documentPicker animated:YES completion:nil];
+ }


### PR DESCRIPTION
# Description

`react-native-document-picker` may have been using an unofficial way of getting the root view controller so that it could present the document picker. The new approach uses an official method from RN (see https://github.com/facebook/react-native/blob/91681016e84cdb99bd823c937762a0d9974e56fe/React/Base/RCTUtils.h#L87)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on iOS (debug)


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes