### PR TITLE
fix(desktop/linux): Show OK button on update message box

### DIFF
--- a/src/desktop/native/libs/Menu.js
+++ b/src/desktop/native/libs/Menu.js
@@ -114,6 +114,7 @@ autoUpdater.on('update-downloaded', async () => {
     await dialog.showMessageBox({
         title: language.updates.installUpdate,
         message: language.updates.installUpdateExplanation,
+        buttons: ['OK'],
     });
     setTimeout(() => {
         const mainWindow = getWindow('main');


### PR DESCRIPTION
# Description of change

On macOS and Windows, if the `buttons` option is not set, `OK` is used by default. On Linux, no button is shown and the user cannot dismiss the message box.

![image](https://user-images.githubusercontent.com/19519564/92524013-65770c80-f1ef-11ea-98d5-1bbbced582fe.png)

This PR explicitly specifies an `OK` button so that it is shown on Linux

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
