### PR TITLE
Mobile/iOS: Fix crash on iOS 13

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -51,7 +51,7 @@
     "qr.js": "https://github.com/defunctzombie/qr.js",
     "react": "16.8.3",
     "react-i18next": "^10.11.5",
-    "react-native": "0.59.10",
+    "react-native": "https://github.com/cvarley100/react-native#0.59.10-patch",
     "react-native-camera": "^1.5.1",
     "react-native-crypto": "^2.0.2",
     "react-native-detect-navbar-android": "^0.2.0",

--- a/src/mobile/patches/react-native-schemes-manager+2.0.0.patch
+++ b/src/mobile/patches/react-native-schemes-manager+2.0.0.patch
@@ -1,3 +1,19 @@
+diff --git a/node_modules/react-native-schemes-manager/src/fix-libraries.js b/node_modules/react-native-schemes-manager/src/fix-libraries.js
+index d587997..3b44f2e 100644
+--- a/node_modules/react-native-schemes-manager/src/fix-libraries.js
++++ b/node_modules/react-native-schemes-manager/src/fix-libraries.js
+@@ -44,7 +44,10 @@ function updateProject (project) {
+ 					const sourceConfig = sourceConfigs[key];
+ 					const configList = configListForConfig(configLists, key);
+ 
+-					if (!configList) throw new Error(`Unable to find config list for build configuration: ${sourceConfig.name}`);
++					if (!configList) {
++						console.log(`Unable to find config list for build configuration: ${sourceConfig.name}`);
++						continue;
++					}
+ 
+ 					// Copy that bad boy.
+ 					const clone = JSON.parse(JSON.stringify(sourceConfig));
 diff --git a/node_modules/react-native-schemes-manager/src/utilities.js b/node_modules/react-native-schemes-manager/src/utilities.js
 index 7dee56e..896cabb 100644
 --- a/node_modules/react-native-schemes-manager/src/utilities.js

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -8289,10 +8289,9 @@ react-native-vector-icons@^6.4.1:
   version "2.4.0"
   resolved "git+https://github.com/cvarley100/react-native-view-shot#b7af36520f10c212ff226c32dc72a6c0b9e1521e"
 
-react-native@0.59.10:
+"react-native@https://github.com/cvarley100/react-native#0.59.10-patch":
   version "0.59.10"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.59.10.tgz#352f381e382f93a0403be499c9e384bf51c2591c"
-  integrity sha512-guB9YW+pBqS1dnfZ4ntzjINopiCUAbdmshU2wMWD1W32fRczLAopi/7Q2iHKP8LTCdxuYZV3fa9Mew5PSuANAw==
+  resolved "https://github.com/cvarley100/react-native#ccc33d86a95b7b47e2a69d0b37b33fecb335a349"
   dependencies:
     "@babel/runtime" "^7.0.0"
     "@react-native-community/cli" "^1.2.1"


### PR DESCRIPTION
## Description

- App crashes on iOS 13/Xcode 11 with EXC_BAD_ACCESS in fishhook.c
- Forks React Native removing unused `fishhook` library applying changes here https://github.com/facebook/react-native/issues/25182
- Applies patch to react-native-schemes-manager to accommodate changes in RN (see https://github.com/thekevinbrown/react-native-schemes-manager/issues/76)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
