### PR TITLE
chore: Fix bug tag in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: "Bug Report"
 about: Report a bug in Trinity
 title: ''
-labels: 'T-Bug'
+labels: 'T - Bug'
 ---
 
 ## Bug description


### PR DESCRIPTION
# Description of change

The bug tag is not being assigned to issues anymore because the specified label (`T-Bug`) does not match ours (`T - Bug`)

## Type of change

- Documentation Fix

## How the change has been tested

N/A

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation