### PR TITLE
chore (desktop): allow users to change installation directory (windows)

### DIFF
--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -118,7 +118,9 @@
       ]
     },
     "nsis": {
-      "deleteAppDataOnUninstall": true
+      "deleteAppDataOnUninstall": true,
+      "allowToChangeInstallationDirectory": true,
+      "oneClick": false
     },
     "win": {
       "publisherName": "IOTA Stiftung",


### PR DESCRIPTION
# Description

Enabling `onClick` option to `true` (which is the current configuration), it installs the new (RC) version inside `Users/<User>/AppData/Local/Programs/trinity-desktop`. This overwrites the existing installation even if it's a release version. 

This PR allows users to change installation directory on windows to avoid the overwrite. 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manually tested Windows

# Checklist:

- [x] My code follows the style guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
