### PR TITLE
Change default depth to 1

### DIFF
--- a/src/shared/config.js
+++ b/src/shared/config.js
@@ -53,7 +53,7 @@ export const MARKETDATA_ENDPOINTS = [
 export const VERSIONS_URL =
     'https://raw.githubusercontent.com/iotaledger/trinity-wallet/develop/src/shared/libs/versions.json';
 
-export const DEFAULT_DEPTH = 4;
+export const DEFAULT_DEPTH = 1;
 export const DEFAULT_MIN_WEIGHT_MAGNITUDE = 14;
 export const DEFAULT_TAG = 'TRINITY';
 export const DEFAULT_SECURITY = 2;


### PR DESCRIPTION
# Description of change

Hornet has 3 as max default depth so 4 could cause problems. 1 should even be faster and help transactions so that they have a longer period where they can get referenced

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Unit tests pass

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`