### PR TITLE
fix: make (cvc & expiry) text fields inline to avoid content overflow

### DIFF
--- a/src/mobile/src/ui/views/wallet/exchanges/MoonPay/AddPaymentMethod.js
+++ b/src/mobile/src/ui/views/wallet/exchanges/MoonPay/AddPaymentMethod.js
@@ -172,12 +172,16 @@ const renderHtml = (theme, t, customerAddress, customerId) => {
         outline:0;
       }
 
+      .single-row-container {
+        display: flex;
+      }
+
       .field-container {
         display: flex;
         flex-direction: column;
         justify-content: center;
-        margin-bottom: ${height / 25}px;
-        margin-top: ${height / 25}px;
+        margin-bottom: ${height / 35}px;
+        margin-top: ${height / 35}px;
         margin-left: ${width / 20}px;
         margin-right: ${width / 20}px;
       }
@@ -217,13 +221,16 @@ const renderHtml = (theme, t, customerAddress, customerId) => {
       .checkbox-container {
         display: flex;
         align-items: center;
-        flex-wrap: wrap;
         margin-bottom: ${height / 50}px;
         margin-left: ${width / 15}px;
         margin-right: ${width / 15}px;
       }
 
       .checkbox-text {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: center;
         font-family: 'Source Sans Pro', sans-serif;
         font-weight: 400;
         font-size: ${Styling.fontSize2}px;
@@ -259,22 +266,25 @@ const renderHtml = (theme, t, customerAddress, customerId) => {
             </div>
         </div>
 
+
         <div class="field-container">
             <label for="cc-number" class="field-label">${t('moonpay:cardNumber')}</label>
             <span id="cc-number" class="form-field">
             </span>
         </div>
 
-        <div class="field-container">
+        <div class="single-row-container">
+          <div class="field-container">
             <label for="cc-cvc" class="field-label">${t('moonpay:cvc')}</label>
             <span id="cc-cvc" class="form-field">
             </span>
-        </div>
+          </div>
 
-        <div class="field-container">
-            <label for="cc-expiration-date" class="field-label">${t('moonpay:expirationDate')}</label>
-            <span id="cc-expiration-date" class="form-field">
-            </span>
+          <div class="field-container">
+              <label for="cc-expiration-date" class="field-label">${t('moonpay:expirationDate')}</label>
+              <span id="cc-expiration-date" class="form-field">
+              </span>
+          </div>
         </div>
 
         <div class="checkbox-container">

--- a/src/mobile/src/ui/views/wallet/exchanges/MoonPay/AddPaymentMethod.js
+++ b/src/mobile/src/ui/views/wallet/exchanges/MoonPay/AddPaymentMethod.js
@@ -174,14 +174,23 @@ const renderHtml = (theme, t, customerAddress, customerId) => {
 
       .single-row-container {
         display: flex;
+        margin-bottom: ${width / 15}px;
+      }
+
+      .first-field-container {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        margin-top: ${width / 15}px;
+        margin-bottom: ${width / 20}px;
+        margin-left: ${width / 20}px;
+        margin-right: ${width / 20}px;
       }
 
       .field-container {
         display: flex;
         flex-direction: column;
         justify-content: center;
-        margin-bottom: ${height / 35}px;
-        margin-top: ${height / 35}px;
         margin-left: ${width / 20}px;
         margin-right: ${width / 20}px;
       }
@@ -267,7 +276,7 @@ const renderHtml = (theme, t, customerAddress, customerId) => {
         </div>
 
 
-        <div class="field-container">
+        <div class="first-field-container">
             <label for="cc-number" class="field-label">${t('moonpay:cardNumber')}</label>
             <span id="cc-number" class="form-field">
             </span>
@@ -313,7 +322,7 @@ const renderHtml = (theme, t, customerAddress, customerId) => {
   }
 
   function handleCheckbox() {
-    document.getElementsByClassName('checkbox-wrapper')[0].innerHTML = !shouldStoreCardDetails ? 
+    document.getElementsByClassName('checkbox-wrapper')[0].innerHTML = !shouldStoreCardDetails ?
     '<i class="far fa-check-square fa-lg checkbox"></i>' : '<i class="far fa-square fa-lg checkbox"></i>';
 
     shouldStoreCardDetails = !shouldStoreCardDetails;
@@ -561,7 +570,7 @@ class AddPaymentMethod extends PureComponent {
         const { t } = this.props;
 
         return {
-            buttons: () => `  
+            buttons: () => `
           document.getElementsByClassName('button-right')[0].innerHTML = "${t('global:submit')}";
           document.getElementsByClassName('button-left')[0].disabled = false;
           true
@@ -570,7 +579,7 @@ class AddPaymentMethod extends PureComponent {
           setTimeout(function() {
             document.getElementsByClassName('container')[0].style.height = "${height}px";
             document.getElementsByClassName('container')[0].style.webkitTransition = "0.5s height";
-          }, 100);  
+          }, 100);
           true
         `,
         };


### PR DESCRIPTION
# Description

This PR makes (cvc & expiration date) text fields inline so have a consistent spacing on the screen.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on iPhone 8 & 11 simulators

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
