### PR TITLE
chore(mobile): Remove duplicate react-native-http

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -66,7 +66,6 @@
     "react-native-fs": "^2.8.1",
     "react-native-google-safetynet": "^0.3.3",
     "react-native-haptic-feedback": "^1.4.0",
-    "react-native-http": "github:tradle/react-native-http#834492d",
     "react-native-is-device-rooted": "https://github.com/rajivshah3/react-native-isDeviceRooted#latest",
     "react-native-keep-awake": "^2.0.6",
     "react-native-keyboard-aware-scroll-view": "^0.7.4",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -8799,13 +8799,6 @@ react-native-haptic-feedback@^1.4.0:
   resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-1.4.2.tgz#e15ed66f2ffe9ec886b4098b792591136efd5ee2"
   integrity sha512-uLtdxKL4nul5QQUczctCdAr2b6P7/KPLyfQVP8lfcVaNANHpL1WFhCnrWPNCkh2LHSduA88MNgPcTsN9CHbwlw==
 
-"react-native-http@github:tradle/react-native-http#834492d":
-  version "1.0.0"
-  resolved "https://codeload.github.com/tradle/react-native-http/tar.gz/834492dbc792b1dec8ec8f0a1c9671f640339f01"
-  dependencies:
-    Base64 "~0.2.0"
-    inherits "~2.0.1"
-
 react-native-iphone-x-helper@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.0.tgz#9f8a376eb00bc712115abff4420318a0063fa796"


### PR DESCRIPTION
# Description of change

Removes duplicate installation of `react-native-http`

## Type of change
- Chore

## How the change has been tested

- Tested on iOS

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code