### PR TITLE
Removes duplicate condition in makeTransaction

### DIFF
--- a/src/shared/actions/transfers.js
+++ b/src/shared/actions/transfers.js
@@ -576,10 +576,6 @@ export const makeTransaction = (seedStore, receiveAddress, value, message, accou
                     throw new Error(Errors.CANNOT_SEND_TO_OWN_ADDRESS);
                 }
 
-                if (isSendingToAnyInputAddress) {
-                    throw new Error(Errors.CANNOT_SEND_TO_OWN_ADDRESS);
-                }
-
                 return getAddressDataUptoRemainder(settings, withQuorum)(
                     accountState.addressData,
                     accountState.transactions,


### PR DESCRIPTION
# Description

Removes a redundant condition in `makeTransaction` which checks twice whether any output address is an input address.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
