### PR TITLE
chore: resolve eslint-utils to >=1.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
   "resolutions": {
     "js-yaml": ">=3.13.1",
     "request": ">=2.88.0",
-    "node.extend": ">=1.1.7"
+    "node.extend": ">=1.1.7",
+    "eslint-utils": ">=1.4.1"
   },
   "snyk": true,
   "husky": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,10 +1186,12 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
-  integrity sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==
+eslint-utils@>=1.4.1, eslint-utils@^1.3.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
+  dependencies:
+    eslint-visitor-keys "^1.0.0"
 
 eslint-visitor-keys@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# Description

Fix for the security issue found in [eslint-utils](https://www.npmjs.com/package/eslint-utils) package. 

<img width="854" alt="Screenshot 2019-08-27 at 2 33 01 pm" src="https://user-images.githubusercontent.com/20437468/63760034-042c1600-c8d8-11e9-835e-e34c7499dc4c.png">

## Type of change

- Fix

# How Has This Been Tested?

N/A

# Checklist:
- [ ] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
