### PR TITLE
feat: allow users to login even if the nodes are unresponsive

### DIFF
--- a/src/mobile/src/ui/views/wallet/Loading.js
+++ b/src/mobile/src/ui/views/wallet/Loading.js
@@ -159,6 +159,9 @@ class Loading extends Component {
             this.props.setSetting('mainSettings');
             this.props.changeHomeScreenRoute('balance');
         }
+
+
+
         if (addingAdditionalAccount) {
             const seedStore = await new SeedStore[additionalAccountMeta.type](
                 global.passwordHash,
@@ -178,7 +181,7 @@ class Loading extends Component {
             this.launchHomeScreen();
         }
         if (!hasErrorFetchingAccountInfo && newProps.hasErrorFetchingAccountInfo) {
-            this.redirectToLogin();
+            this.redirectToHome();
         }
         if (!hasErrorFetchingFullAccountInfo && newProps.hasErrorFetchingFullAccountInfo) {
             if (accountNames.length <= 1) {


### PR DESCRIPTION
# Description of change

Allow users to login even if the nodes the unresponsive. This will allow users to login and export seed vaults. 

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Manually tested iOS

## Change checklist

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] For changes to `mobile` that include native code (including React Native modules): I have verified that both iOS and Android successfully build in both `Debug` and `Release` modes
- [ ] For changes to `shared`: If applicable, I have verified that my changes are implemented correctly in `desktop` and `mobile`
