### PR TITLE
Replace getLatestInclusion api method with getInclusionStates

### DIFF
--- a/src/shared/libs/iota/extendedApi.js
+++ b/src/shared/libs/iota/extendedApi.js
@@ -186,8 +186,9 @@ const getLatestInclusionAsync = (settings, withQuorum = false) => (hashes) =>
     withQuorum
         ? quorum.getLatestInclusion(hashes)
         : new Promise((resolve, reject) => {
-              getIotaInstance(settings, getApiTimeout('getInclusionStates')).api.getLatestInclusion(
+              getIotaInstance(settings, getApiTimeout('getInclusionStates')).api.getInclusionStates(
                   hashes,
+                  [],
                   (err, states) => {
                       if (err) {
                           reject(err);


### PR DESCRIPTION
# Description of change

`tips` param is no longer support in `getInclusionStates` api call. `getLatestInclusion` passes `latestSolidSubtangleMilestone` as a tip to `getInclusionStates` call which is not necessary. This PR thus uses `getInclusionStates` api call. 

Should also fix the [crashes](https://app.bugsnag.com/iota-foundation/trinity-mobile/errors/5edce1de8019a000175672f1?filters[event.since][0]=30d&filters[error.status][0]=open). 

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Manually tested desktop macOS

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
