### PR TITLE
chore(mobile): bump elliptic to 6.5.3

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -37,6 +37,7 @@
     "@tradle/react-native-http": "^2.0.0",
     "axios": "^0.18.1",
     "bugsnag-react-native": "^2.23.6",
+    "elliptic": "^6.5.3",
     "events": "^1.1.1",
     "hoist-non-react-statics": "^3.3.2",
     "intl": "^1.2.5",

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -37,7 +37,6 @@
     "@tradle/react-native-http": "^2.0.0",
     "axios": "^0.18.1",
     "bugsnag-react-native": "^2.23.6",
-    "elliptic": "^6.5.3",
     "events": "^1.1.1",
     "hoist-non-react-statics": "^3.3.2",
     "intl": "^1.2.5",
@@ -137,7 +136,8 @@
     "acorn-globals": ">=6.0.0",
     "**/randomatic/kind-of": "^6.0.3",
     "**/sane/micromatch/kind-of": "^6.0.3",
-    "lodash": ">=4.17.19"
+    "lodash": ">=4.17.19",
+    "elliptic": ">=6.5.3"
   },
   "jest": {
     "preset": "react-native",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -3158,7 +3158,7 @@ browserify-sign@^4.0.4:
     browserify-rsa "^4.0.0"
     create-hash "^1.1.0"
     create-hmac "^1.1.2"
-    elliptic "^6.5.3"
+    elliptic "^6.0.0"
     inherits "^2.0.1"
     parse-asn1 "^5.0.0"
 
@@ -3694,7 +3694,7 @@ create-ecdh@^4.0.0:
   integrity sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
   dependencies:
     bn.js "^4.1.0"
-    elliptic "^6.5.3"
+    elliptic "^6.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
@@ -4276,7 +4276,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-elliptic@^6.5.3:
+elliptic@>=6.5.3, elliptic@^6.0.0:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -3158,7 +3158,7 @@ browserify-sign@^4.0.4:
     browserify-rsa "^4.0.0"
     create-hash "^1.1.0"
     create-hmac "^1.1.2"
-    elliptic "^6.0.0"
+    elliptic "^6.5.3"
     inherits "^2.0.1"
     parse-asn1 "^5.0.0"
 
@@ -3694,7 +3694,7 @@ create-ecdh@^4.0.0:
   integrity sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==
   dependencies:
     bn.js "^4.1.0"
-    elliptic "^6.0.0"
+    elliptic "^6.5.3"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
@@ -4276,10 +4276,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-elliptic@^6.0.0:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
-  integrity sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==
+elliptic@^6.5.3:
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"


### PR DESCRIPTION
Updates Elliptic to 6.5.3.

https://github.com/iotaledger/trinity-wallet/pull/2927