### PR TITLE
chore(desktop): Remove unused dependency i18next

### DIFF
--- a/src/desktop/npm-shrinkwrap.json
+++ b/src/desktop/npm-shrinkwrap.json
@@ -13747,14 +13747,6 @@
         "struct": "0.0.12"
       }
     },
-    "i18next": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-17.0.6.tgz",
-      "integrity": "sha512-bdNhzhcM6RG5m82RypVguCrAQNie/ycxW0Q5C6K9UDWD5hqApZfdJFbj4Ikz9jxIR+Ja1eg0yCQLhlCT+opwIg==",
-      "requires": {
-        "@babel/runtime": "^7.3.1"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -171,7 +171,6 @@
     "electron-updater": "4.0.14",
     "entangled-node": "iotaledger/entangled-node#v0.5.1",
     "hw-app-iota": "0.6.1",
-    "i18next": "17.0.6",
     "iota.lib.js": "0.5.2",
     "kdbxweb": "1.5.7",
     "keytar": "4.11.0",


### PR DESCRIPTION
# Description of change

`i18next` is installed in `desktop` but is not used (the version from `shared` is used instead)

## Type of change

- Chore

## How the change has been tested

Tested on macOS

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes