### PR TITLE
fix(ci): Avoid overwriting env on Windows

### DIFF
--- a/.github/workflows/build_desktop.yml
+++ b/.github/workflows/build_desktop.yml
@@ -75,7 +75,7 @@ jobs:
       if: matrix.os == 'ubuntu-18.04' || matrix.os == 'macos-10.15' && github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
 
     - name: Enable verbose output for electron-builder - Windows
-      run: echo "DEBUG=electron-builder" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8
+      run: echo "DEBUG=electron-builder" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       if: matrix.os == 'windows-2019' && github.event.inputs.debugElectronBuilder && github.event.inputs.debugElectronBuilder == 'true'
 
     - name: Install desktop dependencies


### PR DESCRIPTION
# Description of change

Adds `-Append` so the env is not overwritten

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

N/A

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code