### PR TITLE
fix: ensure polling starts with promotion

### DIFF
--- a/src/desktop/src/ui/Index.js
+++ b/src/desktop/src/ui/Index.js
@@ -121,7 +121,7 @@ class App extends React.Component {
     componentDidMount() {
         this.onMenuToggle = this.menuToggle.bind(this);
         this.onAccountSwitch = this.accountSwitch.bind(this);
-        this.props.fetchNodeList();
+        this.props.fetchNodeList(false);
 
         Electron.onEvent('menu', this.onMenuToggle);
         Electron.onEvent('account.switch', this.onAccountSwitch);

--- a/src/desktop/src/ui/views/onboarding/Login.js
+++ b/src/desktop/src/ui/views/onboarding/Login.js
@@ -81,7 +81,7 @@ class Login extends React.Component {
             this.props.setPassword({});
         }
 
-        this.props.fetchMarketData();
+        this.props.fetchMarketData(false);
     }
 
     componentDidUpdate(prevProps) {

--- a/src/mobile/src/ui/routes/entry.js
+++ b/src/mobile/src/ui/routes/entry.js
@@ -160,7 +160,7 @@ const fetchNodeList = (store) => {
     // Set quorum size
     quorum.setSize(get(settings, 'quorum.size'));
 
-    store.dispatch(fetchNodes());
+    store.dispatch(fetchNodes(false));
 };
 
 /**

--- a/src/mobile/src/ui/views/wallet/Loading.js
+++ b/src/mobile/src/ui/views/wallet/Loading.js
@@ -213,7 +213,7 @@ class Loading extends Component {
     }
 
     getWalletData() {
-        this.props.fetchMarketData();
+        this.props.fetchMarketData(false);
     }
 
     animateElipses = (chars, index, time = 750) => {

--- a/src/shared/actions/polling.js
+++ b/src/shared/actions/polling.js
@@ -38,22 +38,26 @@ const fetchNodeListRequest = () => ({
  * Dispatch when list of IRI nodes are successfully fetched from remote server
  *
  * @method fetchNodeListSuccess
+ * @param {boolean} payload
  *
- * @returns {{type: {string} }}
+ * @returns {{type: {string}, payload: {boolean} }}
  */
-const fetchNodeListSuccess = () => ({
+const fetchNodeListSuccess = (payload) => ({
     type: PollingActionTypes.FETCH_NODELIST_SUCCESS,
+    payload
 });
 
 /**
  * Dispatch if an error occurs while fetching list of IRI nodes from remote server
  *
  * @method fetchNodeListError
+ * @param {boolean} payload
  *
- * @returns {{type: {string} }}
+ * @returns {{type: {string}, payload: {boolean} }}
  */
-const fetchNodeListError = () => ({
+const fetchNodeListError = (payload) => ({
     type: PollingActionTypes.FETCH_NODELIST_ERROR,
+    payload
 });
 
 /**
@@ -71,22 +75,26 @@ const fetchMarketDataRequest = () => ({
  * Dispatch when IOTA market information is successfully fetched
  *
  * @method fetchMarketDataSuccess
+ * @param {boolean} payload
  *
- * @returns {{type: {string} }}
+ * @returns {{type: {string}, payload: {boolean} }}
  */
-const fetchMarketDataSuccess = () => ({
+const fetchMarketDataSuccess = (payload) => ({
     type: PollingActionTypes.FETCH_MARKET_DATA_SUCCESS,
+    payload
 });
 
 /**
  * Dispatch if an error occurs while fetching IOTA market information
  *
  * @method fetchMarketDataError
+ * @param {boolean} payload
  *
- * @returns {{type: {string} }}
+ * @returns {{type: {string}, payload: {boolean} }}
  */
-const fetchMarketDataError = () => ({
+const fetchMarketDataError = (payload) => ({
     type: PollingActionTypes.FETCH_MARKET_DATA_ERROR,
+    payload
 });
 
 /**
@@ -103,10 +111,8 @@ const accountInfoForAllAccountsFetchRequest = () => ({
 /**
  * Dispatch when accounts information is successfully fetched during polling
  *
- * @method accountInfoForAllAccountsFetchSuccess
- * @param {object} payload
- *
- * @returns {{type: {string}, payload: {object} }}
+ * @method accountInfoForAllAccountsFetchSuccess *
+ * @returns {{type: {string} }}
  */
 const accountInfoForAllAccountsFetchSuccess = () => ({
     type: PollingActionTypes.ACCOUNT_INFO_FOR_ALL_ACCOUNTS_FETCH_SUCCESS,
@@ -211,25 +217,26 @@ export const syncAccountWhilePolling = (payload) => ({
 });
 
 /**
- *  Fetch IOTA market information
+ * Fetch IOTA market information
  *
- *   @method fetchMarketData
+ * @method fetchMarketData
+ * @param {boolean} isPolling
  *
- *   @returns {function} - dispatch
+ * @returns {function} - dispatch
  **/
-export const fetchMarketData = () => {
+export const fetchMarketData = (isPolling = true) => {
     return (dispatch) => {
         dispatch(fetchMarketDataRequest());
         getMarketData(dispatch)
             .then((successful) => {
                 if (successful) {
-                    dispatch(fetchMarketDataSuccess());
+                    dispatch(fetchMarketDataSuccess(isPolling));
                 } else {
-                    dispatch(fetchMarketDataError());
+                    dispatch(fetchMarketDataError(isPolling));
                 }
             })
             .catch((err) => {
-                dispatch(fetchMarketDataError());
+                dispatch(fetchMarketDataError(isPolling));
                 dispatch(prepareLogUpdate(err));
             });
     };
@@ -239,10 +246,10 @@ export const fetchMarketData = () => {
  * Fetch list of IRI nodes from a remote server
  *
  * @method fetchNodeList
- *
+ * @param {boolean} isPolling
  * @returns {function}
  */
-export const fetchNodeList = () => {
+export const fetchNodeList = (isPolling = true) => {
     return (dispatch, getState) => {
         dispatch(fetchNodeListRequest());
 
@@ -264,10 +271,10 @@ export const fetchNodeList = () => {
                 );
 
                 dispatch(setNodeList(nodes));
-                dispatch(fetchNodeListSuccess());
+                dispatch(fetchNodeListSuccess(isPolling));
             })
             .catch(() => {
-                dispatch(fetchNodeListError());
+                dispatch(fetchNodeListError(isPolling));
             });
     };
 };

--- a/src/shared/reducers/polling.js
+++ b/src/shared/reducers/polling.js
@@ -98,13 +98,13 @@ const polling = (
             return {
                 ...state,
                 isFetchingNodeList: false,
-                ...setNextPollIfSuccessful(state),
+                ...setNextPollIfSuccessful(state, action.payload),
             };
         case PollingActionTypes.FETCH_NODELIST_ERROR:
             return {
                 ...state,
                 isFetchingNodeList: false,
-                ...setNextPollIfUnsuccessful(state),
+                ...setNextPollIfUnsuccessful(state, action.payload),
             };
         case PollingActionTypes.FETCH_MARKET_DATA_REQUEST:
             return {
@@ -115,13 +115,13 @@ const polling = (
             return {
                 ...state,
                 isFetchingMarketData: false,
-                ...setNextPollIfSuccessful(state),
+                ...setNextPollIfSuccessful(state, action.payload),
             };
         case PollingActionTypes.FETCH_MARKET_DATA_ERROR:
             return {
                 ...state,
                 isFetchingMarketData: false,
-                ...setNextPollIfUnsuccessful(state),
+                ...setNextPollIfUnsuccessful(state, action.payload),
             };
         case PollingActionTypes.ACCOUNT_INFO_FOR_ALL_ACCOUNTS_FETCH_REQUEST:
             return {

--- a/src/shared/reducers/polling.js
+++ b/src/shared/reducers/polling.js
@@ -3,7 +3,11 @@ import isNumber from 'lodash/isNumber';
 import size from 'lodash/size';
 import { PollingActionTypes, TransfersActionTypes } from '../types';
 
-export const setNextPollIfSuccessful = (state) => {
+export const setNextPollIfSuccessful = (state, isPolling = true) => {
+    if (!isPolling) {
+        return;
+    }
+    
     const { allPollingServices, pollFor } = state;
 
     const currentIndex = findIndex(allPollingServices, (service) => pollFor === service);
@@ -19,7 +23,11 @@ export const setNextPollIfSuccessful = (state) => {
     return { pollFor: allPollingServices[0], retryCount: 0 }; // In case something bad happens, restart fresh
 };
 
-export const setNextPollIfUnsuccessful = (state) => {
+export const setNextPollIfUnsuccessful = (state, isPolling = true) => {
+    if (!isPolling) {
+        return;
+    }
+
     const { allPollingServices, pollFor, retryCount } = state;
 
     if (retryCount < 3) {


### PR DESCRIPTION
# Description of change

Polling was skipping to broadcast due to `fetchNodeList` and `fetchMarketData` events called on load.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on iOS simulator and Mac debug

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
