### PR TITLE
fix(desktop): Restrict Ledger account index to valid range

### DIFF
--- a/src/desktop/src/ui/views/onboarding/seedStore/Ledger.js
+++ b/src/desktop/src/ui/views/onboarding/seedStore/Ledger.js
@@ -103,7 +103,6 @@ class Ledger extends React.PureComponent {
 
             history.push('/onboarding/account-name');
         } catch (error) {
-
             if (error.statusCode === 27014) {
                 generateAlert(
                     'error',
@@ -181,10 +180,12 @@ class Ledger extends React.PureComponent {
                             : t('ledger:createNewLedgerAccountInfo')}
                     </p>
                     <div>
+                        {/* Index is an unsigned 31-bit integer, so range is 0 through 2147483647 */}
                         <Number
                             value={index}
                             focus
                             min={0}
+                            max={2147483647}
                             label={advancedMode ? t('ledger:accountIndex') : null}
                             onChange={(value) => this.updateIndex(value)}
                         />
@@ -236,7 +237,4 @@ const mapDispatchToProps = {
     setAccountInfoDuringSetup,
 };
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(withTranslation()(Ledger));
+export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(Ledger));


### PR DESCRIPTION
# Description of change

Prevent users from creating Ledger accounts with indexes higher than the maximum value of a 31-bit unsigned integer (2147483647)

Fixes #2655 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- Tested on macOS

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes