### PR TITLE
Fix: Check app ready state on activate event

### DIFF
--- a/src/desktop/native/Index.js
+++ b/src/desktop/native/Index.js
@@ -419,7 +419,9 @@ app.on('before-quit', () => {
  */
 app.on('activate', () => {
     if (windows.main === null) {
-        createWindow();
+        if (app.isReady()) {
+            createWindow();
+        }
     } else if (!windows.main.isVisible()) {
         windows.main.show();
     }


### PR DESCRIPTION
# Description

Check app ready state on activate event to prevent creating a BrowserWindow before it's possible.

Fixes # (issue)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on macOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code