### PR TITLE
Do not allow users to make purchases if purchases are suspended

### DIFF
--- a/src/desktop/src/ui/components/Chart.js
+++ b/src/desktop/src/ui/components/Chart.js
@@ -35,6 +35,8 @@ export class ChartComponent extends PureComponent {
         }).isRequired,
         /** @ignore */
         isAuthenticatedForMoonPay: PropTypes.bool.isRequired,
+        /** Determines if IOTA purchases are suspended */
+        arePurchasesSuspended: PropTypes.bool.isRequired,
         /** @ignore */
         history: PropTypes.shape({
             push: PropTypes.func.isRequired,
@@ -74,6 +76,7 @@ export class ChartComponent extends PureComponent {
 
     render() {
         const {
+            arePurchasesSuspended,
             isAuthenticatedForMoonPay,
             history,
             priceData,
@@ -131,13 +134,19 @@ export class ChartComponent extends PureComponent {
                         <Button
                             variant="secondary"
                             className="outline"
-                            onClick={() =>
-                                history.push(
-                                    isAuthenticatedForMoonPay
+                            onClick={() => {
+                                const getRoute = () => {
+                                    if (arePurchasesSuspended) {
+                                        return '/exchanges/moonpay/purchase-suspended-warning';
+                                    }
+
+                                    return isAuthenticatedForMoonPay
                                         ? '/exchanges/moonpay/select-account'
-                                        : '/exchanges/moonpay',
-                                )
-                            }
+                                        : '/exchanges/moonpay';
+                                };
+
+                                history.push(getRoute());
+                            }}
                         >
                             {t('moonpay:buyIOTA')}
                         </Button>

--- a/src/desktop/src/ui/views/exchanges/MoonPay/Index.js
+++ b/src/desktop/src/ui/views/exchanges/MoonPay/Index.js
@@ -22,6 +22,7 @@ import PurchaseReceipt from 'ui/views/exchanges/MoonPay/PurchaseReceipt';
 import PaymentSuccess from 'ui/views/exchanges/MoonPay/PaymentSuccess';
 import PaymentFailure from 'ui/views/exchanges/MoonPay/PaymentFailure';
 import PaymentPending from 'ui/views/exchanges/MoonPay/PaymentPending';
+import PurchaseSuspendedWarning from 'ui/views/exchanges/MoonPay/PurchaseSuspendedWarning';
 
 import css from './index.scss';
 
@@ -67,6 +68,10 @@ class MoonPay extends React.PureComponent {
                                 <Route path="/exchanges/moonpay/payment-success" component={PaymentSuccess} />
                                 <Route path="/exchanges/moonpay/payment-failure" component={PaymentFailure} />
                                 <Route path="/exchanges/moonpay/payment-pending" component={PaymentPending} />
+                                <Route
+                                    path="/exchanges/moonpay/purchase-suspended-warning"
+                                    component={PurchaseSuspendedWarning}
+                                />
 
                                 <Route
                                     path="/exchanges/moonpay/purchase-limit-warning"

--- a/src/desktop/src/ui/views/exchanges/MoonPay/PurchaseSuspendedWarning.js
+++ b/src/desktop/src/ui/views/exchanges/MoonPay/PurchaseSuspendedWarning.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withTranslation } from 'react-i18next';
+
+import Button from 'ui/components/Button';
+
+import css from './index.scss';
+
+/** MoonPay purchase suspended screen component */
+class PurchaseSuspendedWarning extends React.PureComponent {
+    static propTypes = {
+        /** @ignore */
+        history: PropTypes.shape({
+            push: PropTypes.func.isRequired,
+        }).isRequired,
+        /** @ignore */
+        t: PropTypes.func.isRequired,
+    };
+
+    render() {
+        const { t } = this.props;
+
+        return (
+            <form onSubmit={this.redirect}>
+                <section className={css.long}>
+                    <div>
+                        <p> {t('moonpay:purchasesAreSuspended')}</p>
+                        <p>{t('moonpay:purchasesAreSuspendedExplanation')}</p>
+                    </div>
+                </section>
+                <footer className={css.choiceDefault}>
+                    <div>
+                        <Button
+                            id="to-cancel"
+                            onClick={() => this.props.history.push('/wallet')}
+                            className="square"
+                            variant="primary"
+                        >
+                            {t('global:goBack')}
+                        </Button>
+                    </div>
+                </footer>
+            </form>
+        );
+    }
+}
+
+export default withTranslation()(PurchaseSuspendedWarning);

--- a/src/desktop/src/ui/views/exchanges/MoonPay/ReviewPurchase.js
+++ b/src/desktop/src/ui/views/exchanges/MoonPay/ReviewPurchase.js
@@ -32,6 +32,8 @@ class ReviewPurchase extends React.PureComponent {
         activeTransaction: PropTypes.object,
         /** @ignore */
         t: PropTypes.func.isRequired,
+        /** @ignore */
+        arePurchasesSuspended: PropTypes.bool.isRequired,
     };
 
     componentWillReceiveProps(nextProps) {
@@ -77,10 +79,10 @@ class ReviewPurchase extends React.PureComponent {
     }
 
     render() {
-        const { isCreatingTransaction, createTransaction, children, t } = this.props;
+        const { history, isCreatingTransaction, createTransaction, arePurchasesSuspended, children, t } = this.props;
 
         return (
-            <form onSubmit={createTransaction}>
+            <form onSubmit={() => arePurchasesSuspended ? history.push('/exchanges/moonpay/purchase-suspended-warning'): createTransaction}>
                 <section className={css.withSummary}>
                     <div>
                         <p>{t('moonpay:reviewYourPurchase')}</p>
@@ -93,7 +95,7 @@ class ReviewPurchase extends React.PureComponent {
                         <Button
                             disabled={isCreatingTransaction}
                             id="to-cancel"
-                            onClick={() => this.props.history.push('/exchanges/moonpay/select-payment-card')}
+                            onClick={() => history.push('/exchanges/moonpay/select-payment-card')}
                             className="square"
                             variant="dark"
                         >

--- a/src/desktop/src/ui/views/exchanges/MoonPay/WithPurchaseSummary.js
+++ b/src/desktop/src/ui/views/exchanges/MoonPay/WithPurchaseSummary.js
@@ -17,6 +17,7 @@ import {
     getPaymentCardBrand,
     getPaymentCardLastDigits,
     getActiveTransaction,
+    arePurchasesSuspended
 } from 'selectors/exchanges/MoonPay';
 import { createTransaction } from 'actions/exchanges/MoonPay';
 import { generateAlert } from 'actions/alerts';
@@ -78,6 +79,8 @@ export default function withPurchaseSummary(WrappedComponent) {
             generateAlert: PropTypes.func.isRequired,
             /** @ignore */
             t: PropTypes.func.isRequired,
+            /** @ignore */
+            arePurchasesSuspended: PropTypes.bool.isRequired,
         };
 
         constructor(props) {
@@ -186,6 +189,7 @@ export default function withPurchaseSummary(WrappedComponent) {
                 expiryInfo,
                 activeTransaction,
                 generateAlert,
+                arePurchasesSuspended
             } = this.props;
 
             const receiveAmount = this.getReceiveAmount();
@@ -202,6 +206,7 @@ export default function withPurchaseSummary(WrappedComponent) {
                     isFetchingTransactionDetails={isFetchingTransactionDetails}
                     hasErrorFetchingTransactionDetails={hasErrorFetchingTransactionDetails}
                     generateAlert={generateAlert}
+                    arePurchasesSuspended={arePurchasesSuspended}
                 >
                     <div className={css.summary}>
                         <div>
@@ -277,6 +282,7 @@ export default function withPurchaseSummary(WrappedComponent) {
         hasCompletedAdvancedIdentityVerification: hasCompletedAdvancedIdentityVerification(state),
         isPurchaseLimitIncreaseAllowed: isLimitIncreaseAllowed(state),
         activeTransaction: getActiveTransaction(state),
+        arePurchasesSuspended: arePurchasesSuspended(state),
     });
 
     const mapDispatchToProps = {

--- a/src/mobile/src/ui/components/Chart.js
+++ b/src/mobile/src/ui/components/Chart.js
@@ -156,6 +156,8 @@ class Chart extends PureComponent {
         animateChartOnMount: PropTypes.bool.isRequired,
         /** @ignore */
         isAuthenticatedForMoonPay: PropTypes.bool.isRequired,
+        /** Determines if IOTA purchases are suspended */
+        arePurchasesSuspended: PropTypes.bool.isRequired,
     };
 
     constructor(props) {
@@ -177,6 +179,7 @@ class Chart extends PureComponent {
 
     render() {
         const {
+            arePurchasesSuspended,
             isAuthenticatedForMoonPay,
             t,
             priceData,
@@ -202,7 +205,17 @@ class Chart extends PureComponent {
                         <Text style={[styles.buttonText, textColor]}>{priceData.currency}</Text>
                     </TouchableOpacity>
                     <TouchableOpacity
-                        onPress={() => navigator.push(isAuthenticatedForMoonPay ? 'selectAccount' : 'landing')}
+                        onPress={() => {
+                            const getRoute = () => {
+                                if (arePurchasesSuspended) {
+                                    return 'purchaseSuspendedWarning';
+                                }
+
+                                return isAuthenticatedForMoonPay ? 'selectAccount' : 'landing';
+                            };
+
+                            navigator.push(getRoute());
+                        }}
                         style={[
                             styles.midButtonContainer,
                             {

--- a/src/mobile/src/ui/routes/navigation.js
+++ b/src/mobile/src/ui/routes/navigation.js
@@ -49,6 +49,7 @@ import MoonPaySelectPaymentCard from 'ui/views/wallet/exchanges/MoonPay/SelectPa
 import MoonPayPaymentSuccess from 'ui/views/wallet/exchanges/MoonPay/PaymentSuccess';
 import MoonPayPaymentFailure from 'ui/views/wallet/exchanges/MoonPay/PaymentFailure';
 import MoonPayPaymentPending from 'ui/views/wallet/exchanges/MoonPay/PaymentPending';
+import MoonPayPurchaseSuspendedWarning from 'ui/views/wallet/exchanges/MoonPay/PurchaseSuspendedWarning';
 
 import { isIPhoneX, isAndroid } from 'libs/device';
 
@@ -106,6 +107,12 @@ export default function registerScreens(store, Provider) {
     Navigation.registerComponentWithRedux('paymentSuccess', () => applyHOCs(MoonPayPaymentSuccess), Provider, store);
     Navigation.registerComponentWithRedux('paymentFailure', () => applyHOCs(MoonPayPaymentFailure), Provider, store);
     Navigation.registerComponentWithRedux('paymentPending', () => applyHOCs(MoonPayPaymentPending), Provider, store);
+    Navigation.registerComponentWithRedux(
+        'purchaseSuspendedWarning',
+        () => applyHOCs(MoonPayPurchaseSuspendedWarning),
+        Provider,
+        store,
+    );
 
     Navigation.registerComponentWithRedux('migration', () => applyHOCs(MigrationComponent), Provider, store);
     Navigation.registerComponentWithRedux('home', () => applyHOCs(Home), Provider, store);

--- a/src/mobile/src/ui/views/wallet/exchanges/MoonPay/PurchaseSuspendedWarning.js
+++ b/src/mobile/src/ui/views/wallet/exchanges/MoonPay/PurchaseSuspendedWarning.js
@@ -1,0 +1,110 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withTranslation } from 'react-i18next';
+import { StyleSheet, View, Text } from 'react-native';
+import navigator from 'libs/navigation';
+import SingleFooterButton from 'ui/components/SingleFooterButton';
+import InfoBox from 'ui/components/InfoBox';
+import { width, height } from 'libs/dimensions';
+import { Styling } from 'ui/theme/general';
+import Header from 'ui/components/Header';
+import AnimatedComponent from 'ui/components/AnimatedComponent';
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    topContainer: {
+        flex: 0.9,
+        alignItems: 'center',
+        justifyContent: 'flex-start',
+    },
+    midContainer: {
+        flex: 3.1,
+        alignItems: 'center',
+        textAlign: 'center',
+    },
+    bottomContainer: {
+        flex: 0.5,
+        alignItems: 'center',
+        justifyContent: 'flex-end',
+    },
+    infoText: {
+        fontFamily: 'SourceSansPro-Light',
+        fontSize: Styling.fontSize6,
+        textAlign: 'center',
+        backgroundColor: 'transparent',
+    },
+    infoTextRegular: {
+        fontFamily: 'SourceSansPro-Regular',
+        textAlign: 'center',
+        fontSize: Styling.fontSize3,
+        backgroundColor: 'transparent',
+    },
+});
+
+/** MoonPay purchase limit screen component */
+class PurchaseLimitWarning extends Component {
+    static propTypes = {
+        /** @ignore */
+        t: PropTypes.func.isRequired,
+        /** @ignore */
+        theme: PropTypes.object.isRequired,
+        /** Component ID */
+        componentId: PropTypes.string.isRequired,
+    };
+
+    /**
+     * Pops the active screen from the navigation stack
+     * @method goBack
+     */
+    goBack() {
+        navigator.pop(this.props.componentId);
+    }
+
+    render() {
+        const {
+            t,
+            theme: { body },
+        } = this.props;
+        const textColor = { color: body.color };
+
+        return (
+            <View style={[styles.container, { backgroundColor: body.bg }]}>
+                <View style={styles.topContainer}>
+                    <AnimatedComponent
+                        animationInType={['slideInRight', 'fadeIn']}
+                        animationOutType={['slideOutLeft', 'fadeOut']}
+                        delay={400}
+                    >
+                        <Header iconSize={width / 3} iconName="moonpay" textColor={body.color} />
+                    </AnimatedComponent>
+                </View>
+                <View style={styles.midContainer}>
+                    <View style={{ flex: 0.4 }} />
+                    <AnimatedComponent
+                        animationInType={['slideInRight', 'fadeIn']}
+                        animationOutType={['slideOutLeft', 'fadeOut']}
+                        delay={200}
+                    >
+                        <InfoBox>
+                            <Text style={[styles.infoText, textColor]}>{t('moonpay:purchasesAreSuspended')}</Text>
+                            <Text style={[styles.infoTextRegular, textColor, { paddingTop: height / 30 }]}>
+                                {t('moonpay:purchasesAreSuspendedExplanation')}
+                            </Text>
+                        </InfoBox>
+                    </AnimatedComponent>
+                </View>
+                <View style={styles.bottomContainer}>
+                    <AnimatedComponent animationInType={['fadeIn']} animationOutType={['fadeOut']}>
+                        <SingleFooterButton onButtonPress={() => this.goBack()} buttonText={t('global:goBack')} />
+                    </AnimatedComponent>
+                </View>
+            </View>
+        );
+    }
+}
+
+export default withTranslation()(PurchaseLimitWarning);

--- a/src/mobile/src/ui/views/wallet/exchanges/MoonPay/PurchaseSuspendedWarning.js
+++ b/src/mobile/src/ui/views/wallet/exchanges/MoonPay/PurchaseSuspendedWarning.js
@@ -52,8 +52,6 @@ class PurchaseLimitWarning extends Component {
         t: PropTypes.func.isRequired,
         /** @ignore */
         theme: PropTypes.object.isRequired,
-        /** Component ID */
-        componentId: PropTypes.string.isRequired,
     };
 
     /**
@@ -61,7 +59,7 @@ class PurchaseLimitWarning extends Component {
      * @method goBack
      */
     goBack() {
-        navigator.pop(this.props.componentId);
+        navigator.setStackRoot('home');
     }
 
     render() {

--- a/src/mobile/src/ui/views/wallet/exchanges/MoonPay/ReviewPurchase.js
+++ b/src/mobile/src/ui/views/wallet/exchanges/MoonPay/ReviewPurchase.js
@@ -45,6 +45,8 @@ class ReviewPurchase extends Component {
         createTransaction: PropTypes.func.isRequired,
         /** @ignore */
         activeTransaction: PropTypes.object,
+        /** @ignore */
+        arePurchasesSuspended: PropTypes.bool.isRequired,
     };
 
     componentWillReceiveProps(nextProps) {
@@ -105,7 +107,7 @@ class ReviewPurchase extends Component {
     }
 
     render() {
-        const { isCreatingTransaction, t, theme } = this.props;
+        const { isCreatingTransaction, arePurchasesSuspended, t, theme } = this.props;
 
         return (
             <View style={[styles.container, { backgroundColor: theme.body.bg }]}>
@@ -123,7 +125,7 @@ class ReviewPurchase extends Component {
                     <AnimatedComponent animationInType={['fadeIn']} animationOutType={['fadeOut']}>
                         <DualFooterButtons
                             onLeftButtonPress={() => this.goBack()}
-                            onRightButtonPress={() => this.props.createTransaction()}
+                            onRightButtonPress={() => arePurchasesSuspended ? this.redirectToScreen('purchaseSuspendedWarning') : this.props.createTransaction()}
                             isRightButtonLoading={isCreatingTransaction}
                             disableLeftButton={isCreatingTransaction}
                             leftButtonText={t('global:goBack')}

--- a/src/mobile/src/ui/views/wallet/exchanges/MoonPay/WithPurchaseSummary.js
+++ b/src/mobile/src/ui/views/wallet/exchanges/MoonPay/WithPurchaseSummary.js
@@ -20,6 +20,7 @@ import {
     getPaymentCardBrand,
     getPaymentCardLastDigits,
     getActiveTransaction,
+    arePurchasesSuspended
 } from 'shared-modules/selectors/exchanges/MoonPay';
 import { createTransaction } from 'shared-modules/actions/exchanges/MoonPay';
 import { generateAlert } from 'shared-modules/actions/alerts';
@@ -114,6 +115,8 @@ export default function withPurchaseSummary(WrappedComponent) {
             activeTransaction: PropTypes.object,
             /** @ignore */
             generateAlert: PropTypes.func.isRequired,
+            /** @ignore */
+            arePurchasesSuspended: PropTypes.bool.isRequired,
         };
 
         constructor(props) {
@@ -365,6 +368,7 @@ export default function withPurchaseSummary(WrappedComponent) {
                 componentId,
                 activeTransaction,
                 generateAlert,
+                arePurchasesSuspended
             } = this.props;
 
             return (
@@ -378,6 +382,7 @@ export default function withPurchaseSummary(WrappedComponent) {
                     componentId={componentId}
                     generateAlert={generateAlert}
                     renderChildren={(config) => this.renderChildren(config)}
+                    arePurchasesSuspended={arePurchasesSuspended}
                 />
             );
         }
@@ -402,6 +407,7 @@ export default function withPurchaseSummary(WrappedComponent) {
         hasCompletedAdvancedIdentityVerification: hasCompletedAdvancedIdentityVerification(state),
         isPurchaseLimitIncreaseAllowed: isLimitIncreaseAllowed(state),
         activeTransaction: getActiveTransaction(state),
+        arePurchasesSuspended: arePurchasesSuspended(state),
     });
 
     const mapDispatchToProps = {

--- a/src/shared/containers/components/Chart.js
+++ b/src/shared/containers/components/Chart.js
@@ -9,6 +9,7 @@ import { setChartCurrency, setChartTimeframe } from '../../actions/settings';
 import { getCurrencySymbol } from '../../libs/currency';
 
 import { getThemeFromState } from '../../selectors/global';
+import { arePurchasesSuspended } from '../../selectors/exchanges/MoonPay';
 
 /**
  * Chart component container
@@ -26,6 +27,7 @@ export default function withChartData(ChartComponent) {
             /** @ignore */
             isAuthenticated: PropTypes.bool.isRequired,
             history: PropTypes.object.isRequired,
+            arePurchasesSuspended: PropTypes.bool.isRequired,
         };
 
         currencies = ['USD', 'EUR', 'BTC', 'ETH']; // eslint-disable-line react/sort-comp
@@ -91,7 +93,7 @@ export default function withChartData(ChartComponent) {
         };
 
         render() {
-            const { history, isAuthenticated, marketData, settings, theme, t } = this.props;
+            const { arePurchasesSuspended, history, isAuthenticated, marketData, settings, theme, t } = this.props;
 
             const currencyData = get(marketData.chartData, settings.chartCurrency.toLowerCase());
             const rawData = get(currencyData, settings.chartTimeframe) || [];
@@ -102,6 +104,7 @@ export default function withChartData(ChartComponent) {
                 return { x: index, y: parseFloat(price), time: time };
             });
             const chartProps = {
+                arePurchasesSuspended,
                 history,
                 isAuthenticatedForMoonPay: isAuthenticated,
                 setCurrency: this.changeCurrency,
@@ -139,6 +142,7 @@ export default function withChartData(ChartComponent) {
         settings: state.settings,
         theme: getThemeFromState(state),
         isAuthenticated: state.exchanges.moonpay.isAuthenticated,
+        arePurchasesSuspended: arePurchasesSuspended(state),
     });
 
     const mapDispatchToProps = {

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -394,7 +394,9 @@
         "idRejection": "Your identity check was rejected.",
         "cardNotSupported": "Your card is not supported. Please try again with a different card.",
         "cancelled": "The payment was cancelled.",
-        "storeCardDetails": "Store card details in MoonPay for faster checkout."
+        "storeCardDetails": "Store card details in MoonPay for faster checkout.",
+        "purchasesAreSuspended": "Purchases are suspended.",
+        "purchasesAreSuspendedExplanation": "MoonPay purchases are currently suspended. Please try again later."
     },
     "home": {
         "balance": "BALANCE",

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -395,8 +395,8 @@
         "cardNotSupported": "Your card is not supported. Please try again with a different card.",
         "cancelled": "The payment was cancelled.",
         "storeCardDetails": "Store card details in MoonPay for faster checkout.",
-        "purchasesAreSuspended": "Purchases are suspended.",
-        "purchasesAreSuspendedExplanation": "MoonPay purchases are currently suspended. Please try again later."
+        "purchasesAreSuspended": "Purchases are suspended",
+        "purchasesAreSuspendedExplanation": "Unfortunately, MoonPay purchases are currently suspended. Please try again later."
     },
     "home": {
         "balance": "BALANCE",

--- a/src/shared/selectors/exchanges/MoonPay/index.js
+++ b/src/shared/selectors/exchanges/MoonPay/index.js
@@ -11,6 +11,7 @@ import {
     BASIC_IDENITY_VERIFICATION_LEVEL_NAME,
     ADVANCED_IDENITY_VERIFICATION_LEVEL_NAME,
     COUNTRY_CODES_REQUIRING_STATE,
+    IOTA_CURRENCY_CODE,
 } from '../../../exchanges/MoonPay';
 
 /**
@@ -470,4 +471,21 @@ export const getAlpha3CodeForIPAddress = createSelector(getExchangesFromState, (
     const ipAddress = exchanges.moonpay.ipAddress;
 
     return get(ipAddress, 'alpha3');
+});
+
+/**
+ * Determines if MoonPay has suspended IOTA purchases
+ *
+ * @method arePurchasesSuspended
+ *
+ * @param {object} state
+ *
+ * @returns {array}
+ */
+export const arePurchasesSuspended = createSelector(getExchangesFromState, (exchanges) => {
+    const currencies = exchanges.moonpay.currencies;
+
+    const currency = find(currencies, (currency) => currency.code === IOTA_CURRENCY_CODE);
+
+    return get(currency, 'isSuspended') === true;
 });


### PR DESCRIPTION
## Description

Redirect users to a warning screen if IOTA purchases are suspended. 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Manually tested mobile (iOS) and desktop (macOS)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
