### PR TITLE
Mobile: Update RN-picker select to 6.3.3

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -76,7 +76,7 @@
     "react-native-navigation": "^2.22.3",
     "react-native-optimized-flatlist": "^1.0.4",
     "react-native-os": "git+https://github.com/laumair/react-native-os.git#527b0ae",
-    "react-native-picker-select": "git+https://github.com/cvarley100/react-native-picker-select#master",
+    "react-native-picker-select": "^6.3.3",
     "react-native-print": "^0.5.0",
     "react-native-progress": "^3.4.0",
     "react-native-qr-generator": "^1.0.3",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -8177,9 +8177,10 @@ react-native-optimized-flatlist@^1.0.4:
   version "1.1.0"
   resolved "git+https://github.com/laumair/react-native-os.git#527b0aef4e30041b5230f5b901767dd9f54903fe"
 
-"react-native-picker-select@git+https://github.com/cvarley100/react-native-picker-select#master":
-  version "6.1.0"
-  resolved "git+https://github.com/cvarley100/react-native-picker-select#a9ee590565b46e2f97669367920d4ce007c218d6"
+react-native-picker-select@^6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/react-native-picker-select/-/react-native-picker-select-6.3.3.tgz#ea4d20a385041a2f4ead3eb3398b08511d7d6c2a"
+  integrity sha512-9cSXWonugev+e0EHrV8FhzwkjAhpipLFXsGMv+Ns5xI47T9fyNrOXpSeSfgnmycbuAbWRVlJRhJZ9eDGUaNk7w==
   dependencies:
     lodash.isequal "^4.5.0"
 


### PR DESCRIPTION
## Description

We no longer need a fork as the required change was merged to master.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on Android

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
