### PR TITLE
feature(ci): Use prebuilt OpenSSL for Windows builds

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -47,14 +47,12 @@ jobs:
 
     - name: Install OpenSSL 1.0.2s - Windows
       # For Realm on Windows
+      # Prebuilt openssl:x64-windows-static from https://github.com/microsoft/vcpkg/releases/tag/2019.12
       run: |
-        git clone https://github.com/Microsoft/vcpkg C:\src\vcpkg
-        cd C:\src\vcpkg
-        git checkout ${{ env.VCPKG_COMMIT }}
-        .\bootstrap-vcpkg.bat
-        .\vcpkg install openssl:x64-windows-static
-      env:
-        VCPKG_COMMIT: 5d7ff36 # https://github.com/microsoft/vcpkg/releases/tag/2019.12
+        $ProgressPreference = 'SilentlyContinue'
+        Invoke-WebRequest https://iotaledger-files.s3.eu-central-1.amazonaws.com/trinity/desktop/prebuild/windows/vcpkg-export-openssl-1.0.2s.zip -OutFile openssl.zip
+        Expand-Archive openssl.zip -DestinationPath C:\src\vcpkg
+        Remove-Item openssl.zip
       if: matrix.os == 'windows-2019'
 
     - name: Install OpenSSL 1.0.2k - Linux


### PR DESCRIPTION
# Description of change

Instead of building OpenSSL from source every time, we can use a prebuilt version exported from `vcpkg`. This PR changes the workflow so that it downloads the prebuilt version from S3, reducing the workflow run time by about 10 min.

## Type of change

- Enhancement (a non-breaking change which adds functionality)


## How the change has been tested

Ran workflow and tested build on Windows

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas