### PR TITLE
fix(desktop): Bump fsevents to 1.2.13 to fix Windows build

### DIFF
--- a/src/desktop/npm-shrinkwrap.json
+++ b/src/desktop/npm-shrinkwrap.json
@@ -12928,15 +12928,14 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
-      "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",
-        "nan": "^2.12.1",
-        "node-pre-gyp": "*"
+        "nan": "^2.12.1"
       }
     },
     "function-bind": {


### PR DESCRIPTION
# Description of change

Bumps `fsevents` to 1.2.13. This version includes a fix to prevent build errors on Windows

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

- Built successfully on Windows

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes