### PR TITLE
Mobile: Fix crash on add custom node

### DIFF
--- a/src/mobile/src/ui/views/wallet/AddCustomNode.js
+++ b/src/mobile/src/ui/views/wallet/AddCustomNode.js
@@ -88,6 +88,7 @@ export class AddCustomNode extends Component {
             customNode: { url: '', username: '', password: '' },
             textInputFlex: new Animated.Value(2.5),
             nodeListFlex: new Animated.Value(7),
+            nodeListHeight: 1,
             viewAuthKeyButton: true,
             viewAuthKeyFields: false,
         };
@@ -282,10 +283,7 @@ export class AddCustomNode extends Component {
                             <Animated.View style={{ flex: nodeListFlex }}>
                                 <View
                                     style={{ flex: 1, width }}
-                                    onLayout={(e) =>
-                                        !nodeListHeight &&
-                                        this.setState({ nodeListHeight: e.nativeEvent.layout.height })
-                                    }
+                                    onLayout={(e) => this.setState({ nodeListHeight: e.nativeEvent.layout.height })}
                                 >
                                     <ScrollView style={{ width, maxHeight: nodeListHeight }} scrollEnabled>
                                         <View style={{ flex: 1 }} onStartShouldSetResponder={() => true}>


### PR DESCRIPTION
## Description

Fixes a crash when adding custom node on mobile

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
