### PR TITLE
fix(ci): Use env files for env vars and PATH

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -67,12 +67,16 @@ jobs:
         sudo make install_sw
         cd ..
         rm -rf openssl-1.0.2k
-        echo "::add-path::/usr/local/ssl"
+        echo "/usr/local/ssl" >> $GITHUB_PATH
       if: matrix.os == 'ubuntu-18.04'
 
-    - name: Enable verbose output for electron-builder
-      run: echo "::set-env name=DEBUG::electron-builder"
-      if: github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
+    - name: Enable verbose output for electron-builder - macOS/Linux
+      run: echo "DEBUG=electron-builder" >> $GITHUB_ENV
+      if: matrix.os == 'ubuntu-18.04' || matrix.os == 'macos-10.15' && github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
+
+    - name: Enable verbose output for electron-builder - Windows
+      run: echo "DEBUG=electron-builder" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
+      if: matrix.os == 'windows-2019' && github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
 
     - name: Install desktop dependencies
       run: yarn deps:desktop
@@ -174,7 +178,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Getting version
-      run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/desktop-}
+      run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/desktop-}" >> $GITHUB_ENV
 
     - name: Downloading artifacts
       uses: actions/download-artifact@v2


### PR DESCRIPTION
# Description of change

The `set-env` and `add-path` commands are now deprecated (see [GitHub blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/))﻿


## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Ran workflow manually

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
