### PR TITLE
feature(ci): Allow desktop releases to be rolled back

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -1,4 +1,4 @@
-name: Build desktop
+name: Build Trinity Desktop
 
 on:
   push:
@@ -271,8 +271,10 @@ jobs:
         asset_name: trinity-desktop-${{ env.RELEASE_VERSION }}.AppImage.asc
         asset_content_type: application/pgp-signature
 
-    - name: Upload to s3
+    - name: Upload to S3
+      # Move current latest.ymls to previous/, then upload the new latest.ymls and binaries
       run: |
+        aws s3 mv s3://iotaledger-files/trinity/desktop/releases/ s3://iotaledger-files/trinity/desktop/releases/previous/ --exclude "*" --include "latest*.yml" --recursive
         aws s3 cp assets/ s3://iotaledger-files/trinity/desktop/releases/ --recursive --include "*" --exclude "*.sha256" --exclude "*.blockmap" --exclude "*.dmg" --exclude "*.asc"
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/rollback_desktop.yml
+++ b/.github/workflows/rollback_desktop.yml
@@ -1,0 +1,17 @@
+name: Rollback Trinity Desktop Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  rollback:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Restore previous latest.yml files
+      # Replace current latest.ymls with the ones in previous/
+      run: |
+        aws s3 mv s3://iotaledger-files/trinity/desktop/releases/previous/ s3://iotaledger-files/trinity/desktop/releases/ --exclude "*" --include "latest*.yml" --recursive
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}


### PR DESCRIPTION
# Description of change

This PR automates the changes necessary to roll back a Trinity Desktop release, specifically related to the auto-updater files on S3. If release assets are removed from S3 without updating `latest*.yml` files, the auto-updater will still look for the now-deleted release assets and show an error message (see #3012). To solve this, the `latest*.yml` files from the last release need to be restored. 

- When running the `release` job of the `Build Trinity Desktop` workflow, the previous `latest*.yml` files are moved to `s3://iotaledger-files/trinity/desktop/releases/previous/`
- If a rollback is necessary, manually triggering the `Rollback Trinity Desktop Release` workflow will move the `latest*.yml` files from `s3://iotaledger-files/trinity/desktop/releases/previous/` to `s3://iotaledger-files/trinity/desktop/releases/` so that they point the auto-updater to the previous release

## Type of change

- Enhancement (a non-breaking change which adds functionality)


## How the change has been tested

Tested manually in AWS CLI

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
