### PR TITLE
Fixed a typo in de-locale

### DIFF
--- a/src/shared/locales/de/translation.json
+++ b/src/shared/locales/de/translation.json
@@ -703,7 +703,7 @@
         "key": "Schlüssel"
     },
     "stateExport": {
-        "stateExportExplanation": "Der Status-Export wird eine Textdatei mit Informationen zu deinem Konto (Tansaktionen, Adressen), Trinityversion, sowie für Trinity relevante Dateinamen auf deinem Gerät speichern.",
+        "stateExportExplanation": "Der Status-Export wird eine Textdatei mit Informationen zu deinem Konto (Transaktionen, Adressen), Trinityversion, sowie für Trinity relevante Dateinamen auf deinem Gerät speichern.",
         "exportSuccess": "Status exportiert",
         "exportSuccessExplanation": "Der Status-Export wurde erfolgreich generiert."
     },


### PR DESCRIPTION
# Description of change

Just fixed a small typo in de locale

## Type of change

- locale fix - saw it in the trinity app and thought "Oh no, i have to fix this"

## How the change has been tested

Open up the advanced settings menu, scrollt to export section and see the corrected description

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
