### PR TITLE
chore: add __diff_output__ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ realm-object-server/
 
 # NPM lockfiles
 package-lock.json
+
+# tests
+__diff_output__


### PR DESCRIPTION
# Description

This PR adds `__diff_output__` (generated when we run desktop tests) to gitignore.

## Type of change

- Chore

# How Has This Been Tested?

N/A

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
