### PR TITLE
fix(desktop): Skip legacy keychain items in isUniqueSeed

### DIFF
--- a/src/desktop/src/libs/SeedStore/Keychain.js
+++ b/src/desktop/src/libs/SeedStore/Keychain.js
@@ -127,7 +127,11 @@ class Keychain extends SeedStoreCore {
         for (let i = 0; i < accounts.length; i++) {
             const account = vault[i];
 
-            if (account.account === `${ALIAS_MAIN}-salt` || account.account === ALIAS_REALM  || account.account === ALIAS_LEGACY) {
+            if (
+                account.account === `${ALIAS_MAIN}-salt` ||
+                account.account === ALIAS_REALM ||
+                account.account === ALIAS_LEGACY
+            ) {
                 continue;
             }
 
@@ -223,7 +227,10 @@ class Keychain extends SeedStoreCore {
         try {
             const accounts = vault.filter(
                 (acc) =>
-                    acc.account !== ALIAS_MAIN && acc.account !== `${ALIAS_MAIN}-salt` && acc.account !== ALIAS_REALM,
+                    acc.account !== ALIAS_MAIN &&
+                    acc.account !== `${ALIAS_MAIN}-salt` &&
+                    acc.account !== ALIAS_REALM &&
+                    acc.account !== ALIAS_LEGACY,
             );
 
             for (let i = 0; i < accounts.length; i++) {


### PR DESCRIPTION
# Description

Legacy keychain items were interfering when checking if the seed a user wants to add already exists in Trinity

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on macOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
