### PR TITLE
chore: fix brew command

### DIFF
--- a/src/mobile/android/fastlane/README.md
+++ b/src/mobile/android/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew cask install fastlane`
+or alternatively using `brew install --cask fastlane`
 
 # Available Actions
 ### release

--- a/src/mobile/android/fastlane/README.md
+++ b/src/mobile/android/fastlane/README.md
@@ -12,7 +12,7 @@ Install _fastlane_ using
 ```
 [sudo] gem install fastlane -NV
 ```
-or alternatively using `brew install --cask fastlane`
+or alternatively using `brew install fastlane`
 
 # Available Actions
 ### release


### PR DESCRIPTION
# Description of change

The command `brew cask install` in `src/mobile/android/fastlane/README.md` doesn't work now because of update of Homebrew.

[Error: Calling brew cask install is disabled! · Discussion #340 · Homebrew/discussions](https://github.com/Homebrew/discussions/discussions/340#discussioncomment-232364)

> `brew cask <command>` was deprecated in favor of `brew <command> --cask` in Homebrew 2.6.0. Now that 2.7.0 has been released, they have been disabled.


## Type of change

- Documentation Fix


## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code