### PR TITLE
Fix(shared): Fix issues with currency and timeframe settings

### DIFF
--- a/src/shared/actions/settings.js
+++ b/src/shared/actions/settings.js
@@ -351,6 +351,8 @@ export const setCurrency = (currency) => (dispatch, getState) => {
     const { marketData } = getState();
     const conversionRate = marketData.rates[currency] || 1;
 
+    Wallet.updateCurrency(currency);
+
     dispatch({
         type: SettingsActionTypes.SET_CURRENCY,
         payload: {
@@ -853,7 +855,7 @@ export const setChartTimeframe = (timeframe) => {
  * @returns {{type: {string}, payload: {string} }}
  */
 export const setChartCurrency = (currency) => {
-    Wallet.updateCurrency(currency);
+    Wallet.updateChartCurrency(currency);
 
     return {
         type: SettingsActionTypes.SET_CHART_CURRENCY,

--- a/src/shared/libs/storageToStateMappers.js
+++ b/src/shared/libs/storageToStateMappers.js
@@ -66,8 +66,6 @@ const mapStorageToState = () => {
                     password,
                 }),
             ),
-            chartTimeframe: '24h',
-            chartCurrency: 'USD',
         }),
         alerts: { notificationLog: map(errorLog, (error) => error) },
     };

--- a/src/shared/storage/index.js
+++ b/src/shared/storage/index.js
@@ -458,7 +458,7 @@ class Wallet {
     }
 
     /**
-     * Updates chart currency.
+     * Updates currency.
      *
      * @method updateCurrency
      * @param {string} payload
@@ -470,6 +470,16 @@ class Wallet {
     }
 
     /**
+     * Updates chart currency
+     * @param  {string} payload
+     */
+    static updateChartCurrency(payload) {
+        realm.write(() => {
+            Wallet.latestSettings.chartCurrency = payload;
+        });
+    }
+
+    /**
      * Updates chart timeframe.
      *
      * @method updateTimeframe
@@ -477,7 +487,7 @@ class Wallet {
      */
     static updateTimeframe(payload) {
         realm.write(() => {
-            Wallet.latestSettings.timeframe = payload;
+            Wallet.latestSettings.chartTimeframe = payload;
         });
     }
 


### PR DESCRIPTION
# Description of change

- Fixes an bug where setting the chart currency caused the `currency` in Realm to be set to the same value. This led to an inconsistency between Realm and Redux when the app is relaunched.

- Fixes chart currency and timeframe not persisting across relaunches

Fixes #2529 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- Tested on macOS (dev)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
