### PR TITLE
Add auto-promotion/reattachment errors to error log

### DIFF
--- a/src/shared/actions/polling.js
+++ b/src/shared/actions/polling.js
@@ -424,6 +424,16 @@ export const promoteTransfer = (bundleHash, accountName, seedStore, quorum = tru
                 );
                 dispatch(setAutoPromotion(false));
             }
+
+            // Add all error messages to error log except for those that are explicitly thrown
+            if (
+                ![Errors.TRANSACTION_ALREADY_CONFIRMED, Errors.BUNDLE_NO_LONGER_FUNDED].some(
+                    (error) => error === err.message,
+                )
+            ) {
+                dispatch(prepareLogUpdate(err));
+            }
+
             if (err.message === Errors.NOT_ENOUGH_SYNCED_NODES) {
                 dispatch(breakPollCycle());
             }


### PR DESCRIPTION
# Description of change

This PR adds auto-promotion/reattachment errors to error log

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually tested macOS desktop

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
