### PR TITLE
fix: enable cleartext traffic for localhost in debug mode

### DIFF
--- a/src/mobile/android/app/src/debug/AndroidManifest.xml
+++ b/src/mobile/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+<application tools:targetApi="28" android:networkSecurityConfig="@xml/network_security_config" />
+</manifest>

--- a/src/mobile/android/app/src/debug/res/xml/network_security_config.xml
+++ b/src/mobile/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">localhost</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
# Description

Android 9 Pie introduced a default application attribute to block all clear text traffic (https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic). For debug, purposes we depend on a connection to localhost. 

This PR sets `cleartextTrafficPermitted ` for localhost to true when the app is in debug mode.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

# How Has This Been Tested?

Tested on Google Pixel 3.

# Checklist:


- [x] My code follows the style guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
