### PR TITLE
Desktop 1.6.1 Release

### DIFF
--- a/src/desktop/CHANGELOG.md
+++ b/src/desktop/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.6.1
+
+- Fix: Deep linking on Windows
+- Fix: Add autopromotion errors to the error log
+- Update: Update to Electron 7.3.3
+
 ### 1.6.0
 - Fix: Remove manual promotion
 - Fix: Update auto-promotion logic for Chrysalis Part 1

--- a/src/desktop/npm-shrinkwrap.json
+++ b/src/desktop/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "trinity-desktop",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/desktop/package.json
+++ b/src/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "trinity-desktop",
   "productName": "Trinity",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "url": "https://trinity.iota.org",
   "homepage": "https://trinity.iota.org",
   "description": "Desktop wallet for IOTA",


### PR DESCRIPTION
### Changelog

- Fix: Deep linking on Windows (#3001)
- Fix: Add autopromotion errors to the error log (#2987)
- Update: Update to Electron 7.3.3 (#2990)