### PR TITLE
fix(mobile/ios): Patch Bugsnag string comparison

### DIFF
--- a/src/mobile/patches/bugsnag-react-native+2.23.6.patch
+++ b/src/mobile/patches/bugsnag-react-native+2.23.6.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/bugsnag-react-native/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c b/node_modules/bugsnag-react-native/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
+index 71452ab..027e552 100644
+--- a/node_modules/bugsnag-react-native/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
++++ b/node_modules/bugsnag-react-native/cocoa/vendor/bugsnag-cocoa/Source/KSCrash/Source/KSCrash/Recording/Sentry/BSG_KSCrashSentry_MachException.c
+@@ -206,7 +206,7 @@ void *ksmachexc_i_handleExceptions(void *const userData) {
+ 
+     const char *threadName = (const char *)userData;
+     pthread_setname_np(threadName);
+-    if (threadName == kThreadSecondary) {
++    if (strcmp(threadName, kThreadSecondary) == 0) {
+         BSG_KSLOG_DEBUG("This is the secondary thread. Suspending.");
+         thread_suspend(bsg_ksmachthread_self());
+     }


### PR DESCRIPTION
# Description of change

Using `==` for string comparison is now an error in Xcode instead of a warning. This PR patches Bugsnag on iOS to use `strcmp` instead.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Build succeeds

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
