### PR TITLE
fix(shared): Use interpolation for sweeps strings

### DIFF
--- a/src/desktop/src/ui/views/settings/account/sweeps/TransferFunds.js
+++ b/src/desktop/src/ui/views/settings/account/sweeps/TransferFunds.js
@@ -11,7 +11,7 @@ import size from 'lodash/size';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withTranslation } from 'react-i18next';
+import { withTranslation, Trans } from 'react-i18next';
 
 import SeedStore from 'libs/SeedStore';
 
@@ -249,6 +249,11 @@ class TransferFunds extends React.PureComponent {
                             const statusObject = get(sweepsStatuses, object.address);
                             const status = get(statusObject, 'status');
                             const initialisationTime = get(statusObject, 'initialisationTime');
+                            const formattedBalance = `${formatIotas(object.balance)} ${formatUnit(object.balance)}`;
+                            const formattedFromAddress = `${object.address.slice(0, 9)} ... ${object.address.slice(
+                                -3,
+                            )}`;
+                            const formattedToAddress = `${latestAddress.slice(0, 9)} ... ${latestAddress.slice(-3)}`;
 
                             const hasFailed = status === -1;
                             const isInProgress = status === 0;
@@ -272,9 +277,10 @@ class TransferFunds extends React.PureComponent {
                                                 marginRight: '40px',
                                             }}
                                         >
-                                            {`${t('sweeps:sweep')} ${index + 1} ${t('global:of')} ${
-                                                spentAddressData.length
-                                            }`}
+                                            {t('sweeps:sweepNumber', {
+                                                sweepIndex: index + 1,
+                                                totalSweeps: spentAddressData.length,
+                                            })}
                                         </strong>
                                         {has(sweepsStatuses, object.address) && (
                                             <span
@@ -307,19 +313,23 @@ class TransferFunds extends React.PureComponent {
                                             display: 'flex',
                                         }}
                                     >
-                                        <span>
-                                            <strong>
-                                                {formatIotas(object.balance)} {formatUnit(object.balance)}{' '}
-                                            </strong>{' '}
-                                            {t('sweeps:fromLockedAddress')}{' '}
-                                            <strong title={object.inputAddress}>
-                                                {object.address.slice(0, 9)} ... {object.address.slice(-3)}
-                                            </strong>{' '}
-                                            {t('sweeps:toSafeAddress')}{' '}
-                                            <strong title={object.outputAddress}>
-                                                {latestAddress.slice(0, 9)} ... {latestAddress.slice(-3)}
-                                            </strong>
-                                        </span>
+                                        <Trans
+                                            i18nKey="sweeps:fromLockedAddressToSafeAddress"
+                                            balance={formattedBalance}
+                                            fromAddress={formattedFromAddress}
+                                            safeAddress={formattedToAddress}
+                                        >
+                                            <span>
+                                                <strong>{{ balance: formattedBalance }}</strong> from the locked address{' '}
+                                                <strong title={object.inputAddress}>
+                                                    {{ fromAddress: formattedFromAddress }}
+                                                </strong>{' '}
+                                                to the safe address{' '}
+                                                <strong title={object.outputAddress}>
+                                                    {{ safeAddress: formattedToAddress }}
+                                                </strong>
+                                            </span>
+                                        </Trans>
                                     </div>
                                 </div>
                             );

--- a/src/mobile/src/ui/views/wallet/sweeps/TransferFunds.js
+++ b/src/mobile/src/ui/views/wallet/sweeps/TransferFunds.js
@@ -6,7 +6,7 @@ import size from 'lodash/size';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withTranslation } from 'react-i18next';
+import { withTranslation, Trans } from 'react-i18next';
 import { StyleSheet, View, Text, ScrollView } from 'react-native';
 import SeedStore from 'libs/SeedStore';
 import navigator from 'libs/navigation';
@@ -250,12 +250,23 @@ class TransferFunds extends React.PureComponent {
                                 const hasFailed = status === -1;
                                 const isInProgress = status === 0;
                                 const hasCompleted = status === 1;
+                                const formattedBalance = `${formatIotas(object.balance)} ${formatUnit(object.balance)}`;
+                                const formattedFromAddress = `${object.address.slice(0, 9)} ... ${object.address.slice(
+                                    -3,
+                                )}`;
+                                const formattedToAddress = `${latestAddress.slice(0, 9)} ... ${latestAddress.slice(
+                                    -3,
+                                )}`;
 
                                 return (
                                     <View key={index}>
                                         <View style={styles.sweepHeader}>
-                                            <Text style={[styles.infoText, { color: body.color }]}>{`Sweep ${index +
-                                                1} of ${spentAddressDataWithBalance.length}`}</Text>
+                                            <Text style={[styles.infoText, { color: body.color }]}>
+                                                {t('sweeps:sweepNumber', {
+                                                    sweepIndex: index + 1,
+                                                    totalSweeps: spentAddressDataWithBalance.length,
+                                                })}
+                                            </Text>
                                             {has(sweepsStatuses, object.address) && (
                                                 <OldProgressBar
                                                     width={width / 3}
@@ -276,18 +287,27 @@ class TransferFunds extends React.PureComponent {
                                                     { color: body.color, marginBottom: height / 40 },
                                                 ]}
                                             >
-                                                <Text>
-                                                    {formatIotas(object.balance)} {formatUnit(object.balance)} from the
-                                                    locked address{' '}
-                                                </Text>
-                                                <Text title={object.inputAddress}>
-                                                    {object.address.slice(0, 9)} ... {object.address.slice(-3)}
-                                                </Text>
-                                                <Text title={object.outputAddress}>
-                                                    {' '}
-                                                    to the safe address {latestAddress.slice(0, 9)} ...{' '}
-                                                    {latestAddress.slice(-3)}
-                                                </Text>
+                                                {/* The nbsp used below is necessary to ensure elements are spaced properly */}
+                                                {/* Because of the way react-i18next counts elements, regular space strings (' ') cannot be used */}
+                                                {/* Otherwise we cannot use the same translation string on desktop and mobile */}
+                                                <Trans
+                                                    i18nKey="sweeps:fromLockedAddressToSafeAddress"
+                                                    balance={formattedBalance}
+                                                    fromAddress={formattedFromAddress}
+                                                    safeAddress={formattedToAddress}
+                                                >
+                                                    <Text>
+                                                        <Text>{{ balance: formattedBalance }}</Text> from the locked
+                                                        address &nbsp;
+                                                        <Text title={object.inputAddress}>
+                                                            {{ fromAddress: formattedFromAddress }}
+                                                        </Text>{' '}
+                                                        &nbsp; to the safe address &nbsp;
+                                                        <Text title={object.outputAddress}>
+                                                            {{ safeAddress: formattedToAddress }}
+                                                        </Text>
+                                                    </Text>
+                                                </Trans>
                                             </Text>
                                         </View>
                                     </View>

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -59,7 +59,6 @@
         "share": "Share",
         "proceed": "Proceed",
         "qr": "QR",
-        "of": "of",
         "enterSeed": "Please enter your seed.",
         "yes": "Yes",
         "no": "No",
@@ -621,9 +620,8 @@
         "doNotCloseTrinityMobile": "Do not minimise/close Trinity or turn off your device during this process.",
         "fundsUnlockedExplanation": "Your funds have been successfully unlocked. Promote the transactions to help them confirm.",
         "tryAgain": "Try again",
-        "sweep": "Sweep",
-        "fromLockedAddress": "from the locked address",
-        "toSafeAddress": "to the safe address"
+        "sweepNumber": "Sweep {{sweepIndex}} of {{totalSweeps}}",
+        "fromLockedAddressToSafeAddress": "<0><0>{{balance}}</0> from the locked address <2>{{fromAddress}}</2> to the safe address <4>{{safeAddress}}</4></0>"
     },
     "resetWalletRequirePassword": {
         "enterPassword": "Enter your password to reset the wallet.",


### PR DESCRIPTION
# Description

Uses interpolation for sweeps strings so that they are easier to translate (see https://github.com/iotaledger/trinity-wallet/pull/2226#pullrequestreview-338474325 for context)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on iOS (debug)
- Tested on macOS (debug)


# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
