### PR TITLE
Shared: Fix untranslated "Empty" in transaction details

### DIFF
--- a/src/desktop/src/ui/components/List.js
+++ b/src/desktop/src/ui/components/List.js
@@ -375,7 +375,7 @@ export class ListComponent extends React.PureComponent {
                                     <strong>{t('send:message')}:</strong>
                                     <Scrollbar>
                                         <Clipboard
-                                            text={activeTx.message}
+                                            text={activeTx.message === 'Empty' ? t('history:empty') : activeTx.message}
                                             title={t('history:messageCopied')}
                                             success={t('history:messageCopiedExplanation')}
                                         />

--- a/src/mobile/src/ui/components/TransactionHistoryModal.js
+++ b/src/mobile/src/ui/components/TransactionHistoryModal.js
@@ -407,7 +407,9 @@ export default class TransactionHistoryModal extends PureComponent {
                     >
                         <View style={{ width: contentWidth }}>
                             <TouchableOpacity onPress={() => this.copy(message, 'message')}>
-                                <Text style={[styles.messageText, style.defaultTextColor]}>{message}</Text>
+                                <Text style={[styles.messageText, style.defaultTextColor]}>
+                                    {message === 'Empty' ? t('history:empty') : message}
+                                </Text>
                             </TouchableOpacity>
                         </View>
                     </ScrollView>


### PR DESCRIPTION
# Description

Fixes untranslated "Empty" in transaction details

Fixes #2192 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on iOS (debug)
- Tested on macOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes