### PR TITLE
fix: reenable iphone11 settings seedvault export

### DIFF
--- a/src/mobile/src/ui/views/wallet/AccountManagement.js
+++ b/src/mobile/src/ui/views/wallet/AccountManagement.js
@@ -8,7 +8,6 @@ import { getThemeFromState } from 'shared-modules/selectors/global';
 import { withTranslation } from 'react-i18next';
 import { leaveNavigationBreadcrumb } from 'libs/bugsnag';
 import { renderSettingsRows } from 'ui/components/SettingsContent';
-import { isIPhone11 } from 'libs/device';
 
 const styles = StyleSheet.create({
     container: {
@@ -80,9 +79,6 @@ class AccountManagement extends Component {
             { name: 'back', function: () => this.props.setSetting('mainSettings') },
         ];
 
-        if (isIPhone11) {
-            rows.splice(6, 1);
-        }
         return renderSettingsRows(rows, theme);
     }
 
@@ -102,8 +98,5 @@ const mapDispatchToProps = {
 };
 
 export default withTranslation(['accountManagement', 'global'])(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-    )(AccountManagement),
+    connect(mapStateToProps, mapDispatchToProps)(AccountManagement),
 );


### PR DESCRIPTION
# Description

- Reenables SeedVault export from iPhone 11 settings

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on iOS

# Checklist:

- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
