### PR TITLE
Make sure realm file decryption does not fail on migrations

### DIFF
--- a/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
+++ b/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
@@ -1663,7 +1663,7 @@
 								enabled = 1;
 							};
 							com.apple.Keychain = {
-								enabled = 0;
+								enabled = 1;
 							};
 							com.apple.iCloud = {
 								enabled = 1;

--- a/src/mobile/ios/iotaWallet/iotaWallet.entitlements
+++ b/src/mobile/ios/iotaWallet/iotaWallet.entitlements
@@ -8,5 +8,9 @@
 	<array/>
 	<key>com.apple.developer.ubiquity-kvstore-identifier</key>
 	<string>$(TeamIdentifierPrefix)$(CFBundleIdentifier)</string>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)org.reactjs.native.example.iotaWallet</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
# Description

Reverts changes made in [this](https://github.com/iotaledger/trinity-wallet/pull/2155) PR which was causing migration to fail.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested by building on top of the latest AppStore version (1.0.0) and ensuring migration doesn't lead to a crash.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
