### PR TITLE
Shared: Use correct currency symbols in MoonPay amount warning text

### DIFF
--- a/src/desktop/src/ui/views/exchanges/MoonPay/AddAmount.js
+++ b/src/desktop/src/ui/views/exchanges/MoonPay/AddAmount.js
@@ -114,6 +114,18 @@ class AddAmount extends React.PureComponent {
     }
 
     /**
+     * Gets currency symbol for currently selected currency
+     *
+     * @method getCurrencySymbol
+     *
+     * @returns {string}
+     */
+    getCurrencySymbol() {
+        const { denomination } = this.props;
+        return denomination === 'Mi' ? '$' : getCurrencySymbol(denomination);
+    }
+
+    /**
      * Fetches latest currency quote
      *
      * @method fetchCurrencyQuote
@@ -237,11 +249,11 @@ class AddAmount extends React.PureComponent {
             const fiatAmount = getAmountInFiat(Number(amount), denomination, exchangeRates);
 
             if (fiatAmount < MINIMUM_TRANSACTION_SIZE) {
-                return t('moonpay:minimumTransactionAmount', { amount: `€${MINIMUM_TRANSACTION_SIZE}` });
+                return t('moonpay:minimumTransactionAmount', { amount: this.getCurrencySymbol() + MINIMUM_TRANSACTION_SIZE });
             }
 
             if (fiatAmount > MAXIMUM_TRANSACTION_SIZE) {
-                return t('moonpay:maximumTransactionAmount', { amount: `€${MAXIMUM_TRANSACTION_SIZE}` });
+                return t('moonpay:maximumTransactionAmount', { amount: this.getCurrencySymbol() + MAXIMUM_TRANSACTION_SIZE });
             }
 
             if (
@@ -250,7 +262,7 @@ class AddAmount extends React.PureComponent {
                 isPurchaseLimitIncreaseAllowed
             ) {
                 return fiatAmount > BASIC_MONTHLY_LIMIT
-                    ? t('moonpay:kycRequired', { limit: `€${BASIC_MONTHLY_LIMIT}` })
+                    ? t('moonpay:kycRequired', { limit: this.getCurrencySymbol() + BASIC_MONTHLY_LIMIT })
                     : null;
             } else if (
                 hasCompletedBasicIdentityVerification &&

--- a/src/mobile/src/ui/views/wallet/exchanges/MoonPay/AddAmount.js
+++ b/src/mobile/src/ui/views/wallet/exchanges/MoonPay/AddAmount.js
@@ -318,7 +318,7 @@ class AddAmount extends Component {
                 isPurchaseLimitIncreaseAllowed
             ) {
                 return fiatAmount > BASIC_MONTHLY_LIMIT
-                    ? t('moonpay:kycRequired', { limit: `€${BASIC_MONTHLY_LIMIT}` })
+                    ? t('moonpay:kycRequired', { limit: this.getCurrencySymbol() + BASIC_MONTHLY_LIMIT })
                     : null;
             } else if (
                 hasCompletedBasicIdentityVerification &&


### PR DESCRIPTION
# Description

Ensures correct currency symbols are displayed in MoonPay amount warning text.

Fixes #2445 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS and Mac

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
