### PR TITLE
fix: store complete token details in store

### DIFF
--- a/src/desktop/src/ui/views/exchanges/MoonPay/AddPaymentMethod.js
+++ b/src/desktop/src/ui/views/exchanges/MoonPay/AddPaymentMethod.js
@@ -173,12 +173,10 @@ class AddPaymentMethod extends React.PureComponent {
                                 t('moonpay:duplicateCardExplanation'),
                             );
                         } else {
-                            const tokenId = get(response, 'id');
-
                             if (shouldStoreCardDetails) {
-                                this.props.createPaymentCard(tokenId);
+                                this.props.createPaymentCard(response.id);
                             } else {
-                                this.props.updateCustomerInfo({ tokenId });
+                                this.props.updateCustomerInfo({ token: response });
                                 this.props.history.push('/exchanges/moonpay/review-purchase');
                             }
                         }


### PR DESCRIPTION
# Description

We store token (object) details in redux store if a user does not opt for storing his/her payment card details on MoonPay servers. However, on desktop we were only storing the token id (and not the complete token object) hence it was giving undefined values on Review Purchase screen.

This commit fixes the issue by storing the complete token details in store.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manually tested desktop dev mode (macOS)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
