### PR TITLE
fix(shared): Temporarily disable milestone timestamp check

### DIFF
--- a/src/shared/__tests__/libs/iota/extendedApi.spec.js
+++ b/src/shared/__tests__/libs/iota/extendedApi.spec.js
@@ -143,7 +143,7 @@ describe('libs: iota/extendedApi', () => {
         });
 
         describe(`when latestSolidSubtangleMilestoneIndex is ${MAX_MILESTONE_FALLBEHIND} less than latestMilestoneIndex`, () => {
-            describe.skip('when "timestamp" on trytes is from five minutes ago', () => {
+            describe('when "timestamp" on trytes is from five minutes ago', () => {
                 beforeEach(() => {
                     nock('http://localhost:14265', {
                         reqheaders: {
@@ -236,7 +236,7 @@ describe('libs: iota/extendedApi', () => {
 
         describe(`when latestSolidSubtangleMilestoneIndex is ${MAX_MILESTONE_FALLBEHIND -
             1} less than latestMilestoneIndex`, () => {
-            describe.skip('when "timestamp" on trytes is from five minutes ago', () => {
+            describe('when "timestamp" on trytes is from five minutes ago', () => {
                 beforeEach(() => {
                     nock('http://localhost:14265', {
                         reqheaders: {
@@ -328,7 +328,7 @@ describe('libs: iota/extendedApi', () => {
         });
 
         describe(`when latestMilestone is not ${EMPTY_HASH_TRYTES} and is equal to latestSolidSubtangleMilestone`, () => {
-            describe.skip('when "timestamp" on trytes is from five minutes ago', () => {
+            describe('when "timestamp" on trytes is from five minutes ago', () => {
                 beforeEach(() => {
                     nock('http://localhost:14265', {
                         reqheaders: {

--- a/src/shared/__tests__/libs/iota/extendedApi.spec.js
+++ b/src/shared/__tests__/libs/iota/extendedApi.spec.js
@@ -143,7 +143,7 @@ describe('libs: iota/extendedApi', () => {
         });
 
         describe(`when latestSolidSubtangleMilestoneIndex is ${MAX_MILESTONE_FALLBEHIND} less than latestMilestoneIndex`, () => {
-            describe('when "timestamp" on trytes is from five minutes ago', () => {
+            describe.skip('when "timestamp" on trytes is from five minutes ago', () => {
                 beforeEach(() => {
                     nock('http://localhost:14265', {
                         reqheaders: {
@@ -236,7 +236,7 @@ describe('libs: iota/extendedApi', () => {
 
         describe(`when latestSolidSubtangleMilestoneIndex is ${MAX_MILESTONE_FALLBEHIND -
             1} less than latestMilestoneIndex`, () => {
-            describe('when "timestamp" on trytes is from five minutes ago', () => {
+            describe.skip('when "timestamp" on trytes is from five minutes ago', () => {
                 beforeEach(() => {
                     nock('http://localhost:14265', {
                         reqheaders: {
@@ -328,7 +328,7 @@ describe('libs: iota/extendedApi', () => {
         });
 
         describe(`when latestMilestone is not ${EMPTY_HASH_TRYTES} and is equal to latestSolidSubtangleMilestone`, () => {
-            describe('when "timestamp" on trytes is from five minutes ago', () => {
+            describe.skip('when "timestamp" on trytes is from five minutes ago', () => {
                 beforeEach(() => {
                     nock('http://localhost:14265', {
                         reqheaders: {

--- a/src/shared/actions/settings.js
+++ b/src/shared/actions/settings.js
@@ -413,7 +413,7 @@ export function setFullNode(node, addingCustomNode = false) {
 
     return (dispatch) => {
         dispatch(dispatcher.request());
-        throwIfNodeNotHealthy(node)
+        throwIfNodeNotHealthy(node, true)
             .then(() => allowsRemotePow(node))
             .then((hasRemotePow) => {
                 // Change IOTA provider on the global iota instance

--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -1,5 +1,5 @@
 import get from 'lodash/get';
-import head from 'lodash/head';
+//import head from 'lodash/head';
 import has from 'lodash/has';
 import includes from 'lodash/includes';
 import map from 'lodash/map';
@@ -8,7 +8,7 @@ import IOTA from 'iota.lib.js';
 import { composeAPI } from '@iota/core';
 import { iota, quorum } from './index';
 import Errors from '../errors';
-import { isWithinMinutes } from '../date';
+//import { isWithinMinutes } from '../date';
 import {
     DEFAULT_BALANCES_THRESHOLD,
     DEFAULT_DEPTH,
@@ -680,10 +680,13 @@ const isNodeHealthy = (settings) => {
                 throw new Error(Errors.NODE_NOT_SYNCED);
             },
         )
-        .then((trytes) => {
+        .then(() => {
+            /*
             const { timestamp } = iota.utils.transactionObject(head(trytes), cached.latestMilestone);
 
             return isWithinMinutes(timestamp * 1000, 5 * MAX_MILESTONE_FALLBEHIND);
+            */
+            return true;
         });
 };
 

--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -1,5 +1,5 @@
 import get from 'lodash/get';
-//import head from 'lodash/head';
+import head from 'lodash/head';
 import has from 'lodash/has';
 import includes from 'lodash/includes';
 import map from 'lodash/map';
@@ -8,7 +8,7 @@ import IOTA from 'iota.lib.js';
 import { composeAPI } from '@iota/core';
 import { iota, quorum } from './index';
 import Errors from '../errors';
-//import { isWithinMinutes } from '../date';
+import { isWithinMinutes } from '../date';
 import {
     DEFAULT_BALANCES_THRESHOLD,
     DEFAULT_DEPTH,
@@ -651,7 +651,7 @@ const getTrytesAsync = (settings) => (hashes) =>
  *
  * @returns {Promise}
  */
-const isNodeHealthy = (settings) => {
+const isNodeHealthy = (settings, skipMilestoneCheck = false) => {
     const cached = {
         latestMilestone: EMPTY_HASH_TRYTES,
     };
@@ -680,13 +680,13 @@ const isNodeHealthy = (settings) => {
                 throw new Error(Errors.NODE_NOT_SYNCED);
             },
         )
-        .then(() => {
-            /*
+        .then((trytes) => {
+            if (skipMilestoneCheck) {
+                return true;
+            }
             const { timestamp } = iota.utils.transactionObject(head(trytes), cached.latestMilestone);
 
             return isWithinMinutes(timestamp * 1000, 5 * MAX_MILESTONE_FALLBEHIND);
-            */
-            return true;
         });
 };
 

--- a/src/shared/libs/iota/utils.js
+++ b/src/shared/libs/iota/utils.js
@@ -505,8 +505,8 @@ export const getRandomNodes = (nodes, size = 5, blacklistedNodes = [], PoW = fal
  *
  * @returns {Promise<boolean>}
  */
-export const throwIfNodeNotHealthy = (settings) => {
-    return isNodeHealthy(settings).then((isSynced) => {
+export const throwIfNodeNotHealthy = (settings, skipMilestoneCheck = false) => {
+    return isNodeHealthy(settings, skipMilestoneCheck).then((isSynced) => {
         if (!isSynced) {
             throw new Error(Errors.NODE_NOT_SYNCED_BY_TIMESTAMP);
         }


### PR DESCRIPTION
# Description

Since the coordinator is currently down, the latest milestone has been issued more than 5 min ago. This means that this check will always fail and users will not be able to log in.

## Type of change

_Please delete options that are not relevant._

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

- Tested on macOS (debug)

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
