### PR TITLE
Mobile/Android: Use default jsBundleDir

### DIFF
--- a/src/mobile/android/app/build.gradle
+++ b/src/mobile/android/app/build.gradle
@@ -71,7 +71,6 @@ import com.android.build.OutputFile
  */
 project.ext.react = [
         entryFile: "index.js",
-        jsBundleDirRelease: "$buildDir/intermediates/merged_assets/release/mergeReleaseAssets/out"
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"


### PR DESCRIPTION
# Description

Fixes crashes on Android release builds

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Verified that JS bundle was included in the APK


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code