### PR TITLE
fix(shared): Fix default values for chart settings

### DIFF
--- a/src/shared/schemas/v10/index.js
+++ b/src/shared/schemas/v10/index.js
@@ -27,6 +27,14 @@ export default map(v9Schema, (schema) => {
                     type: 'bool',
                     default: true,
                 },
+                chartTimeframe: {
+                    type: 'string',
+                    default: '24h',
+                },
+                chartCurrency: {
+                    type: 'string',
+                    default: 'USD',
+                },
             },
         });
     }


### PR DESCRIPTION
# Description of change

Fixes default chart settings so that chart data is properly shown after the initial onboarding process or migration to schema v9. Currently, the default values are missing (the chart shows the price as `$NaN/Mi`, for example)

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- Tested on macOS (dev)

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
