### PR TITLE
improvement: reenable updater on mac and linux

### DIFF
--- a/src/desktop/native/libs/Menu.js
+++ b/src/desktop/native/libs/Menu.js
@@ -81,9 +81,7 @@ autoUpdater.on('error', () => {
  * On update available event callback
  */
 autoUpdater.on('update-available', () => {
-    const opsys = process.platform;
-
-    if (opsys !== 'win32' && opsys !== 'win64') {
+    if (process.platform !== 'win32') {
         return dialog.showMessageBox(
             {
                 type: 'info',

--- a/src/desktop/native/libs/Menu.js
+++ b/src/desktop/native/libs/Menu.js
@@ -51,7 +51,7 @@ let language = {
         noUpdatesAvailable: 'No updates available',
         noUpdatesAvailableExplanation: 'You have the latest version of Trinity!',
         newVersionAvailable: 'New version available',
-        newVersionAvailableExplanationWin: 'A new Trinity version is available. Visit trinity.iota.org to download.',
+        newVersionAvailableExplanationWin: 'A new Trinity version is available. Visit trinity.iota.org to download it.',
         newVersionAvailableExplanation: 'A new Trinity version is available. Do you want to update now?',
         installUpdate: 'Install update and restart',
         installUpdateExplanation: 'Download complete, Trinity will now restart to install the update',

--- a/src/desktop/native/libs/Menu.js
+++ b/src/desktop/native/libs/Menu.js
@@ -51,7 +51,8 @@ let language = {
         noUpdatesAvailable: 'No updates available',
         noUpdatesAvailableExplanation: 'You have the latest version of Trinity!',
         newVersionAvailable: 'New version available',
-        newVersionAvailableExplanation: 'A new Trinity version is available. Visit trinity.iota.org to download.',
+        newVersionAvailableExplanationWin: 'A new Trinity version is available. Visit trinity.iota.org to download.',
+        newVersionAvailableExplanation: 'A new Trinity version is available. Do you want to update now?',
         installUpdate: 'Install update and restart',
         installUpdateExplanation: 'Download complete, Trinity will now restart to install the update',
     },
@@ -80,10 +81,28 @@ autoUpdater.on('error', () => {
  * On update available event callback
  */
 autoUpdater.on('update-available', () => {
+    const opsys = process.platform;
+
+    if (opsys !== 'win32' && opsys !== 'win64') {
+        return dialog.showMessageBox(
+            {
+                type: 'info',
+                title: language.updates.newVersionAvailable,
+                message: language.updates.newVersionAvailableExplanation,
+                buttons: [language.yes, language.no],
+            },
+            (buttonIndex) => {
+                if (buttonIndex === 0) {
+                    autoUpdater.downloadUpdate();
+                }
+            },
+        );
+    }
+
     dialog.showMessageBox({
         type: 'info',
         title: language.updates.newVersionAvailable,
-        message: language.updates.newVersionAvailableExplanation,
+        message: language.updates.newVersionAvailableExplanationWin,
         buttons: ['OK'],
     });
 });

--- a/src/desktop/native/preload/Electron.js
+++ b/src/desktop/native/preload/Electron.js
@@ -604,6 +604,7 @@ const Electron = {
                 noUpdatesAvailableExplanation: t('updates:noUpdatesAvailableExplanation'),
                 newVersionAvailable: t('updates:newVersionAvailable'),
                 newVersionAvailableExplanation: t('updates:newVersionAvailableExplanation'),
+                newVersionAvailableExplanationWin: t('updates:newVersionAvailableExplanationWin'),
                 installUpdate: t('updates:installUpdate'),
                 installUpdateExplanation: t('updates:installUpdateExplanation'),
             },

--- a/src/shared/locales/en/translation.json
+++ b/src/shared/locales/en/translation.json
@@ -790,6 +790,7 @@
         "noUpdatesAvailableExplanation": "You have the latest version of Trinity!",
         "newVersionAvailable": "New version available",
         "newVersionAvailableExplanation": "A new Trinity version is available. Do you want to update now?",
+        "newVersionAvailableExplanationWin": "A new Trinity version is available. Visit trinity.iota.org to download it.",
         "installUpdate": "Install update and restart",
         "installUpdateExplanation": "Download complete, Trinity will now restart to install the update.",
         "downloadingUpdate": "Downloading update",


### PR DESCRIPTION
# Description

- Reenables electron updater on Mac and Linux

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on Mac

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
