### PR TITLE
Disable copying receive address if address is not generated

### DIFF
--- a/src/desktop/src/ui/components/Clipboard.js
+++ b/src/desktop/src/ui/components/Clipboard.js
@@ -20,6 +20,8 @@ export class ClipboardComponent extends React.PureComponent {
         children: PropTypes.any,
         /** Timeout to clear the clipboard */
         timeout: PropTypes.number,
+        /** Determines whether to disable the copy to clipboard functionality */
+        disableCopy: PropTypes.bool,
         /** Success notification title */
         title: PropTypes.string.isRequired,
         /** Success notification description */
@@ -33,18 +35,20 @@ export class ClipboardComponent extends React.PureComponent {
             e.stopPropagation();
         }
 
-        const { text, generateAlert, title, success, timeout } = this.props;
+        const { disableCopy, text, generateAlert, title, success, timeout } = this.props;
 
-        Electron.clipboard(text);
-        generateAlert('success', title, success);
+        if (!disableCopy) {
+            Electron.clipboard(text);
+            generateAlert('success', title, success);
 
-        if (timeout > 0) {
-            if (this.timeout) {
-                clearTimeout(this.timeout);
+            if (timeout > 0) {
+                if (this.timeout) {
+                    clearTimeout(this.timeout);
+                }
+                this.timeout = setTimeout(() => {
+                    Electron.clipboard('');
+                }, timeout * 1000);
             }
-            this.timeout = setTimeout(() => {
-                Electron.clipboard('');
-            }, timeout * 1000);
         }
     };
 
@@ -63,7 +67,4 @@ const mapDispatchToProps = {
     generateAlert,
 };
 
-export default connect(
-    null,
-    mapDispatchToProps,
-)(ClipboardComponent);
+export default connect(null, mapDispatchToProps)(ClipboardComponent);

--- a/src/desktop/src/ui/views/wallet/Receive.js
+++ b/src/desktop/src/ui/views/wallet/Receive.js
@@ -251,11 +251,12 @@ class Receive extends React.PureComponent {
                             {t('close')}
                         </Button>
                         <Clipboard
+                            disableCopy={!hasSyncedAddress}
                             text={receiveAddress}
                             title={t('receive:addressCopied')}
                             success={t('receive:addressCopiedExplanation')}
                         >
-                            <Button className="small" onClick={() => {}}>
+                            <Button disabled={!hasSyncedAddress} className="small" onClick={() => {}}>
                                 {t('receive:copyAddress')}
                             </Button>
                         </Clipboard>
@@ -286,7 +287,4 @@ const mapDispatchToProps = {
     addressValidationSuccess,
 };
 
-export default connect(
-    mapStateToProps,
-    mapDispatchToProps,
-)(withTranslation()(Receive));
+export default connect(mapStateToProps, mapDispatchToProps)(withTranslation()(Receive));


### PR DESCRIPTION
# Description of change

This PR ensures that users are not allowed to copy the receive address before it's generated. 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually tested macOS

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
