### PR TITLE
Mobile: Reset denomination on QR scan

### DIFF
--- a/src/mobile/src/ui/views/wallet/Send.js
+++ b/src/mobile/src/ui/views/wallet/Send.js
@@ -376,6 +376,8 @@ export class Send extends Component {
         this.hideModal();
         // Clear clipboard
         Clipboard.setString(' ');
+        // Reset send denomination on QR scan
+        this.props.setSendDenomination('i');
 
         if (parsedData.address) {
             // For codes containing JSON (iotaledger and Trinity)


### PR DESCRIPTION
# Description

- Reset denomination on QR scan to ensure correct IOTA value

Fixes #2046 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS

# Checklist:

_Please delete items that are not relevant._

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes