### PR TITLE
fix(mobile): Bump graceful-fs to 4.2.6

### DIFF
--- a/src/mobile/package.json
+++ b/src/mobile/package.json
@@ -137,7 +137,8 @@
     "**/randomatic/kind-of": "^6.0.3",
     "**/sane/micromatch/kind-of": "^6.0.3",
     "lodash": ">=4.17.20",
-    "elliptic": ">=6.5.3"
+    "elliptic": ">=6.5.3",
+    "graceful-fs": ">=4.2.0"
   },
   "jest": {
     "preset": "react-native",

--- a/src/mobile/yarn.lock
+++ b/src/mobile/yarn.lock
@@ -5127,15 +5127,10 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
-
-graceful-fs@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
-  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+graceful-fs@>=4.2.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.3:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 graphlib@2.1.8, graphlib@^2.1.8:
   version "2.1.8"


### PR DESCRIPTION
# Description of change

Resolve `graceful-fs` to version 4.2.0 or later for Node.js 12 compatibility

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

RN bundler works now

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code