### PR TITLE
feature(ci): Allow manual desktop builds to be triggered

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -6,6 +6,12 @@ on:
       - release/desktop-*
     tags:
       - desktop-*
+  workflow_dispatch:
+    inputs:
+      debugElectronBuilder:
+        description: "Verbose electron-builder output"     
+        required: true
+        default: "false"
 
 jobs:
   build:
@@ -65,6 +71,10 @@ jobs:
         rm -rf openssl-1.0.2k
         echo "::add-path::/usr/local/ssl"
       if: matrix.os == 'ubuntu-18.04'
+
+    - name: Enable verbose output for electron-builder
+      run: echo "::set-env name=DEBUG::electron-builder"
+      if: github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
 
     - name: Install desktop dependencies
       run: yarn deps:desktop


### PR DESCRIPTION
# Description of change

Uses `workflow_dispatch` event to allow builds to be [manually triggered](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) for purposes such as internal testing. Also allows for verbose `electron-builder` output for help debugging build issues on CI.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

N/A

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code