### PR TITLE
chore(mobile/ios): Update iOS code signing identity

### DIFF
--- a/src/mobile/ios/fastlane/Fastfile
+++ b/src/mobile/ios/fastlane/Fastfile
@@ -10,7 +10,7 @@ def enable_manual_provisioning(project_file, provisioning_profile_uuid)
   target.build_configurations.each do |item|
     item.build_settings['PROVISIONING_PROFILE[sdk=iphoneos*]'] = provisioning_profile_uuid
     item.build_settings['DEVELOPMENT_TEAM'] = 'UG77RJKZHH'
-    item.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = 'iPhone Distribution'
+    item.build_settings['CODE_SIGN_IDENTITY[sdk=iphoneos*]'] = 'Apple Distribution'
   end
   project.save
 end


### PR DESCRIPTION
# Description of change

Uses new Apple Distribution certificate for all Apple platforms. These certificates were [introduced in Xcode 11](https://developer.apple.com/documentation/xcode_release_notes/xcode_11_release_notes?language=objc):

> Xcode 11 supports the new Apple Development and Apple Distribution certificate types. These certificates support building, running, and distributing apps on any Apple platform. Preexisting iOS and macOS development and distribution certificates continue to work, however, new certificates you create in Xcode 11 use the new types. Previous versions of Xcode don’t support these certificates. (45527608)

## Type of change

- Chore

## How the change has been tested
N/A

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code