### PR TITLE
hotfix: use default settings if (realm) chart settings are empty

### DIFF
--- a/src/shared/libs/storageToStateMappers.js
+++ b/src/shared/libs/storageToStateMappers.js
@@ -54,6 +54,8 @@ const mapStorageToState = () => {
             ),
         },
         settings: assign({}, settings, {
+            chartCurrency: settings.chartCurrency || 'USD',
+            chartTimeframe: settings.chartTimeframe || '24h',
             node: find(nodes, { url: settings.node }) || DEFAULT_NODE,
             powNode: settings.powNode,
             nodes: map(nodes, ({ url, pow, username, password }) => ({ url, pow, username, password })),


### PR DESCRIPTION
# Description of change

This PR uses default settings if persisted (realm) chart settings are empty

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually tested desktop macOS

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
