### PR TITLE
chore/desktop: bump to 1.2.2

### DIFF
--- a/src/desktop/npm-shrinkwrap.json
+++ b/src/desktop/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "trinity-desktop",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trinity-desktop",
   "productName": "Trinity",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "url": "https://trinity.iota.org",
   "homepage": "https://trinity.iota.org",
   "description": "Desktop wallet for IOTA",


### PR DESCRIPTION
### Changelog 

Fix: Incorrect currency in MoonPay warning alerts (#2504)
Fix: Ensure correct currency symbols are used for MoonPay warnings (#2347)
Fix: Ensure full bundle is broadcast during promotion (fixing an invalid bundle error locking up the wallet) (#2486)
Fix: Use placeholder for DOB field in MoonPay registration (#2451)
Fix: Add MoonPay DOB validation (#2451)
Fix: Fix navigation flow returning from MoonPay review purchase (#2451)
Fix: Fix MoonPay store card layout issue (#2451)
Fix: Ensure USA is not displayed if unsupported by MoonPay (#2451)
Fix: Show an informational page when MoonPay purchases are suspended (#2476)
Fix: Don't fail silently when drag-dropping an incorrect seed (#2474)
Update: Add Ledger icon to differentiate standard and ledger accounts (#2474)

Fixes #655, #1974, #2414, #2445, #2446, #2477, #2478, #2480, #2481