### PR TITLE
Mobile Release 1.6.1

### DIFF
--- a/src/mobile/android/app/build.gradle
+++ b/src/mobile/android/app/build.gradle
@@ -94,8 +94,8 @@ android {
     buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId "com.iota.trinity"
-        versionCode 106
-        versionName "1.6.0"
+        versionCode 107
+        versionName "1.6.1"
         minSdkVersion 21
         targetSdkVersion 28
         multiDexEnabled true

--- a/src/mobile/ios/fastlane/README.md
+++ b/src/mobile/ios/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew cask install fastlane`
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ### configure_release

--- a/src/mobile/ios/iotaWallet-tvOS/Info.plist
+++ b/src/mobile/ios/iotaWallet-tvOS/Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>106</string>
+	<string>107</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/src/mobile/ios/iotaWallet-tvOSTests/Info.plist
+++ b/src/mobile/ios/iotaWallet-tvOSTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>106</string>
+	<string>107</string>
 </dict>
 </plist>

--- a/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
+++ b/src/mobile/ios/iotaWallet.xcodeproj/project.pbxproj
@@ -2958,7 +2958,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
@@ -3356,7 +3356,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -3630,7 +3630,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 106;
+				CURRENT_PROJECT_VERSION = 107;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/src/mobile/ios/iotaWallet/Info.plist
+++ b/src/mobile/ios/iotaWallet/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -34,7 +34,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>106</string>
+	<string>107</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/src/mobile/ios/iotaWalletTests/Info.plist
+++ b/src/mobile/ios/iotaWalletTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>106</string>
+	<string>107</string>
 </dict>
 </plist>

--- a/src/mobile/ios/iotaWalletUITests/Info.plist
+++ b/src/mobile/ios/iotaWalletUITests/Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.6.0</string>
+	<string>1.6.1</string>
 	<key>CFBundleVersion</key>
-	<string>106</string>
+	<string>107</string>
 </dict>
 </plist>

--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trinity-mobile",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "url": "https://trinity.iota.org",
   "homepage": "https://trinity.iota.org",


### PR DESCRIPTION
### Changelog 

- Update: Add auto-promotion/reattachment errors to error log (#2987)
- Fix: Polling crash on Android (#2986)
- Fix: Android crash when returning from app minimise (#2982) 