### PR TITLE
feat(desktop): Allow app entry when nodes are down

### DIFF
--- a/src/desktop/src/ui/views/onboarding/Login.js
+++ b/src/desktop/src/ui/views/onboarding/Login.js
@@ -35,8 +35,6 @@ class Login extends React.Component {
         /** @ignore */
         password: PropTypes.object.isRequired,
         /** @ignore */
-        ui: PropTypes.object.isRequired,
-        /** @ignore */
         addingAdditionalAccount: PropTypes.bool.isRequired,
         /** @ignore */
         additionalAccountMeta: PropTypes.object.isRequired,
@@ -62,11 +60,14 @@ class Login extends React.Component {
         t: PropTypes.func.isRequired,
         /** @ignore */
         themeName: PropTypes.string.isRequired,
+        /** @ignore */
+        history: PropTypes.object.isRequired,
     };
 
     state = {
         password: '',
         shouldMigrate: false,
+        loading: false
     };
 
     componentDidMount() {
@@ -92,6 +93,7 @@ class Login extends React.Component {
 
     componentWillUnmount() {
         setTimeout(() => Electron.garbageCollect(), 1000);
+        clearTimeout(this.timeout)
     }
 
     /**
@@ -178,6 +180,11 @@ class Login extends React.Component {
             }
 
             try {
+                this.setState({ loading: true });
+                this.timeout = setTimeout(() => {
+                    Electron.updateMenu('authorised', true);
+                    this.props.history.push('/wallet/');
+                }, 2500);
                 await this.setupAccount();
             } catch (err) {
                 generateAlert(
@@ -190,10 +197,10 @@ class Login extends React.Component {
     };
 
     render() {
-        const { forceUpdate, t, addingAdditionalAccount, ui, completedMigration, themeName } = this.props;
-        const { shouldMigrate } = this.state;
+        const { forceUpdate, t, addingAdditionalAccount, completedMigration, themeName } = this.props;
+        const { shouldMigrate, loading } = this.state;
 
-        if (ui.isFetchingAccountInfo) {
+        if (loading) {
             return (
                 <Loading
                     loop

--- a/src/desktop/src/ui/views/onboarding/Login.js
+++ b/src/desktop/src/ui/views/onboarding/Login.js
@@ -34,6 +34,8 @@ class Login extends React.Component {
         currentAccountMeta: PropTypes.object,
         /** @ignore */
         password: PropTypes.object.isRequired,
+                /** @ignore */
+        ui: PropTypes.object.isRequired,
         /** @ignore */
         addingAdditionalAccount: PropTypes.bool.isRequired,
         /** @ignore */
@@ -197,10 +199,10 @@ class Login extends React.Component {
     };
 
     render() {
-        const { forceUpdate, t, addingAdditionalAccount, completedMigration, themeName } = this.props;
+        const { forceUpdate, t, addingAdditionalAccount, ui, completedMigration, themeName } = this.props;
         const { shouldMigrate, loading } = this.state;
 
-        if (loading) {
+        if (loading || ui.isFetchingAccountInfo) {
             return (
                 <Loading
                     loop


### PR DESCRIPTION
# Description of change

- Allows users to enter the app and export their seed for when nodes are down post Chrysalis

## Type of change

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Tested on Mac

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
