### PR TITLE
fix/desktop: currency in moonpay warning alerts

### DIFF
--- a/src/desktop/src/ui/views/exchanges/MoonPay/AddAmount.js
+++ b/src/desktop/src/ui/views/exchanges/MoonPay/AddAmount.js
@@ -349,13 +349,13 @@ class AddAmount extends React.PureComponent {
             this.props.generateAlert(
                 'error',
                 t('moonpay:notEnoughAmount'),
-                t('moonpay:notEnoughAmountExplanation', { amount: `€${MINIMUM_TRANSACTION_SIZE}` }),
+                t('moonpay:notEnoughAmountExplanation', { amount: this.getCurrencySymbol() + MINIMUM_TRANSACTION_SIZE }),
             );
         } else if (fiatAmount > MAXIMUM_TRANSACTION_SIZE) {
             this.props.generateAlert(
                 'error',
                 t('moonpay:amountTooHigh'),
-                t('moonpay:amountTooHighExplanation', { amount: `€${MAXIMUM_TRANSACTION_SIZE}` }),
+                t('moonpay:amountTooHighExplanation', { amount: this.getCurrencySymbol() + MAXIMUM_TRANSACTION_SIZE }),
             );
         } else {
             if (isFetchingCurrencyQuote || shouldGetLatestCurrencyQuote) {


### PR DESCRIPTION
# Description

Fixes incorrect currency symbol in MoonPay desktop alerts.

Fixes #2503

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Mac.

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code

