### PR TITLE
fix: rebroadcast bundle during promotion

### DIFF
--- a/src/shared/actions/polling.js
+++ b/src/shared/actions/polling.js
@@ -357,8 +357,8 @@ export const promoteTransfer = (bundleHash, accountName, seedStore, quorum = tru
 
     let accountState = selectedAccountStateFactory(accountName)(getState());
 
-    const getTailTransactionsForThisBundleHash = (transactions) =>
-        filter(transactions, (transaction) => transaction.bundle === bundleHash && transaction.currentIndex === 0);
+    const getTransactionsForThisBundleHash = (transactions) =>
+        filter(transactions, (transaction) => transaction.bundle === bundleHash);
 
     const executePrePromotionChecks = (settings, withQuorum) => () => {
         return syncAccount(
@@ -396,7 +396,13 @@ export const promoteTransfer = (bundleHash, accountName, seedStore, quorum = tru
                     throw new Error(Errors.BUNDLE_NO_LONGER_FUNDED);
                 }
 
-                return findPromotableTail()(getTailTransactionsForThisBundleHash(accountState.transactions), 0);
+                return findPromotableTail()(
+                    filter(
+                        getTransactionsForThisBundleHash(accountState.transactions),
+                        (transaction) => transaction.currentIndex === 0,
+                    ),
+                    0,
+                );
             });
     };
 
@@ -412,7 +418,7 @@ export const promoteTransfer = (bundleHash, accountName, seedStore, quorum = tru
                 forceTransactionPromotion(
                     accountName,
                     result,
-                    getTailTransactionsForThisBundleHash(accountState.transactions),
+                    getTransactionsForThisBundleHash(accountState.transactions),
                     false,
                     // Make sure proof-of-work is offloaded when it comes to auto promotion
                     extend(

--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -1,5 +1,6 @@
 import assign from 'lodash/assign';
 import extend from 'lodash/extend';
+import cloneDeep from 'lodash/cloneDeep';
 import has from 'lodash/has';
 import head from 'lodash/head';
 import find from 'lodash/find';
@@ -9,6 +10,7 @@ import orderBy from 'lodash/orderBy';
 import filter from 'lodash/filter';
 import isEmpty from 'lodash/isEmpty';
 import some from 'lodash/some';
+import isUndefined from 'lodash/isUndefined';
 import get from 'lodash/get';
 import size from 'lodash/size';
 import every from 'lodash/every';
@@ -17,7 +19,7 @@ import uniq from 'lodash/uniq';
 import { verifyCDA } from '@iota/cda';
 import { iota } from '../libs/iota';
 import {
-    replayBundleAsync,
+    replayLocallyStoredBundleAsync,
     promoteTransactionAsync,
     getTransactionsToApproveAsync,
     attachToTangleAsync,
@@ -219,8 +221,8 @@ export const promoteTransaction = (bundleHash, accountName, seedStore, quorum = 
     }
 
     let accountState = selectedAccountStateFactory(accountName)(getState());
-    const getTailTransactionsForThisBundleHash = (transactions) =>
-        filter(transactions, (transaction) => transaction.bundle === bundleHash && transaction.currentIndex === 0);
+    const getTransactionsForThisBundleHash = (transactions) =>
+        filter(transactions, (transaction) => transaction.bundle === bundleHash);
 
     const executePrePromotionChecks = (settings, withQuorum) => () => {
         return syncAccount(
@@ -258,7 +260,13 @@ export const promoteTransaction = (bundleHash, accountName, seedStore, quorum = 
                     throw new Error(Errors.BUNDLE_NO_LONGER_VALID);
                 }
 
-                return findPromotableTail()(getTailTransactionsForThisBundleHash(accountState.transactions), 0);
+                return findPromotableTail()(
+                    filter(
+                        getTransactionsForThisBundleHash(accountState.transactions),
+                        (transaction) => transaction.currentIndex === 0,
+                    ),
+                    0,
+                );
             });
     };
 
@@ -275,7 +283,7 @@ export const promoteTransaction = (bundleHash, accountName, seedStore, quorum = 
                 forceTransactionPromotion(
                     accountName,
                     result,
-                    getTailTransactionsForThisBundleHash(accountState.transactions),
+                    getTransactionsForThisBundleHash(accountState.transactions),
                     true,
                     // If proof of work configuration is set to remote,
                     // Extend seedStore object with offloadPow
@@ -346,7 +354,7 @@ export const promoteTransaction = (bundleHash, accountName, seedStore, quorum = 
  *   @method forceTransactionPromotion
  *   @param {string} accountName
  *   @param {boolean | object} consistentTail
- *   @param {array} tailTransactionHashes
+ *   @param {array} transactions
  *   @param {boolean} shouldGenerateAlert
  *   @param {object} seedStore
  *   @param {number} maxReplays - Maximum number of reattachments if promotion fails because of transaction inconsistency
@@ -357,7 +365,7 @@ export const promoteTransaction = (bundleHash, accountName, seedStore, quorum = 
 export const forceTransactionPromotion = (
     accountName,
     consistentTail,
-    tailTransactionHashes,
+    transactions,
     shouldGenerateAlert,
     seedStore,
     maxReplays = 1,
@@ -365,6 +373,8 @@ export const forceTransactionPromotion = (
 ) => (dispatch, getState) => {
     let replayCount = 0;
     let promotionAttempt = 0;
+
+    let transactionsCopy = cloneDeep(transactions);
 
     const promote = (settings) => (tailTransaction) => {
         const { hash, attachmentTimestamp } = tailTransaction;
@@ -382,8 +392,20 @@ export const forceTransactionPromotion = (
                 // If promotion attempt on this reference (hash) hasn't exceeded maximum promotion attempts
                 promotionAttempt < maxPromotionAttempts
             ) {
+                const bundles = constructBundlesFromTransactions(transactionsCopy);
+
+                const trytes = map(
+                    head(
+                        filter(
+                            bundles,
+                            (bundle) => !isUndefined(find(bundle, (transaction) => transaction.hash === hash)),
+                        ),
+                    ),
+                    (transaction) => iota.utils.transactionTrytes(transaction),
+                );
+
                 // Retry promotion on same reference (hash)
-                return promote(settings)(tailTransaction);
+                return storeAndBroadcastAsync(settings)(trytes).then(() => promote(settings)(tailTransaction));
             } else if (
                 isTransactionInconsistent &&
                 promotionAttempt === maxPromotionAttempts &&
@@ -407,20 +429,23 @@ export const forceTransactionPromotion = (
     const reattachAndPromote = (settings) => () => {
         // Increment the reattachment's count
         replayCount += 1;
-        // Grab first tail transaction hash
-        const tailTransaction = head(tailTransactionHashes);
-        const hash = tailTransaction.hash;
 
-        return replayBundleAsync(
+        const bundle = head(constructBundlesFromTransactions(transactionsCopy));
+
+        return replayLocallyStoredBundleAsync(
             settings,
             seedStore,
-        )(hash).then((reattachment) => {
+        )(bundle).then((reattachment) => {
+            transactionsCopy = [...transactionsCopy, ...reattachment];
+
+            const tailTransaction = find(reattachment, { currentIndex: 0 });
+
             if (shouldGenerateAlert) {
                 dispatch(
                     generateAlert(
                         'success',
                         i18next.t('global:reattached'),
-                        i18next.t('global:reattachedExplanation', { hash }),
+                        i18next.t('global:reattachedExplanation', { hash: tailTransaction.hash }),
                         2500,
                     ),
                 );
@@ -434,7 +459,6 @@ export const forceTransactionPromotion = (
 
             // Update redux store
             dispatch(updateAccountAfterReattachment(newState));
-            const tailTransaction = find(reattachment, { currentIndex: 0 });
 
             return promote(settings)(tailTransaction);
         });

--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -378,7 +378,6 @@ export const forceTransactionPromotion = (
 
     const promote = (settings) => (tailTransaction) => {
         const { hash, attachmentTimestamp } = tailTransaction;
-
         promotionAttempt += 1;
 
         return promoteTransactionAsync(
@@ -470,16 +469,16 @@ export const forceTransactionPromotion = (
         })(getState()),
     );
 
-    if (has(consistentTail, 'hash')) {
-        return manager
-            .withRetries()(promote)(consistentTail)
-            .then((result) => {
-                return result;
-            });
-    }
+    const _execute = (settings) => () => {
+        if (has(consistentTail, 'hash')) {
+            return promote(settings)(consistentTail);
+        }
+
+        return reattachAndPromote(settings)();
+    };
 
     return manager
-        .withRetries()(reattachAndPromote)()
+        .withRetries()(_execute)()
         .then((result) => {
             return result;
         });

--- a/src/shared/libs/errors.js
+++ b/src/shared/libs/errors.js
@@ -25,7 +25,7 @@ export default {
     INVALID_BUNDLE_CONSTRUCTED_WITH_LOCAL_POW: 'Invalid bundle constructed with local proof-of-work.',
     INVALID_PARAMETERS: 'Invalid parameters.',
     ALREADY_SPENT_FROM_ADDRESSES: 'Addresses used in this bundle have already been spent from.',
-    TRANSACTION_IS_INCONSISTENT: 'The transaction you are retrying is inconsistent.',
+    TRANSACTION_IS_INCONSISTENT: 'Transaction is inconsistent',
     ADDRESS_METADATA_LENGTH_MISMATCH: 'Address metadata length mismatch.',
     SOMETHING_WENT_WRONG_DURING_INPUT_SELECTION: 'Something went wrong during input selection.',
     NO_NODE_TO_RETRY: 'No nodes are available to retry the request.',

--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -24,7 +24,7 @@ import reduce from 'lodash/reduce';
 import transform from 'lodash/transform';
 import orderBy from 'lodash/orderBy';
 import xor from 'lodash/xor';
-import { DEFAULT_TAG, DEFAULT_MIN_WEIGHT_MAGNITUDE, BUNDLE_OUTPUTS_THRESHOLD } from '../../config';
+import { DEFAULT_TAG, DEFAULT_MIN_WEIGHT_MAGNITUDE, BUNDLE_OUTPUTS_THRESHOLD, __DEV__ } from '../../config';
 import { iota } from './index';
 import { accumulateBalance } from './addresses';
 import {
@@ -120,18 +120,29 @@ export const findPromotableTail = (settings) => (tails, idx) => {
     }
 
     const thisTail = tailsAboveMaxDepth[idx];
+    const _isAboveMaxDepth = isAboveMaxDepth(get(thisTail, 'attachmentTimestamp'));
 
-    return isPromotable(settings)(get(thisTail, 'hash'))
-        .then((state) => {
-            // (Temporarily) Allow transaction to promote even if consistency check fails
-            if (state === true || isAboveMaxDepth(get(thisTail, 'attachmentTimestamp'))) {
-                return thisTail;
-            }
+    // If tail is above max depth, skip checkConsistency call and use this tail as a reference for promotion
+    return _isAboveMaxDepth
+        ? Promise.resolve(thisTail)
+        : isPromotable(settings)(get(thisTail, 'hash'))
+              .then((state) => {
+                  if (state === true) {
+                      return thisTail;
+                  }
 
-            idx += 1;
-            return findPromotableTail(settings)(tailsAboveMaxDepth, idx);
-        })
-        .catch(() => false);
+                  idx += 1;
+                  return findPromotableTail(settings)(tailsAboveMaxDepth, idx);
+              })
+              .catch((error) => {
+                  if (__DEV__) {
+                      /* eslint-disable no-console */
+                      console.log(error);
+                      /* eslint-enable no-console */
+                  }
+
+                  return false;
+              });
 };
 
 /**

--- a/src/shared/libs/iota/transfers.js
+++ b/src/shared/libs/iota/transfers.js
@@ -180,7 +180,10 @@ export const prepareTransferArray = (address, value, message, addressData, tag =
     const isZeroValueTransaction = value === 0;
 
     if (isZeroValueTransaction) {
-        return includes(map(addressData, (addressObject) => addressObject.address), iota.utils.noChecksum(address))
+        return includes(
+            map(addressData, (addressObject) => addressObject.address),
+            iota.utils.noChecksum(address),
+        )
             ? [transfer]
             : [transfer, assign({}, transfer, { address: firstAddress })];
     }
@@ -411,10 +414,13 @@ export const normaliseBundle = (bundle, addressData, tailTransactions, persisten
         incoming: isReceivedTransfer(bundle, addresses),
         transferValue: getTransferValue(inputs, outputs, addresses),
         message: computeTransactionMessage(bundle),
-        tailTransactions: map(filter(tailTransactions, (tx) => tx.bundle === bundleHash), (tx) => ({
-            hash: tx.hash,
-            attachmentTimestamp: tx.attachmentTimestamp,
-        })),
+        tailTransactions: map(
+            filter(tailTransactions, (tx) => tx.bundle === bundleHash),
+            (tx) => ({
+                hash: tx.hash,
+                attachmentTimestamp: tx.attachmentTimestamp,
+            }),
+        ),
     };
 };
 
@@ -513,7 +519,7 @@ export const syncTransactions = (settings) => (diff, existingTransactions) => {
  *  @returns {array}
  **/
 export const getTransactionsDiff = (existingHashes, newHashes) => {
-    return xor(existingHashes, newHashes);
+    return filter(xor(existingHashes, newHashes), (hash) => !includes(existingHashes, hash));
 };
 
 /**
@@ -791,9 +797,10 @@ export const isFundedBundle = (settings, withQuorum) => (bundle) => {
         return Promise.reject(new Error(Errors.EMPTY_BUNDLE_PROVIDED));
     }
 
-    return getBalancesAsync(settings, withQuorum)(
-        reduce(bundle, (acc, tx) => (tx.value < 0 ? [...acc, tx.address] : acc), []),
-    ).then((balances) => {
+    return getBalancesAsync(
+        settings,
+        withQuorum,
+    )(reduce(bundle, (acc, tx) => (tx.value < 0 ? [...acc, tx.address] : acc), [])).then((balances) => {
         return (
             reduce(bundle, (acc, tx) => (tx.value < 0 ? acc + Math.abs(tx.value) : acc), 0) <=
             accumulateBalance(map(balances.balances, Number))
@@ -832,7 +839,10 @@ export const filterNonFundedBundles = (settings, withQuorum) => (bundles) => {
         filterZeroValueBundles(bundles),
         (promise, bundle) => {
             return promise.then((result) => {
-                return isFundedBundle(settings, withQuorum)(bundle).then((isFunded) => {
+                return isFundedBundle(
+                    settings,
+                    withQuorum,
+                )(bundle).then((isFunded) => {
                     if (isFunded) {
                         return [...result, bundle];
                     }
@@ -907,7 +917,10 @@ export const promoteTransactionTilConfirmed = (settings, seedStore) => (
             const { hash, attachmentTimestamp } = tailTransaction;
 
             // Promote transaction
-            return promoteTransactionAsync(settings, seedStore)(hash)
+            return promoteTransactionAsync(
+                settings,
+                seedStore,
+            )(hash)
                 .then(() => {
                     return _promote(tailTransaction);
                 })
@@ -931,7 +944,10 @@ export const promoteTransactionTilConfirmed = (settings, seedStore) => (
         const tailTransaction = head(tailTransactionsClone);
         const hash = tailTransaction.hash;
 
-        return replayBundleAsync(settings, seedStore)(hash).then((reattachment) => {
+        return replayBundleAsync(
+            settings,
+            seedStore,
+        )(hash).then((reattachment) => {
             const tailTransaction = find(reattachment, { currentIndex: 0 });
             // Add newly reattached transaction
             tailTransactionsClone.push(tailTransaction);


### PR DESCRIPTION
# Description

This PR ensures that the bundles are rebroadcasted during promotion on the nodes where the complete bundle is not present. 

Fixes https://github.com/iotaledger/trinity-wallet/issues/2414
Also related https://github.com/iotaledger/iri/issues/1709

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Manually tested (on desktop) by manually promoting transactions 

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
