### PR TITLE
fix: Deep linking fixes

### DIFF
--- a/src/desktop/src/ui/Index.js
+++ b/src/desktop/src/ui/Index.js
@@ -7,7 +7,7 @@ import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import i18next from 'libs/i18next';
 import { withTranslation } from 'react-i18next';
 
-import { parseDeepLink } from 'libs/iota/utils';
+import { parseDeepLink, ADDRESS_LENGTH } from 'libs/iota/utils';
 import { ALIAS_MAIN } from 'libs/constants';
 import { fetchVersions, fetchIsSeedMigrationUp, VALID_IOTA_SUBDOMAIN_REGEX } from 'libs/utils';
 
@@ -203,7 +203,11 @@ class App extends React.Component {
                 this.props.history.push('/wallet/send');
             }
         } else {
-            generateAlert('error', t('send:invalidAddress'), t('send:invalidAddressExplanation1'));
+            generateAlert(
+                'error',
+                t('send:invalidAddress'),
+                t('send:invalidAddressExplanation1', { maxLength: ADDRESS_LENGTH }),
+            );
         }
     }
 

--- a/src/desktop/src/ui/Index.js
+++ b/src/desktop/src/ui/Index.js
@@ -7,7 +7,7 @@ import { TransitionGroup, CSSTransition } from 'react-transition-group';
 import i18next from 'libs/i18next';
 import { withTranslation } from 'react-i18next';
 
-import { parseAddress } from 'libs/iota/utils';
+import { parseDeepLink } from 'libs/iota/utils';
 import { ALIAS_MAIN } from 'libs/constants';
 import { fetchVersions, fetchIsSeedMigrationUp, VALID_IOTA_SUBDOMAIN_REGEX } from 'libs/utils';
 
@@ -196,15 +196,9 @@ class App extends React.Component {
             this.props.history.push('/settings/advanced');
             return generateAlert('info', t('deepLink:deepLinkingInfoTitle'), t('deepLink:deepLinkingInfoMessage'));
         }
-
-        const parsedData = parseAddress(data);
-
+        const parsedData = parseDeepLink(data);
         if (parsedData) {
-            this.props.setDeepLinkContent(
-                parsedData.amount ? String(parsedData.amount) : '0',
-                parsedData.address,
-                parsedData.message || '',
-            );
+            this.props.setDeepLinkContent(parsedData.amount, parsedData.address, parsedData.message);
             if (this.props.wallet.ready === true) {
                 this.props.history.push('/wallet/send');
             }

--- a/src/mobile/src/ui/components/DeepLinking.js
+++ b/src/mobile/src/ui/components/DeepLinking.js
@@ -4,7 +4,7 @@ import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { initiateDeepLinkRequest, setDeepLinkContent, setSetting } from 'shared-modules/actions/wallet';
-import { parseAddress, ADDRESS_LENGTH } from 'shared-modules/libs/iota/utils';
+import { parseDeepLink, ADDRESS_LENGTH } from 'shared-modules/libs/iota/utils';
 import { generateAlert } from 'shared-modules/actions/alerts';
 import { changeHomeScreenRoute } from 'shared-modules/actions/home';
 import { isAndroid } from 'libs/device';
@@ -33,7 +33,7 @@ export default () => (C) => {
 
         /**
          * Prefills transactional information on deep link
-         * @param {Object} data
+         * @param {Object | string} data
          */
         setDeepUrl(data) {
             const { t, generateAlert, deepLinking } = this.props;
@@ -44,13 +44,9 @@ export default () => (C) => {
                 return generateAlert('info', t('deepLink:deepLinkingInfoTitle'), t('deepLink:deepLinkingInfoMessage'));
             }
             this.props.changeHomeScreenRoute('send');
-            const parsedData = parseAddress(data.url || data);
+            const parsedData = parseDeepLink(data.url || data);
             if (parsedData) {
-                this.props.setDeepLinkContent(
-                    parsedData.amount.toString() || '0',
-                    parsedData.address,
-                    parsedData.message || null,
-                );
+                this.props.setDeepLinkContent(parsedData.amount, parsedData.address, parsedData.message);
             } else {
                 generateAlert(
                     'error',

--- a/src/shared/libs/iota/utils.js
+++ b/src/shared/libs/iota/utils.js
@@ -366,6 +366,24 @@ export const parseAddress = (input) => {
 };
 
 /**
+ * Parse a deep link (iota://)
+ * @param  {string} data Deep link data
+ * @return {ParsedURL}  The parsed address, message and/or amount values
+ */
+export const parseDeepLink = (data) => {
+    const parsed = parseAddress(data);
+    if (!parsed) {
+        return null;
+    }
+
+    return {
+        address: parsed.address,
+        message: parsed.message || '',
+        amount: parsed.amount ? parsed.amount.toString() : '0',
+    };
+};
+
+/**
  * Retry IOTA api calls on different nodes
  *
  * @method withRetriesOnDifferentNodes


### PR DESCRIPTION
# Description of change

- Moves deep link parsing to `shared`
- Fixes crash on mobile when parsing a deep link
- Fixes mistake in error message on desktop

Fixes #2862 

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- Unit tests pass
- Tested manually on macOS
- Tested manually on iOS

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
